### PR TITLE
feat(quests): SP4 — éditeur monde, authoring de quêtes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -863,8 +863,15 @@ if(WIN32)
 endif()
 
 # World Editor : exécutable séparé, même cœur Vulkan que le jeu (flag interne --world-editor).
+# SP4 (authoring quêtes) — QuestEditorPanel.cpp + QuestEditIo.cpp sont compilés
+# UNIQUEMENT ici (pas dans engine_core) : QuestEditIo.cpp est déjà compilé
+# directement dans l'exécutable de test `quest_edit_io_tests` (qui lie aussi
+# engine_core) — l'ajouter à engine_core créerait un symbole dupliqué au link
+# de ce test.
 add_executable(world_editor_app
   src/world_editor/main.cpp
+  src/world_editor/quests/QuestEditIo.cpp
+  src/world_editor/panels/QuestEditorPanel.cpp
 )
 if(WIN32)
   target_sources(world_editor_app PRIVATE "${CMAKE_SOURCE_DIR}/game/data/icons/lcdlln_world_editor.rc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,6 +580,14 @@ add_library(engine_core
   src/world_editor/panels/InspectorPanel.cpp
   src/world_editor/panels/AssetBrowserPanel.cpp
   src/world_editor/panels/BuildingEditorPanel.cpp
+  # SP4 (authoring quêtes) : QuestEditIo.cpp + QuestEditorPanel.cpp doivent être
+  # dans engine_core (pas seulement world_editor_app) car WorldEditorShell.cpp
+  # (ci-dessus) instancie QuestEditorPanel et est lui-même compilé dans
+  # engine_core, lié par engine_app (flag runtime --editor-world) : sans ça,
+  # engine_app ne résout pas le vtable/Render() au link. Même pattern que
+  # QuestTextCatalog.cpp / QuestGiverTable.cpp plus haut.
+  src/world_editor/quests/QuestEditIo.cpp
+  src/world_editor/panels/QuestEditorPanel.cpp
   src/world_editor/panels/OutlinerPanel.cpp
   src/world_editor/panels/ConsolePanel.cpp
   src/world_editor/panels/ToolPropertiesPanel.cpp
@@ -863,15 +871,12 @@ if(WIN32)
 endif()
 
 # World Editor : exécutable séparé, même cœur Vulkan que le jeu (flag interne --world-editor).
-# SP4 (authoring quêtes) — QuestEditorPanel.cpp + QuestEditIo.cpp sont compilés
-# UNIQUEMENT ici (pas dans engine_core) : QuestEditIo.cpp est déjà compilé
-# directement dans l'exécutable de test `quest_edit_io_tests` (qui lie aussi
-# engine_core) — l'ajouter à engine_core créerait un symbole dupliqué au link
-# de ce test.
+# SP4 (authoring quêtes) — QuestEditIo.cpp + QuestEditorPanel.cpp sont désormais
+# dans engine_core (CMakeLists racine, requis par WorldEditorShell::Init lié
+# aussi dans engine_app) -> ne pas les re-lister ici, world_editor_app les
+# obtient via engine_core.
 add_executable(world_editor_app
   src/world_editor/main.cpp
-  src/world_editor/quests/QuestEditIo.cpp
-  src/world_editor/panels/QuestEditorPanel.cpp
 )
 if(WIN32)
   target_sources(world_editor_app PRIVATE "${CMAKE_SOURCE_DIR}/game/data/icons/lcdlln_world_editor.rc")

--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2448,3 +2448,13 @@ Au `Talk` sur un PNJ, le shard renvoie `QuestGiverList` (opcode 92) listant ses 
 Côté client, le système de quêtes (shard, SP1) est affiché par `QuestImGuiRenderer` (`src/client/render/`) branché dans la boucle ImGui in-game : **journal** (quêtes Active/ReadyToTurnIn, textes via `QuestTextCatalog`), **tracker HUD**, et **panneau donneur** (boutons Accepter/Terminer). Les textes lisibles viennent de `game/data/quests/quest_texts.<lang>.json` (`QuestTextCatalog`) ; le mapping PNJ→quêtes de `game/data/quests/quest_givers.json` (`QuestGiverTable`).
 
 Interaction : les choix de dialogue portent un `questKey` (string) qui déclenche `GameplayUdpClient::SendQuestAcceptRequest`/`SendQuestTurnInRequest` (opcodes 93/94) vers le shard, ciblant le PNJ courant (`m_currentDialogueNpcTargetId`, posé à l'ouverture du dialogue — qui envoie aussi un Talk pour recevoir la giver-list). La réception de `QuestGiverList` (opcode 92) alimente `UIModel.giverList`. Un **marqueur world-space** (rune procédurale, 2 variantes : doré = proposer, bleu = rendre ; culling par `client.quest.giver_marker_distance_m`) signale les PNJ ayant une quête `Offered` (donneur) ou `ReadyToTurnIn` (receveur) pour ce joueur. Les envois système A (master, opcodes 59/61/63) ne sont plus émis (retrait complet = sous-projet Cleanup). Détails : `docs/superpowers/specs/2026-07-02-quest-sp2-client-ui-design.md`.
+
+## Quêtes — authoring éditeur (SP4)
+
+Dans l'éditeur monde (`lcdlln_world_editor.exe`), le **`QuestEditorPanel`** (`src/world_editor/panels/`, `IPanel`) permet de créer/éditer des quêtes par formulaire (id, giver, turnIn, pré-requis, étapes typées kill/collect/talk/enter, récompenses, textes titre/description/libellés). La logique I/O + validation est isolée dans **`QuestEditIo`** (`src/world_editor/quests/`, pur, testable) :
+
+- **Load** : parse `quest_definitions.json` (pur JSON) + fusionne `quest_texts.fr.json`.
+- **Validate** : id unique, giver/turnIn obligatoires, étapes bien formées, pré-requis existants, **détection de cycle** (DFS), items valides.
+- **Save** : écrit les **3 fichiers** — `quest_definitions.json` (pur JSON, format inchangé relisible par le shard), `quest_texts.fr.json`, et **régénère `quest_givers.json`** depuis les giver/turnIn (cohérence garantie).
+
+Greffé dans `WorldEditorShell::Init` (après `BuildingEditorPanel`) ; rendu automatique via la boucle des panneaux. ⚠️ Toute quête créée/éditée = contenu → **restart shard** pour la charger. Détails : `docs/superpowers/specs/2026-07-02-quest-sp4-editor-authoring-design.md`.

--- a/docs/superpowers/plans/2026-07-02-quest-sp4-editor-authoring.md
+++ b/docs/superpowers/plans/2026-07-02-quest-sp4-editor-authoring.md
@@ -1,0 +1,169 @@
+# SP4 — Éditeur monde : authoring de quêtes — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Un panneau `QuestEditorPanel` dans `lcdlln_world_editor.exe` pour créer/éditer des quêtes et écrire les 3 fichiers de contenu (`quest_definitions.json`, `quest_texts.fr.json`, `quest_givers.json` régénéré).
+
+**Architecture:** Séparer l'**I/O + validation** (`QuestEditIo`, pur, testable) du **rendu** (`QuestEditorPanel`, `IPanel`, ImGui, intégration). Greffer dans `WorldEditorShell::Init` (après `BuildingEditorPanel`) ; rendu automatique via la boucle `RenderFrame`.
+
+**Tech Stack:** C++20, ImGui (world editor), `src/world_editor/{panels,quests}`, contenu `game/data/quests/`.
+
+## Global Constraints
+
+- **Commentaires en français** ; clarté > brièveté.
+- **Règle CLAUDE.md éditeur** : TOUTE fonction nouvelle de `src/world_editor/` (libre, méthode, lambda nommée) documentée `///` (Doxygen) : rôle (1-2 phrases), `\param` non-évidents, **effet de bord** (écriture disque !), **contrainte thread/timing** (main thread, phase ImGui). Non négociable.
+- **PascalCase** pour tout nouveau symbole/fichier. **Jamais « CMANGOS »**.
+- **Pas de build local** : vérification via CI (`build-linux` compile `world_editor_app` + `ctest`). Étapes « run test » = commande `ctest` attendue.
+- **Tests non-strippables** : CI Release (`-DNDEBUG`) strippe `assert()` → style `std::cerr`+compteur+`return 1` (cf. `src/shardd/gameplay/quest/QuestRuntimeTests.cpp`), OU `#undef NDEBUG` en tête.
+- **`quest_definitions.json` reste du PUR JSON** (tableaux `[]`) — NE PAS basculer au format Config `count`-indexé (casserait `QuestRuntime` shard).
+- **Déploiement** : ✅ outillage éditeur (`world_editor_app`), pas de redéploiement jeu ; contenu créé → restart shard.
+
+---
+
+## Structure de fichiers
+
+**Créés :**
+- `src/world_editor/quests/QuestEditIo.{h,cpp}` — modèle `EditedQuest` + `Load`/`Validate`/`Save`.
+- `src/world_editor/quests/QuestEditIoTests.cpp` — tests (non-strippables).
+- `src/world_editor/panels/QuestEditorPanel.{h,cpp}` — panneau `IPanel`.
+
+**Modifiés :**
+- `src/world_editor/core/WorldEditorShell.{h,cpp}` — instancier + injecter `QuestEditorPanel`.
+- `src/CMakeLists.txt` (+ racine `CMakeLists.txt` si nécessaire) — source `QuestEditIo.cpp`/`QuestEditorPanel.cpp` dans la cible `world_editor_app` ; test `quest_edit_io_tests`.
+
+> **⚠️ Piège CMake (cf. SP2)** : `QuestEditIo.cpp` doit être compilé dans la cible **`world_editor_app`** (là où sont listés `BuildingEditorPanel.cpp`/`WorldEditorShell.cpp`) **et** dans le test `quest_edit_io_tests` (source directe), mais **PAS dans `engine_core`** (sinon doublon de symboles). Repérer la liste de sources `world_editor_app` dans le CMake avant d'ajouter.
+
+---
+
+## Task 1 : QuestEditIo — modèle + Load
+
+**Files:** Create `src/world_editor/quests/QuestEditIo.{h,cpp}`, `src/world_editor/quests/QuestEditIoTests.cpp` ; Modify CMake.
+
+**Interfaces — Produces:**
+```cpp
+namespace engine::editor::world::quests {
+  struct EditedStep { std::string type; std::string target; uint32_t requiredCount = 1; };
+  struct EditedRewardItem { uint32_t itemId = 0; uint32_t quantity = 1; };
+  struct EditedQuest {
+    std::string id, giver, turnIn;
+    std::vector<std::string> prereqs;
+    std::vector<EditedStep> steps;
+    uint32_t rewardXp = 0, rewardGold = 0;
+    std::vector<EditedRewardItem> rewardItems;
+    std::string title, description;       // depuis quest_texts.<lang>.json
+    std::vector<std::string> stepLabels;  // 1 par étape
+  };
+  class QuestEditIo {
+  public:
+    /// Charge quest_definitions.json (pur JSON) + fusionne quest_texts.fr.json.
+    bool Load(const std::string& contentRoot, std::vector<EditedQuest>& out, std::string& outError) const;
+    // Validate / Save : Tasks 2 / 3.
+  };
+}
+```
+
+- [ ] **Step 1 : Test (échec attendu)** — `QuestEditIoTests.cpp` (style non-strippable). Écrire une fixture : un dossier temporaire `<tmp>/quests/quest_definitions.json` (2 quêtes, dont `kill_10_boars` giver/turnIn `npc:elder_marn`, step kill mob:100 x10, reward xp/gold) + `<tmp>/quests/quest_texts.fr.json` (title/description/steps pour `kill_10_boars`). Appeler `Load(<tmp>, out, err)`. Asserts : `out.size()==2` ; la quête `kill_10_boars` a `giver=="npc:elder_marn"`, `steps[0].type=="kill"`, `steps[0].target=="mob:100"`, `steps[0].requiredCount==10`, `title` non vide, `stepLabels[0]` non vide.
+
+- [ ] **Step 2 : Enregistrer le test** — `src/CMakeLists.txt` : `lcdlln_add_simple_test(quest_edit_io_tests <…>/QuestEditIoTests.cpp <…>/QuestEditIo.cpp)` (engine_core lié par le helper → FileSystem dispo). Mirror une registration voisine (`quest_runtime_tests`).
+
+- [ ] **Step 3 : Vérif échec CI** — `ctest -R quest_edit_io_tests` → FAIL.
+
+- [ ] **Step 4 : Implémenter `Load`** — lire `<contentRoot>/quests/quest_definitions.json` (via `engine::platform::FileSystem::ReadAllTextContent` ou lecture fichier direct `std::ifstream` sur le chemin absolu) + parser avec le **`JsonParser` inline** (copier le patron de `src/shardd/gameplay/quest/QuestRuntime.cpp` : `JsonParser`/`JsonValue`/`FindObjectMember`/`JsonType`). Remplir `EditedQuest` (id/giver/turnIn/prereqs/steps/rewards). Puis lire `quest_texts.fr.json` (map questId → {title, description, steps[]}) et fusionner par id (champs vides si absent). `///` sur chaque fonction. Commentaires FR.
+
+- [ ] **Step 5 : Vérif succès CI** — `ctest -R quest_edit_io_tests` → PASS.
+
+- [ ] **Step 6 : Commit** — `feat(quests-editor): QuestEditIo::Load (quest_definitions + quest_texts)`.
+
+---
+
+## Task 2 : QuestEditIo — Validate
+
+**Files:** Modify `src/world_editor/quests/QuestEditIo.{h,cpp}`, `QuestEditIoTests.cpp`.
+
+**Interfaces — Produces:**
+```cpp
+/// Valide l'ensemble ; remplit outErrors (vide = OK). Pur, sans I/O.
+bool Validate(const std::vector<EditedQuest>& quests, std::vector<std::string>& outErrors) const;
+```
+
+- [ ] **Step 1 : Test (échec attendu)** — ajouter des cas : (a) ensemble valide → `Validate` true, 0 erreur ; (b) 2 quêtes même `id` → false ; (c) `prereqs=["inconnu"]` → false (dangling) ; (d) cycle `A.prereqs=[B]`, `B.prereqs=[A]` → false ; (e) `giver==""` → false ; (f) quête sans étape → false ; (g) étape `target==""` → false.
+
+- [ ] **Step 2 : Vérif échec CI**.
+
+- [ ] **Step 3 : Implémenter `Validate`** — règles : id non vide + unique ; giver/turnIn non vides ; ≥1 étape ; chaque `type` ∈ {kill,collect,talk,enter}, `target` non vide, `requiredCount≥1` ; chaque prereq existe dans l'ensemble ; **détection de cycle** par DFS sur le graphe prereqs (coloriage blanc/gris/noir) ; items reward `itemId>0 && quantity≥1`. Messages d'erreur lisibles (FR). `///` sur chaque fonction/aide.
+
+- [ ] **Step 4 : Vérif succès CI** ; **Step 5 : Commit** — `feat(quests-editor): QuestEditIo::Validate (unicité, prereqs, cycle, formes)`.
+
+---
+
+## Task 3 : QuestEditIo — Save (3 fichiers, pur JSON)
+
+**Files:** Modify `src/world_editor/quests/QuestEditIo.{h,cpp}`, `QuestEditIoTests.cpp`.
+
+**Interfaces — Produces:**
+```cpp
+/// Écrit les 3 fichiers sous <contentRoot>/quests/ (pur JSON pretty). Effet de bord DISQUE.
+/// quest_givers.json est RÉGÉNÉRÉ depuis giver/turnIn. \return false + outError si échec.
+bool Save(const std::string& contentRoot, const std::vector<EditedQuest>& quests, std::string& outError) const;
+```
+
+- [ ] **Step 1 : Test (échec attendu)** — round-trip : partir d'un `std::vector<EditedQuest>` en mémoire → `Save(<tmp>, quests, err)` → `Load(<tmp>, reloaded, err)` → égalité structurelle (id/giver/turnIn/steps/rewards/title/stepLabels). PLUS : parser le `quest_givers.json` écrit et vérifier que `npc:elder_marn` a `{kill_10_boars, role0}` ET `{kill_10_boars, role1}` (giver+turnIn = même npc). PLUS : vérifier que le `quest_definitions.json` écrit est du **pur JSON** (contient `"quests": [` et PAS `"count"`).
+
+- [ ] **Step 2 : Vérif échec CI**.
+
+- [ ] **Step 3 : Implémenter `Save`** — sérialiser à la main via `std::ostringstream` (helpers `JsonEscape`/`Num` copiés du patron `BuildingTemplateLibrary.cpp`) :
+  - `quest_definitions.json` : `{ "quests": [ {id,giver,turnIn,prereqs[],steps[{type,target,requiredCount}],rewards{xp,gold,items[{itemId,quantity}]}} ] }` — **pur JSON, tableaux**.
+  - `quest_texts.fr.json` : `{ "<id>": {title,description,steps[]} }`.
+  - `quest_givers.json` : parcourir toutes les quêtes ; pour chaque `giver` ajouter `{questId,role:0}` sous la clé npc, pour chaque `turnIn` ajouter `{questId,role:1}` ; grouper par npcTargetId. Écrire `{ "<npc>": [ {questId,role} ] }`.
+  - Écrire chaque fichier via `std::ofstream(path, binary|trunc)`. `///` + effet de bord disque documenté.
+
+- [ ] **Step 4 : Vérif succès CI** ; **Step 5 : Commit** — `feat(quests-editor): QuestEditIo::Save (3 fichiers pur JSON + régénération givers)`.
+
+---
+
+## Task 4 : QuestEditorPanel (IPanel) + enregistrement shell
+
+**Files:** Create `src/world_editor/panels/QuestEditorPanel.{h,cpp}` ; Modify `src/world_editor/core/WorldEditorShell.{h,cpp}`, CMake. **Intégration — pas de test unitaire** (UI éditeur, validée compil CI + en éditeur).
+
+- [ ] **Step 1 : Créer `QuestEditorPanel`** — hérite de `IPanel` (`GetName()="Quest Editor"`, `Render()`, `IsVisible/SetVisible`). Injections : `SetContentRoot(std::string)`, `SetIo(QuestEditIo*)` (ou possède un `QuestEditIo` interne). Membres : `std::vector<EditedQuest> m_quests;` (chargées au 1er Render via `m_io->Load`), index sélectionné, buffers d'édition (id/giver/turnIn/steps/rewards/textes), `std::string m_status`.
+  `Render()` (patron `BuildingEditorPanel::Render`) :
+  - combo « Charger » (liste des ids) + bouton « Nouvelle quête » ;
+  - champs id/giver/turnIn ; multi-sélection prereqs ; liste d'étapes (combo type + target + requiredCount, +/×) ; rewards (xp/gold/items) ; textes (title/description/stepLabels) ;
+  - bouton **Enregistrer** → `m_io->Validate(m_quests, errs)` ; si OK `m_io->Save(m_contentRoot, m_quests, err)` ; sinon afficher les erreurs dans `m_status`.
+  **`///` sur CHAQUE méthode/lambda nommée** (rôle, effet de bord disque au save, thread main/ImGui). Commentaires FR. Pas d'aperçu 3D.
+
+- [ ] **Step 2 : Enregistrer dans le shell** — `WorldEditorShell::Init` (`WorldEditorShell.cpp:~136`, après le bloc `BuildingEditorPanel`) : instancier `QuestEditorPanel`, `SetContentRoot(cfg.GetString("paths.content","game/data"))`, `SetIo(&m_questEditIo)` (ajouter un membre `QuestEditIo m_questEditIo;` au shell), `m_panels.emplace_back(std::move(...))`. Le rendu est **automatique** (boucle `RenderFrame:431`). `///` sur toute lambda/fonction ajoutée.
+
+- [ ] **Step 3 : CMake** — ajouter `QuestEditIo.cpp` **et** `QuestEditorPanel.cpp` à la liste de sources de la cible **`world_editor_app`** (repérer où `BuildingEditorPanel.cpp`/`WorldEditorShell.cpp` sont listés). **PAS** dans `engine_core` (QuestEditIo.cpp est déjà dans le test ; l'y mettre dans engine_core créerait un doublon au link du test).
+
+- [ ] **Step 4 : Vérif compilation CI** — `cmake --build --preset linux-x64-release --target world_editor_app` (via CI) doit passer ; `ctest` reste vert.
+
+- [ ] **Step 5 : Commit** — `feat(quests-editor): QuestEditorPanel + enregistrement dans WorldEditorShell`.
+
+---
+
+## Task 5 : Documentation
+
+- [ ] **Step 1** — `CODEBASE_MAP.md` : section « Quêtes — authoring éditeur (SP4) » : `QuestEditorPanel` + `QuestEditIo` (load/validate/save 3 fichiers, régénération givers), greffe dans le shell, restart shard pour charger. Renvoyer à la spec SP4.
+
+- [ ] **Step 2 : Commit** — `docs(quests): authoring éditeur SP4 dans CODEBASE_MAP`.
+
+---
+
+## Checklist finale (DoD SP4)
+
+- [ ] `QuestEditIo` Load/Validate/Save + tests verts (round-trip, validation, cycle, régénération givers).
+- [ ] `quest_definitions.json` écrit en **pur JSON** (round-trip relisible par le shard).
+- [ ] `quest_givers.json` régénéré cohérent ; `quest_texts.fr.json` écrit.
+- [ ] `QuestEditorPanel` (IPanel) : charger/éditer/valider/enregistrer + statut ; greffé dans `WorldEditorShell::Init`.
+- [ ] CMake : sources dans `world_editor_app` (pas engine_core) ; test enregistré.
+- [ ] **Toutes** les fonctions `src/world_editor/` nouvelles documentées `///` (FR).
+- [ ] CI verte (build-linux world_editor_app + ctest). Rapport : ✅ outillage éditeur, restart shard pour le contenu créé.
+
+---
+
+## Self-review (effectuée)
+- **Couverture spec** : §2/§5 I/O → Tasks 1,3 ; §4 validation → Task 2 ; §3 UX panneau → Task 4 ; §8 doc rule → toutes les tasks + Task 5.
+- **Points « lire le voisin »** : liste de sources `world_editor_app` dans le CMake (Task 4 Step 3) ; helpers `JsonEscape`/`Num` (BuildingTemplateLibrary) ; `JsonParser` inline (QuestRuntime) ; call-site d'instanciation (WorldEditorShell.cpp:128-136).
+- **Piège CMake** explicité (QuestEditIo.cpp dans world_editor_app + test, PAS engine_core).
+- **Doc rule** rappelée à chaque task (spécificité éditeur).

--- a/docs/superpowers/specs/2026-07-02-quest-sp4-editor-authoring-design.md
+++ b/docs/superpowers/specs/2026-07-02-quest-sp4-editor-authoring-design.md
@@ -1,0 +1,124 @@
+# SP4 — Éditeur monde : authoring de quêtes
+
+**Date** : 2026-07-02
+**Statut** : design (à relire)
+**Doc parent** : `2026-07-02-quest-system-overview-design.md` (décision 5)
+**Dépend de** : SP1 (schéma `quest_definitions.json` + `giver`/`turnIn`), SP2 (fichiers client `quest_texts`/`quest_givers`) — tous mergés dans `main`.
+**Portée** : un panneau de `lcdlln_world_editor.exe` pour **créer/éditer des quêtes** (authoring hors-ligne, écrit le JSON de contenu). Aucun changement runtime jeu/serveur.
+
+> **Déploiement** : ✅ outillage éditeur (binaire client `world_editor_app`), **pas de redéploiement jeu**. En revanche, toute quête créée/éditée = **contenu** → le shard la charge à l'`Init` de `QuestRuntime`/`SpawnerRuntime` → **restart shard** pour la prendre en compte.
+
+---
+
+## 1. Contexte & ancrages (cartographie 2026-07-02)
+
+L'éditeur monde a une infra de panneaux stable :
+- **`IPanel`** (`src/world_editor/core/IPanel.h`) : `GetName()`, `Render()`, `IsVisible()`/`SetVisible()`. Appelé **main thread**, phase ImGui.
+- **Patron `BuildingEditorPanel`** (`src/world_editor/panels/BuildingEditorPanel.{h,cpp}`) : formulaire ImGui + injections par setters + bouton **Enregistrer** → `BuildingTemplateLibrary::SaveVariant(m_contentRoot, …)`.
+- **Enregistrement** : `WorldEditorShell::Init` (`src/world_editor/core/WorldEditorShell.cpp:128-136`) instancie les panneaux **en fin de liste** (pour ne pas décaler les index fixes) + injecte `SetContentRoot(cfg.GetString("paths.content","game/data"))`. Le rendu est **automatique** via la boucle `RenderFrame` (`:431` : `for(panel) if(IsVisible()) panel->Render();`).
+- **Sérialisation** : `BuildingTemplateLibrary::SaveVariant` (`src/client/world/instances/BuildingTemplateLibrary.cpp:153-259`) écrit à la main via `std::ostringstream` (+ helpers `JsonEscape`/`Num`) puis `std::ofstream`. **MAIS** au format Config (`count`-indexé). `quest_definitions.json` est du **pur JSON** (tableaux `[]`) → format différent.
+- **Contraintes éditeur (CLAUDE.md)** : **toute fonction** de `src/world_editor/` doit être documentée `///` (rôle, params non-évidents, effets de bord, thread/timing) ; police **Arial** ; commentaires **FR** ; **PascalCase** pour le nouveau code.
+
+Les 3 fichiers de contenu quête existent déjà dans `game/data/quests/` :
+- `quest_definitions.json` (shard) : `[{ id, giver, turnIn, prereqs[], steps[{type,target,requiredCount}], rewards{xp,gold,items[{itemId,quantity}]} }]`.
+- `quest_texts.fr.json` (client) : `{ "<questId>": { title, description, steps[] } }`.
+- `quest_givers.json` (client) : `{ "<npcTargetId>": [{ questId, role }] }` (role 0=giver,1=turnIn).
+
+---
+
+## 2. Architecture SP4
+
+```
+QuestEditorPanel  (src/world_editor/panels/, IPanel)   ← formulaire ImGui
+        │  injections : SetContentRoot(), SetIo(QuestEditIo*)
+        │  Render() : charger/éditer/valider/enregistrer
+        ▼
+QuestEditIo  (src/world_editor/quests/)                ← I/O des 3 fichiers
+        ├─ Load(contentRoot, out<vector<EditedQuest>>, outError)
+        │     lit quest_definitions.json (JsonParser inline, comme QuestRuntime)
+        │     + fusionne quest_texts.fr.json (title/desc/stepLabels)
+        ├─ Validate(quests, outErrors)                 ← pur, testable
+        └─ Save(contentRoot, quests, outError)
+              écrit quest_definitions.json (pur JSON hand-sérialisé)
+              + quest_texts.fr.json
+              + quest_givers.json (RÉGÉNÉRÉ depuis giver/turnIn)
+
+Enregistrement : WorldEditorShell::Init  (après BuildingEditorPanel, ~:136)
+Rendu          : WorldEditorShell::RenderFrame  (:431, automatique)
+```
+
+- **`QuestEditorPanel`** : le panneau (UI). Pas d'aperçu 3D (les quêtes sont des données).
+- **`QuestEditIo`** : la logique I/O + validation (séparée du rendu → **testable** sans ImGui).
+- **`EditedQuest`** (struct éditeur) : `id, giver, turnIn, prereqs[], steps[{type,target,requiredCount}], rewards{xp,gold,items[]}, title, description, stepLabels[]` — **mécanique + texte réunis** pour l'édition.
+
+---
+
+## 3. UX du panneau (`Render`)
+
+1. **Charger** : combo de la liste des `id` de quêtes chargées (au premier `Render`, `QuestEditIo::Load`) → remplit le formulaire. Bouton **Nouvelle quête** (formulaire vide).
+2. **Métadonnées** : champs texte `id`, `giver`, `turnIn` ; multi-sélection `prereqs` parmi les ids existants.
+3. **Étapes** : liste de lignes typées (combo `type` = kill/collect/talk/enter, champ `target`, `requiredCount`), boutons **+ étape** / **× supprimer**.
+4. **Récompenses** : `xp`, `gold`, liste d'items `{itemId, quantity}` (ajout/suppression).
+5. **Texte** : `title`, `description`, et un libellé par étape (`stepLabels[i]`, ex. « Sangliers tués : {current}/{required} »).
+6. **Enregistrer** : bouton → `Validate` puis `QuestEditIo::Save`. Message de statut (succès / liste d'erreurs) affiché en bas (comme `BuildingEditorPanel.m_status`).
+7. **Annuler/Rétablir** local (optionnel V1) : pile de snapshots du formulaire, comme `BuildingEditorPanel`.
+
+---
+
+## 4. Validation (`QuestEditIo::Validate`, pur/testable)
+
+- `id` non vide et **unique** dans l'ensemble.
+- `giver` et `turnIn` **non vides** (acquisition/turn-in explicites, cf. SP1).
+- au moins **une étape** ; chaque `target` non vide ; `requiredCount` ≥ 1 ; `type` ∈ {kill,collect,talk,enter}.
+- `prereqs` : chaque id **existe** dans l'ensemble (pas de dangling).
+- **Détection de cycle** dans le graphe `prereqs` (DFS) — refuse un cycle.
+- items reward : `itemId` > 0, `quantity` ≥ 1.
+
+`Validate` renvoie une liste d'erreurs lisibles (affichées dans le panneau) ; `Save` est refusé si non vide.
+
+---
+
+## 5. I/O (`QuestEditIo::Load` / `Save`)
+
+- **Load** : `FileSystem::ReadAllTextContent(cfg-less path)` sur `<root>/quests/quest_definitions.json` + `JsonParser` **inline** (le même que `QuestRuntime::LoadDefinitions` — recopié, cf. dette parser JSON repo-wide). Fusionne `quest_texts.fr.json` par `questId` (title/desc/stepLabels) ; les quêtes sans entrée texte prennent des champs vides.
+- **Save** (écrit les **3** fichiers, pur JSON pretty, via `std::ostringstream` + `std::ofstream`, patron `SaveVariant`) :
+  - `quest_definitions.json` : tableau `quests[]` (mécanique). **Format pur JSON** (pas le format Config `count`-indexé) — pour rester lisible par `QuestRuntime` côté shard **sans changement serveur**.
+  - `quest_texts.fr.json` : map `questId → {title, description, steps[]}`.
+  - `quest_givers.json` : **régénéré** depuis les `giver`/`turnIn` de toutes les quêtes (chaque `giver` → `{questId, role:0}`, chaque `turnIn` → `{questId, role:1}`), groupé par `npcTargetId`. Garantit la cohérence des 3 fichiers.
+- Helpers `JsonEscape`/`Num` réutilisés/recopiés du patron `BuildingTemplateLibrary`.
+
+---
+
+## 6. Décisions à confirmer (relecture)
+
+1. **L'éditeur écrit les 3 fichiers** (`quest_definitions` + `quest_texts.fr` + `quest_givers` régénéré) — reco, garde le contenu cohérent de bout en bout. *Alternative : `quest_definitions` seul (texte/givers hand-maintenus).* → **reco : les 3.**
+2. **Placement du PNJ donneur** (interactable + `npc_target_id` dans `zone.json`) = **hors périmètre SP4** (l'éditeur édite la *donnée quête* ; le placement PNJ reste l'édition d'interactables/zone existante). OK ?
+3. **Langue des textes** : V1 = **`fr`** uniquement (fichier `quest_texts.fr.json`) ; les autres langues restent hand-maintenues/copiées. OK ?
+4. **Emplacement code** : `src/world_editor/panels/QuestEditorPanel.{h,cpp}` + `src/world_editor/quests/QuestEditIo.{h,cpp}`. OK ?
+5. **Autocomplete des références** (giver/turnIn/target/itemId depuis des catalogues) — **hors V1** (champs texte libres + validation de forme). Un durcissement « la cible existe-t-elle » viendra plus tard. OK ?
+
+---
+
+## 7. Tests
+- `QuestEditIoTests` (non-strippable, cf. contrainte CI Release/NDEBUG) :
+  - **Round-trip** : charger un `quest_definitions.json` de fixture → sérialiser → re-parser → égalité structurelle.
+  - **Validation** : id dupliqué rejeté ; prereq dangling rejeté ; **cycle** (`A→B→A`) rejeté ; giver/turnIn vide rejeté ; étape sans target rejetée.
+  - **Régénération `quest_givers`** : giver/turnIn → entrées {role 0/1} correctes, groupées par npc.
+- Le panneau ImGui (`QuestEditorPanel::Render`) = **intégration** (validé dans l'éditeur, pas de test unitaire) — comme `BuildingEditorPanel`.
+
+## 8. Contraintes (rappel)
+- **CLAUDE.md** : toute fonction nouvelle de `src/world_editor/` documentée `///` (rôle, params, effets de bord disque, thread=main/ImGui). Police Arial (héritée du shell). Commentaires **FR**. **PascalCase**.
+- Pas de build local → CI (`build-linux` compile `world_editor_app`). Tests non-strippables.
+- Format `quest_definitions.json` **inchangé** (pur JSON) : ne PAS le basculer au format Config `count`-indexé (casserait `QuestRuntime` côté shard).
+
+## 9. Hors périmètre
+- Placement/édition des PNJ dans le monde (interactables/zone). Autocomplete/validation d'existence des références. Édition multi-langue. Le POI minimap (SP3), le Cleanup système A.
+
+## 10. Definition of Done
+- [ ] `QuestEditIo` (Load/Validate/Save 3 fichiers) + tests verts.
+- [ ] `QuestEditorPanel` (IPanel) : formulaire charger/éditer/valider/enregistrer, statut.
+- [ ] Enregistré dans `WorldEditorShell::Init` (après BuildingEditor) + rendu auto.
+- [ ] `quest_definitions.json` reste du pur JSON relisible par le shard (round-trip testé).
+- [ ] `quest_givers.json` régénéré cohérent ; `quest_texts.fr.json` écrit.
+- [ ] Toutes les fonctions éditeur documentées `///` (FR). PascalCase. Pas de « CMANGOS ».
+- [ ] CI verte (build-linux world_editor_app + ctest). Rapport final : ✅ outillage éditeur, restart shard pour charger le contenu créé.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -589,9 +589,11 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntime.cpp)
   # SP4 (éditeur monde) : QuestEditIo — chargement authoring (quest_definitions + quest_texts fusionnés).
+  # QuestEditIo.cpp est désormais dans engine_core (CMakeLists racine, requis
+  # par QuestEditorPanel/WorldEditorShell) -> ne pas le re-lister ici (double
+  # définition de symboles), même pattern que quest_text_catalog_tests ci-dessous.
   lcdlln_add_simple_test(quest_edit_io_tests
-    ${CMAKE_SOURCE_DIR}/src/world_editor/quests/QuestEditIoTests.cpp
-    ${CMAKE_SOURCE_DIR}/src/world_editor/quests/QuestEditIo.cpp)
+    ${CMAKE_SOURCE_DIR}/src/world_editor/quests/QuestEditIoTests.cpp)
   # SP2 (client) : QuestTextCatalog — titres/descriptions/étapes lisibles par locale.
   # QuestTextCatalog.cpp est desormais dans engine_core (CMakeLists racine, requis
   # par QuestImGuiRenderer/Engine.cpp) -> ne pas le re-lister ici (double définition

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -588,6 +588,10 @@ elseif(UNIX)
   lcdlln_add_simple_test(quest_runtime_tests
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/quest/QuestRuntime.cpp)
+  # SP4 (éditeur monde) : QuestEditIo — chargement authoring (quest_definitions + quest_texts fusionnés).
+  lcdlln_add_simple_test(quest_edit_io_tests
+    ${CMAKE_SOURCE_DIR}/src/world_editor/quests/QuestEditIoTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/world_editor/quests/QuestEditIo.cpp)
   # SP2 (client) : QuestTextCatalog — titres/descriptions/étapes lisibles par locale.
   # QuestTextCatalog.cpp est desormais dans engine_core (CMakeLists racine, requis
   # par QuestImGuiRenderer/Engine.cpp) -> ne pas le re-lister ici (double définition

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -5,6 +5,7 @@
 #include "src/world_editor/panels/InspectorPanel.h"
 #include "src/world_editor/panels/AssetBrowserPanel.h"
 #include "src/world_editor/panels/BuildingEditorPanel.h"
+#include "src/world_editor/panels/QuestEditorPanel.h"
 #include "src/world_editor/panels/OutlinerPanel.h"
 #include "src/world_editor/panels/ConsolePanel.h"
 #include "src/world_editor/panels/ToolPropertiesPanel.h"
@@ -133,6 +134,16 @@ namespace engine::editor::world
 			buildingEditor->SetContentRoot(cfg.GetString("paths.content", "game/data"));
 			m_buildingEditorPtr = buildingEditor.get(); // pour l'aperçu 3D live (Engine)
 			m_panels.emplace_back(std::move(buildingEditor));
+		}
+		// SP4 — Quest Editor : authoring des quêtes (charger/éditer/valider/
+		// enregistrer via QuestEditIo). AJOUTÉ EN FIN (n'affecte pas les
+		// indices fixes). Pas d'aperçu 3D (donnée pure).
+		{
+			auto questEditor = std::make_unique<panels::QuestEditorPanel>();
+			questEditor->SetContentRoot(cfg.GetString("paths.content", "game/data"));
+			questEditor->SetIo(&m_questEditIo);
+			m_questEditorPtr = questEditor.get();
+			m_panels.emplace_back(std::move(questEditor));
 		}
 
 #if defined(_WIN32)

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -3,6 +3,7 @@
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/buildings/BuildingDocument.h"
 #include "src/client/world/instances/BuildingTemplateLibrary.h"
+#include "src/world_editor/quests/QuestEditIo.h"
 #include "src/world_editor/terrain/erosion/HydraulicErosionTool.h"
 #include "src/world_editor/terrain/erosion/ThermalWindErosionTool.h"
 #include "src/world_editor/volumes/MeshInsertDocument.h"
@@ -36,6 +37,7 @@ namespace engine::editor::world
 {
 	namespace panels { class ScenePanel; }
 	namespace panels { class BuildingEditorPanel; }
+	namespace panels { class QuestEditorPanel; }
 
 	/// Identifiant de l'outil actif dans le shell éditeur monde (M100.6+).
 	/// `None` est l'état initial après `Init`. `TerrainSculpt` est activé
@@ -382,6 +384,12 @@ namespace engine::editor::world
 		/// nullptr tant qu'Init n'a pas été appelé.
 		panels::BuildingEditorPanel* GetBuildingEditorPanel() { return m_buildingEditorPtr; }
 
+		/// SP4 — Panneau Quest Editor (authoring des quêtes). nullptr tant
+		/// qu'Init n'a pas été appelé. Exposé pour d'éventuels tests/outils
+		/// externes ; le rendu normal passe par la boucle `m_panels` de
+		/// `RenderFrame`.
+		panels::QuestEditorPanel* GetQuestEditorPanel() { return m_questEditorPtr; }
+
 		/// M100.43 — Accès mutable à l'outil Dungeon Portal.
 		volumes::dungeons::DungeonPortalTool&       MutableDungeonPortalTool()       { return m_dungeonPortalTool; }
 		const volumes::dungeons::DungeonPortalTool& GetDungeonPortalTool()     const { return m_dungeonPortalTool; }
@@ -439,6 +447,8 @@ namespace engine::editor::world
 		buildings::BuildingDocument m_buildingDoc;                    // Auberge éditable
 		panels::BuildingEditorPanel* m_buildingEditorPtr = nullptr;  // non possédé (dans m_panels)
 		engine::world::instances::BuildingTemplateLibrary m_buildingLibrary; // bibliothèque de types
+		engine::editor::world::quests::QuestEditIo m_questEditIo;    // SP4 — E/S authoring quêtes
+		panels::QuestEditorPanel* m_questEditorPtr = nullptr;        // non possédé (dans m_panels)
 		ActiveTool m_activeTool = ActiveTool::None;
 		std::string m_layoutPath;
 		bool m_dirty = false;

--- a/src/world_editor/panels/QuestEditorPanel.cpp
+++ b/src/world_editor/panels/QuestEditorPanel.cpp
@@ -1,0 +1,326 @@
+#include "src/world_editor/panels/QuestEditorPanel.h"
+
+#include <algorithm>
+#include <cfloat>
+#include <cstdio>
+#include <cstring>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world::panels
+{
+	using engine::editor::world::quests::EditedQuest;
+	using engine::editor::world::quests::EditedStep;
+	using engine::editor::world::quests::EditedRewardItem;
+
+	void QuestEditorPanel::EnsureLoaded()
+	{
+		if (m_loaded) return;
+		m_loaded = true;
+		if (!m_io)
+		{
+			m_status = "Erreur : QuestEditIo non initialise.";
+			return;
+		}
+		std::string err;
+		if (m_io->Load(m_contentRoot, m_quests, err))
+		{
+			m_status = std::to_string(m_quests.size()) + " quete(s) chargee(s).";
+		}
+		else
+		{
+			m_status = "Echec chargement : " + err;
+		}
+	}
+
+	void QuestEditorPanel::LoadBuffersFromSelected()
+	{
+		if (m_selected < 0 || m_selected >= static_cast<int>(m_quests.size())) return;
+		const EditedQuest& q = m_quests[m_selected];
+		std::snprintf(m_idBuf, sizeof(m_idBuf), "%s", q.id.c_str());
+		std::snprintf(m_giverBuf, sizeof(m_giverBuf), "%s", q.giver.c_str());
+		std::snprintf(m_turnInBuf, sizeof(m_turnInBuf), "%s", q.turnIn.c_str());
+		m_prereqBuffer = q.prereqs;
+		m_stepsBuffer = q.steps;
+		m_rewardXpBuffer = q.rewardXp;
+		m_rewardGoldBuffer = q.rewardGold;
+		m_rewardItemsBuffer = q.rewardItems;
+		std::snprintf(m_titleBuf, sizeof(m_titleBuf), "%s", q.title.c_str());
+		std::snprintf(m_descriptionBuf, sizeof(m_descriptionBuf), "%s", q.description.c_str());
+		m_stepLabelsBuffer = q.stepLabels;
+		m_stepLabelsBuffer.resize(m_stepsBuffer.size());
+	}
+
+	EditedQuest QuestEditorPanel::BuildQuestFromBuffers() const
+	{
+		EditedQuest q;
+		q.id = m_idBuf;
+		q.giver = m_giverBuf;
+		q.turnIn = m_turnInBuf;
+		q.prereqs = m_prereqBuffer;
+		q.steps = m_stepsBuffer;
+		q.rewardXp = m_rewardXpBuffer;
+		q.rewardGold = m_rewardGoldBuffer;
+		q.rewardItems = m_rewardItemsBuffer;
+		q.title = m_titleBuf;
+		q.description = m_descriptionBuf;
+		q.stepLabels = m_stepLabelsBuffer;
+		q.stepLabels.resize(q.steps.size());
+		return q;
+	}
+
+	void QuestEditorPanel::ResetBuffersToNew()
+	{
+		m_selected = -1;
+		m_idBuf[0] = '\0';
+		m_giverBuf[0] = '\0';
+		m_turnInBuf[0] = '\0';
+		m_prereqBuffer.clear();
+		m_stepsBuffer.clear();
+		m_rewardXpBuffer = 0;
+		m_rewardGoldBuffer = 0;
+		m_rewardItemsBuffer.clear();
+		m_titleBuf[0] = '\0';
+		m_descriptionBuf[0] = '\0';
+		m_stepLabelsBuffer.clear();
+		m_status.clear();
+	}
+
+#if defined(_WIN32)
+	void QuestEditorPanel::RenderLoadSection()
+	{
+		ImGui::TextUnformatted("Charger une quete existante :");
+		const char* preview = (m_selected >= 0 && m_selected < static_cast<int>(m_quests.size()))
+			? m_quests[m_selected].id.c_str() : "(nouvelle quete)";
+		if (ImGui::BeginCombo("Quete a charger", preview))
+		{
+			for (int i = 0; i < static_cast<int>(m_quests.size()); ++i)
+			{
+				const bool isSel = (m_selected == i);
+				if (ImGui::Selectable(m_quests[i].id.c_str(), isSel))
+				{
+					m_selected = i;
+					LoadBuffersFromSelected();
+					m_status = "Quete chargee : " + m_quests[i].id;
+				}
+			}
+			ImGui::EndCombo();
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("Nouvelle quete")) ResetBuffersToNew();
+	}
+
+	void QuestEditorPanel::RenderIdentityFields()
+	{
+		ImGui::InputText("Id", m_idBuf, sizeof(m_idBuf));
+		ImGui::InputText("Donneur (giver)", m_giverBuf, sizeof(m_giverBuf));
+		ImGui::InputText("Rendu a (turnIn)", m_turnInBuf, sizeof(m_turnInBuf));
+	}
+
+	void QuestEditorPanel::RenderPrereqSection()
+	{
+		ImGui::TextUnformatted("Prerequis (quetes a completer avant) :");
+		if (m_quests.empty())
+		{
+			ImGui::TextDisabled("(aucune autre quete chargee)");
+			return;
+		}
+		for (const auto& q : m_quests)
+		{
+			// Une quête ne peut pas être son propre prérequis direct ; les
+			// cycles plus longs restent détectés par QuestEditIo::Validate.
+			if (q.id == m_idBuf) continue;
+			bool checked = false;
+			for (const auto& p : m_prereqBuffer) if (p == q.id) { checked = true; break; }
+			if (ImGui::Checkbox(q.id.c_str(), &checked))
+			{
+				if (checked)
+				{
+					m_prereqBuffer.push_back(q.id);
+				}
+				else
+				{
+					m_prereqBuffer.erase(
+						std::remove(m_prereqBuffer.begin(), m_prereqBuffer.end(), q.id),
+						m_prereqBuffer.end());
+				}
+			}
+		}
+	}
+
+	void QuestEditorPanel::RenderStepsSection()
+	{
+		ImGui::TextUnformatted("Etapes :");
+		static const char* kStepTypes[] = { "kill", "collect", "talk", "enter" };
+		int removeIdx = -1;
+		for (size_t i = 0; i < m_stepsBuffer.size(); ++i)
+		{
+			EditedStep& step = m_stepsBuffer[i];
+			ImGui::PushID(static_cast<int>(i));
+
+			int typeIdx = 0;
+			for (int t = 0; t < 4; ++t) if (step.type == kStepTypes[t]) { typeIdx = t; break; }
+			if (ImGui::Combo("Type", &typeIdx, kStepTypes, 4)) step.type = kStepTypes[typeIdx];
+
+			char targetBuf[128];
+			std::snprintf(targetBuf, sizeof(targetBuf), "%s", step.target.c_str());
+			if (ImGui::InputText("Cible", targetBuf, sizeof(targetBuf))) step.target = targetBuf;
+
+			int count = static_cast<int>(step.requiredCount);
+			if (ImGui::DragInt("Quantite requise", &count, 1.0f, 1, 100000))
+				step.requiredCount = static_cast<uint32_t>(count < 1 ? 1 : count);
+
+			if (ImGui::SmallButton("Suppr etape")) removeIdx = static_cast<int>(i);
+			ImGui::Separator();
+			ImGui::PopID();
+		}
+		if (removeIdx >= 0)
+		{
+			m_stepsBuffer.erase(m_stepsBuffer.begin() + removeIdx);
+			if (removeIdx < static_cast<int>(m_stepLabelsBuffer.size()))
+				m_stepLabelsBuffer.erase(m_stepLabelsBuffer.begin() + removeIdx);
+		}
+		if (ImGui::Button("Ajouter une etape"))
+		{
+			EditedStep s;
+			s.type = "kill";
+			s.requiredCount = 1;
+			m_stepsBuffer.push_back(s);
+			m_stepLabelsBuffer.push_back(std::string());
+		}
+	}
+
+	void QuestEditorPanel::RenderRewardsSection()
+	{
+		ImGui::TextUnformatted("Recompenses :");
+		int xp = static_cast<int>(m_rewardXpBuffer);
+		if (ImGui::DragInt("XP", &xp, 1.0f, 0, 1000000)) m_rewardXpBuffer = static_cast<uint32_t>(xp < 0 ? 0 : xp);
+		int gold = static_cast<int>(m_rewardGoldBuffer);
+		if (ImGui::DragInt("Or", &gold, 1.0f, 0, 1000000)) m_rewardGoldBuffer = static_cast<uint32_t>(gold < 0 ? 0 : gold);
+
+		ImGui::TextUnformatted("Items :");
+		int removeIdx = -1;
+		for (size_t i = 0; i < m_rewardItemsBuffer.size(); ++i)
+		{
+			EditedRewardItem& item = m_rewardItemsBuffer[i];
+			ImGui::PushID(static_cast<int>(i) + 1000);
+			int itemId = static_cast<int>(item.itemId);
+			int qty = static_cast<int>(item.quantity);
+			if (ImGui::DragInt("Item id", &itemId, 1.0f, 0, 1000000)) item.itemId = static_cast<uint32_t>(itemId < 0 ? 0 : itemId);
+			ImGui::SameLine();
+			if (ImGui::DragInt("Quantite", &qty, 1.0f, 1, 100000)) item.quantity = static_cast<uint32_t>(qty < 1 ? 1 : qty);
+			ImGui::SameLine();
+			if (ImGui::SmallButton("Suppr item")) removeIdx = static_cast<int>(i);
+			ImGui::PopID();
+		}
+		if (removeIdx >= 0) m_rewardItemsBuffer.erase(m_rewardItemsBuffer.begin() + removeIdx);
+		if (ImGui::Button("Ajouter un item")) m_rewardItemsBuffer.push_back(EditedRewardItem{});
+	}
+
+	void QuestEditorPanel::RenderTextsSection()
+	{
+		ImGui::TextUnformatted("Textes (fr) :");
+		ImGui::InputText("Titre", m_titleBuf, sizeof(m_titleBuf));
+		ImGui::InputTextMultiline("Description", m_descriptionBuf, sizeof(m_descriptionBuf), ImVec2(-FLT_MIN, 80.f));
+		if (m_stepLabelsBuffer.size() != m_stepsBuffer.size())
+			m_stepLabelsBuffer.resize(m_stepsBuffer.size());
+		for (size_t i = 0; i < m_stepLabelsBuffer.size(); ++i)
+		{
+			ImGui::PushID(static_cast<int>(i) + 2000);
+			char label[160];
+			std::snprintf(label, sizeof(label), "Libelle etape %zu", i);
+			char buf[160];
+			std::snprintf(buf, sizeof(buf), "%s", m_stepLabelsBuffer[i].c_str());
+			if (ImGui::InputText(label, buf, sizeof(buf))) m_stepLabelsBuffer[i] = buf;
+			ImGui::PopID();
+		}
+	}
+
+	void QuestEditorPanel::RenderSaveSection()
+	{
+		if (ImGui::Button("Enregistrer"))
+		{
+			if (!m_io)
+			{
+				m_status = "Erreur : QuestEditIo non initialise.";
+			}
+			else if (m_idBuf[0] == '\0')
+			{
+				m_status = "Id de quete requis.";
+			}
+			else
+			{
+				EditedQuest edited = BuildQuestFromBuffers();
+				std::vector<EditedQuest> candidate = m_quests;
+				if (m_selected >= 0 && m_selected < static_cast<int>(candidate.size()))
+					candidate[m_selected] = edited;
+				else
+					candidate.push_back(edited);
+
+				std::vector<std::string> errs;
+				if (!m_io->Validate(candidate, errs))
+				{
+					m_status = "Validation echouee :";
+					for (const auto& e : errs) m_status += "\n - " + e;
+				}
+				else
+				{
+					std::string err;
+					if (m_io->Save(m_contentRoot, candidate, err))
+					{
+						m_quests = candidate;
+						// Retrouve l'index de la quête qu'on vient d'éditer (id stable).
+						m_selected = -1;
+						for (int i = 0; i < static_cast<int>(m_quests.size()); ++i)
+							if (m_quests[i].id == edited.id) { m_selected = i; break; }
+						m_status = "Quete enregistree : " + edited.id;
+					}
+					else
+					{
+						m_status = "Echec sauvegarde : " + err;
+					}
+				}
+			}
+		}
+	}
+#endif
+
+	void QuestEditorPanel::Render()
+	{
+#if defined(_WIN32)
+		if (!m_visible) return;
+		EnsureLoaded();
+		if (ImGui::Begin("Quest Editor", &m_visible))
+		{
+			ImGui::TextWrapped(
+				"Edite les quetes du contenu actif (quest_definitions.json + "
+				"quest_texts.fr.json). Redemarrer le shard pour que le contenu "
+				"enregistre soit pris en compte en jeu.");
+			ImGui::Separator();
+
+			RenderLoadSection();
+			ImGui::Separator();
+			RenderIdentityFields();
+			ImGui::Separator();
+			RenderPrereqSection();
+			ImGui::Separator();
+			RenderStepsSection();
+			ImGui::Separator();
+			RenderRewardsSection();
+			ImGui::Separator();
+			RenderTextsSection();
+			ImGui::Separator();
+			RenderSaveSection();
+
+			if (!m_status.empty())
+			{
+				ImGui::Separator();
+				ImGui::TextWrapped("%s", m_status.c_str());
+			}
+		}
+		ImGui::End();
+#endif
+	}
+}

--- a/src/world_editor/panels/QuestEditorPanel.h
+++ b/src/world_editor/panels/QuestEditorPanel.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include "src/world_editor/core/IPanel.h"
+#include "src/world_editor/quests/QuestEditIo.h"
+
+#include <string>
+#include <vector>
+
+namespace engine::editor::world::panels
+{
+	/// Panneau d'authoring des quêtes (SP4) : charge, édite, valide et
+	/// enregistre l'ensemble des quêtes du contenu actif via `QuestEditIo`.
+	/// Miroir structurel de `BuildingEditorPanel` (formulaire ImGui + statut
+	/// texte + bouton Enregistrer), mais sans aperçu 3D — une quête est de la
+	/// donnée pure (id/giver/turnIn/prereqs/steps/rewards/textes).
+	///
+	/// Dépendance injectée (non possédée) via `SetIo`, posée par le shell à
+	/// l'Init. Le chargement disque (`QuestEditIo::Load`) est différé au
+	/// premier `Render()` (pas de coût tant que le panneau reste masqué).
+	class QuestEditorPanel final : public IPanel
+	{
+	public:
+		const char* GetName() const override { return "Quest Editor"; }
+		void Render() override;
+		bool IsVisible() const override { return m_visible; }
+		void SetVisible(bool visible) override { m_visible = visible; }
+
+		/// Injecte la racine de contenu filesystem (ex. "game/data") utilisée
+		/// par `QuestEditIo::Load`/`Save`. À appeler avant le premier `Render`.
+		void SetContentRoot(std::string root) { m_contentRoot = std::move(root); }
+
+		/// Injecte l'E/S de quêtes (non possédée, doit survivre au panneau —
+		/// portée par le shell). À appeler avant le premier `Render`.
+		void SetIo(engine::editor::world::quests::QuestEditIo* io) { m_io = io; }
+
+	private:
+		/// Charge (une seule fois) l'ensemble des quêtes depuis
+		/// `m_contentRoot` via `m_io->Load`. Effet de bord : lecture disque,
+		/// remplit `m_quests`, positionne `m_status` en cas d'échec. Marque
+		/// `m_loaded = true` dans tous les cas (échec inclus) pour ne
+		/// tenter le chargement qu'une fois par session panneau ; l'utilisateur
+		/// peut forcer une relecture via le bouton « Recharger ».
+		/// Thread : main thread (appelé depuis Render, phase ImGui).
+		void EnsureLoaded();
+
+		/// Réinitialise les buffers d'édition (id/giver/turnIn/prereqs/steps/
+		/// rewards/textes) à partir de la quête sélectionnée `m_quests[m_selected]`.
+		/// Sans effet si `m_selected` est hors plage. Effet de bord : aucun
+		/// (mémoire locale au panneau uniquement).
+		void LoadBuffersFromSelected();
+
+		/// Construit une `EditedQuest` à partir des buffers d'édition courants
+		/// (id/giver/turnIn/prereqs/steps/rewards/textes). Pure : ne touche
+		/// pas `m_quests`, l'appelant décide de l'insertion/remplacement.
+		engine::editor::world::quests::EditedQuest BuildQuestFromBuffers() const;
+
+		/// Réinitialise les buffers d'édition à une quête vierge (utilisé par
+		/// le bouton « Nouvelle quête »). Effet de bord : vide `m_status`.
+		void ResetBuffersToNew();
+
+		/// Rend la section « Charger » : combo listant les ids de `m_quests`
+		/// + bouton « Nouvelle quête ». Sélectionner une entrée appelle
+		/// `LoadBuffersFromSelected`. Effet de bord : état ImGui uniquement.
+		/// Thread : main thread (ImGui).
+		void RenderLoadSection();
+
+		/// Rend les champs scalaires du formulaire (id/giver/turnIn). Effet
+		/// de bord : état ImGui uniquement (écrit dans les buffers membres).
+		void RenderIdentityFields();
+
+		/// Rend la multi-sélection des prérequis (`m_prereqBuffer`) : une
+		/// case à cocher par id de quête connu (hors la quête en cours
+		/// d'édition, pour éviter l'auto-référence triviale ; les cycles plus
+		/// longs restent détectés par `QuestEditIo::Validate`). Effet de bord :
+		/// état ImGui + `m_prereqBuffer`.
+		void RenderPrereqSection();
+
+		/// Rend la liste éditable des étapes (`m_stepsBuffer`) : combo type
+		/// (kill/collect/talk/enter), champ target, champ requiredCount,
+		/// boutons Suppr par ligne + bouton « Ajouter une étape » en fin de
+		/// liste. Effet de bord : état ImGui + `m_stepsBuffer`
+		/// (+ `m_stepLabelsBuffer`, gardé de même taille que `m_stepsBuffer`).
+		void RenderStepsSection();
+
+		/// Rend les champs de récompense : xp, or, liste d'items
+		/// (itemId + quantité, +/× par ligne). Effet de bord : état ImGui +
+		/// `m_rewardXpBuffer`/`m_rewardGoldBuffer`/`m_rewardItemsBuffer`.
+		void RenderRewardsSection();
+
+		/// Rend les champs de texte lisible (titre/description/libellés
+		/// d'étape, un par étape de `m_stepsBuffer`, taille synchronisée par
+		/// `RenderStepsSection`). Effet de bord : état ImGui uniquement.
+		void RenderTextsSection();
+
+		/// Rend le bouton « Enregistrer » : construit la quête courante via
+		/// `BuildQuestFromBuffers`, l'insère/remplace dans une copie de
+		/// `m_quests`, appelle `m_io->Validate` puis, si valide,
+		/// `m_io->Save(m_contentRoot, ...)`. Met à jour `m_status` (succès ou
+		/// liste d'erreurs). Effet de bord : ÉCRITURE DISQUE (3 fichiers sous
+		/// `<contentRoot>/quests/`) en cas de validation réussie ; recharge
+		/// `m_quests` depuis le résultat sauvegardé pour rester cohérent avec
+		/// le disque. Thread : main thread (ImGui + I/O synchrone).
+		void RenderSaveSection();
+
+		bool m_visible = true;
+		bool m_loaded = false; // Load() déjà tenté cette session panneau
+
+		std::string m_contentRoot = "game/data";
+		engine::editor::world::quests::QuestEditIo* m_io = nullptr;
+
+		std::vector<engine::editor::world::quests::EditedQuest> m_quests;
+		int m_selected = -1; // index dans m_quests (-1 = nouvelle quête / aucune)
+
+		// --- Buffers d'édition (formulaire courant, pas encore enregistré) ---
+		char m_idBuf[64] = "";
+		char m_giverBuf[64] = "";
+		char m_turnInBuf[64] = "";
+		std::vector<std::string> m_prereqBuffer;
+
+		std::vector<engine::editor::world::quests::EditedStep> m_stepsBuffer;
+		uint32_t m_rewardXpBuffer = 0;
+		uint32_t m_rewardGoldBuffer = 0;
+		std::vector<engine::editor::world::quests::EditedRewardItem> m_rewardItemsBuffer;
+
+		char m_titleBuf[128] = "";
+		char m_descriptionBuf[512] = "";
+		std::vector<std::string> m_stepLabelsBuffer; // même taille que m_stepsBuffer
+
+		std::string m_status; // dernier message (succès/erreurs), affiché en bas
+	};
+}

--- a/src/world_editor/quests/QuestEditIo.cpp
+++ b/src/world_editor/quests/QuestEditIo.cpp
@@ -1,0 +1,714 @@
+#include "src/world_editor/quests/QuestEditIo.h"
+
+#include "src/shared/platform/FileSystem.h"
+
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+namespace engine::editor::world::quests
+{
+	namespace
+	{
+		enum class JsonType
+		{
+			Null,
+			Bool,
+			Number,
+			String,
+			Object,
+			Array
+		};
+
+		struct JsonValue
+		{
+			JsonType type = JsonType::Null;
+			bool boolValue = false;
+			double numberValue = 0.0;
+			std::string stringValue;
+			std::unordered_map<std::string, JsonValue> objectValue;
+			std::vector<JsonValue> arrayValue;
+		};
+
+		/// Analyseur JSON minimal dédié à l'éditeur de quêtes, pour éviter une
+		/// dépendance externe (miroir volontairement dupliqué de
+		/// `QuestRuntime::JsonParser` côté serveur / `QuestTextCatalog::JsonParser`
+		/// côté client : pas de lib JSON partagée aujourd'hui).
+		class JsonParser final
+		{
+		public:
+			/// Construit un analyseur sur \p input (non copié, doit rester valide
+			/// pendant tout l'appel à Parse).
+			explicit JsonParser(std::string_view input)
+				: m_input(input)
+			{
+			}
+
+			/// Analyse l'intégralité de `m_input` comme une unique valeur JSON.
+			/// \param outRoot reçoit la valeur racine analysée.
+			/// \param outError message d'erreur lisible en cas d'échec.
+			/// \return false si le texte n'est pas un JSON valide (y compris
+			///         caractères en trop après la valeur racine).
+			bool Parse(JsonValue& outRoot, std::string& outError)
+			{
+				SkipWhitespace();
+				if (!ParseValue(outRoot, outError))
+				{
+					return false;
+				}
+
+				SkipWhitespace();
+				if (m_pos != m_input.size())
+				{
+					outError = "unexpected trailing characters";
+					return false;
+				}
+
+				return true;
+			}
+
+		private:
+			/// Avance `m_pos` au-delà des espaces/retours à la ligne courants.
+			void SkipWhitespace()
+			{
+				while (m_pos < m_input.size() && std::isspace(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					++m_pos;
+				}
+			}
+
+			/// Consomme le caractère \p expected s'il est au curseur courant.
+			/// \return true et avance si le caractère correspond, false sinon (sans avancer).
+			bool Consume(char expected)
+			{
+				if (m_pos >= m_input.size() || m_input[m_pos] != expected)
+				{
+					return false;
+				}
+
+				++m_pos;
+				return true;
+			}
+
+			/// \return true si le texte restant commence par \p token (sans avancer).
+			bool StartsWith(std::string_view token) const
+			{
+				return m_input.substr(m_pos, token.size()) == token;
+			}
+
+			/// Analyse une valeur JSON quelconque (objet, tableau, chaîne, bool,
+			/// null ou nombre) au curseur courant.
+			bool ParseValue(JsonValue& outValue, std::string& outError)
+			{
+				if (m_pos >= m_input.size())
+				{
+					outError = "unexpected end of input";
+					return false;
+				}
+
+				switch (m_input[m_pos])
+				{
+				case '{':
+					return ParseObject(outValue, outError);
+				case '[':
+					return ParseArray(outValue, outError);
+				case '"':
+					outValue = JsonValue{};
+					outValue.type = JsonType::String;
+					return ParseString(outValue.stringValue, outError);
+				default:
+					break;
+				}
+
+				if (StartsWith("true"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = true;
+					return true;
+				}
+
+				if (StartsWith("false"))
+				{
+					m_pos += 5;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Bool;
+					outValue.boolValue = false;
+					return true;
+				}
+
+				if (StartsWith("null"))
+				{
+					m_pos += 4;
+					outValue = JsonValue{};
+					outValue.type = JsonType::Null;
+					return true;
+				}
+
+				return ParseNumber(outValue, outError);
+			}
+
+			/// Analyse un objet JSON `{ "clé": valeur, ... }` au curseur courant.
+			bool ParseObject(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('{'))
+				{
+					outError = "expected '{'";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Object;
+				SkipWhitespace();
+				if (Consume('}'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					std::string key;
+					if (!ParseString(key, outError))
+					{
+						return false;
+					}
+
+					SkipWhitespace();
+					if (!Consume(':'))
+					{
+						outError = "expected ':' after object key";
+						return false;
+					}
+
+					SkipWhitespace();
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.objectValue.emplace(std::move(key), std::move(child));
+					SkipWhitespace();
+					if (Consume('}'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between object members";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			/// Analyse un tableau JSON `[ valeur, ... ]` au curseur courant.
+			bool ParseArray(JsonValue& outValue, std::string& outError)
+			{
+				if (!Consume('['))
+				{
+					outError = "expected '['";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Array;
+				SkipWhitespace();
+				if (Consume(']'))
+				{
+					return true;
+				}
+
+				while (true)
+				{
+					JsonValue child;
+					if (!ParseValue(child, outError))
+					{
+						return false;
+					}
+
+					outValue.arrayValue.emplace_back(std::move(child));
+					SkipWhitespace();
+					if (Consume(']'))
+					{
+						return true;
+					}
+
+					if (!Consume(','))
+					{
+						outError = "expected ',' between array entries";
+						return false;
+					}
+
+					SkipWhitespace();
+				}
+			}
+
+			/// Analyse une chaîne JSON entre guillemets (avec échappements standards)
+			/// au curseur courant.
+			bool ParseString(std::string& outValue, std::string& outError)
+			{
+				if (!Consume('"'))
+				{
+					outError = "expected string";
+					return false;
+				}
+
+				outValue.clear();
+				while (m_pos < m_input.size())
+				{
+					const char current = m_input[m_pos++];
+					if (current == '"')
+					{
+						return true;
+					}
+
+					if (current != '\\')
+					{
+						outValue.push_back(current);
+						continue;
+					}
+
+					if (m_pos >= m_input.size())
+					{
+						outError = "unterminated escape sequence";
+						return false;
+					}
+
+					const char escaped = m_input[m_pos++];
+					switch (escaped)
+					{
+					case '"': outValue.push_back('"'); break;
+					case '\\': outValue.push_back('\\'); break;
+					case '/': outValue.push_back('/'); break;
+					case 'b': outValue.push_back('\b'); break;
+					case 'f': outValue.push_back('\f'); break;
+					case 'n': outValue.push_back('\n'); break;
+					case 'r': outValue.push_back('\r'); break;
+					case 't': outValue.push_back('\t'); break;
+					default:
+						outError = "unsupported escape sequence";
+						return false;
+					}
+				}
+
+				outError = "unterminated string";
+				return false;
+			}
+
+			/// Analyse un nombre JSON (entier ou flottant, notation exponentielle
+			/// comprise) au curseur courant.
+			bool ParseNumber(JsonValue& outValue, std::string& outError)
+			{
+				const size_t start = m_pos;
+				if (m_input[m_pos] == '-')
+				{
+					++m_pos;
+				}
+
+				bool hasDigit = false;
+				while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+				{
+					hasDigit = true;
+					++m_pos;
+				}
+
+				if (m_pos < m_input.size() && m_input[m_pos] == '.')
+				{
+					++m_pos;
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (m_pos < m_input.size() && (m_input[m_pos] == 'e' || m_input[m_pos] == 'E'))
+				{
+					++m_pos;
+					if (m_pos < m_input.size() && (m_input[m_pos] == '+' || m_input[m_pos] == '-'))
+					{
+						++m_pos;
+					}
+
+					while (m_pos < m_input.size() && std::isdigit(static_cast<unsigned char>(m_input[m_pos])) != 0)
+					{
+						hasDigit = true;
+						++m_pos;
+					}
+				}
+
+				if (!hasDigit)
+				{
+					outError = "expected number";
+					return false;
+				}
+
+				const std::string token(m_input.substr(start, m_pos - start));
+				char* endPtr = nullptr;
+				const double parsedValue = std::strtod(token.c_str(), &endPtr);
+				if (endPtr == nullptr || *endPtr != '\0')
+				{
+					outError = "invalid number";
+					return false;
+				}
+
+				outValue = JsonValue{};
+				outValue.type = JsonType::Number;
+				outValue.numberValue = parsedValue;
+				return true;
+			}
+
+			std::string_view m_input;
+			size_t m_pos = 0;
+		};
+
+		/// Renvoie un membre d'objet JSON, ou `nullptr` si \p object n'est pas un
+		/// objet ou si la clé \p key est absente.
+		const JsonValue* FindObjectMember(const JsonValue& object, std::string_view key)
+		{
+			if (object.type != JsonType::Object)
+			{
+				return nullptr;
+			}
+
+			const auto it = object.objectValue.find(std::string(key));
+			if (it == object.objectValue.end())
+			{
+				return nullptr;
+			}
+
+			return &it->second;
+		}
+
+		/// Convertit un nombre JSON en entier non signé 32 bits validé (fini,
+		/// positif ou nul, sans partie fractionnaire significative).
+		/// \return false si \p value n'est pas un nombre entier représentable.
+		bool TryGetUint(const JsonValue& value, uint32_t& outValue)
+		{
+			if (value.type != JsonType::Number
+				|| !std::isfinite(value.numberValue)
+				|| value.numberValue < 0.0
+				|| value.numberValue > static_cast<double>(std::numeric_limits<uint32_t>::max()))
+			{
+				return false;
+			}
+
+			const double truncated = std::floor(value.numberValue);
+			if (std::abs(truncated - value.numberValue) > 0.000001)
+			{
+				return false;
+			}
+
+			outValue = static_cast<uint32_t>(truncated);
+			return true;
+		}
+
+		/// Analyse une étape éditable (`{type, target, requiredCount}`) depuis
+		/// \p stepValue et la pousse dans `quest.steps`.
+		/// \return false si `type`/`target` sont absents ou de mauvais type
+		///         (échec bloquant : la quête entière est rejetée).
+		bool ParseEditedStep(const JsonValue& stepValue, EditedQuest& quest, std::string& outError)
+		{
+			if (stepValue.type != JsonType::Object)
+			{
+				outError = "quest '" + quest.id + "': step must be an object";
+				return false;
+			}
+
+			const JsonValue* typeValue = FindObjectMember(stepValue, "type");
+			const JsonValue* targetValue = FindObjectMember(stepValue, "target");
+			if (typeValue == nullptr || typeValue->type != JsonType::String || typeValue->stringValue.empty())
+			{
+				outError = "quest '" + quest.id + "': step.type must be a non-empty string";
+				return false;
+			}
+			if (targetValue == nullptr || targetValue->type != JsonType::String || targetValue->stringValue.empty())
+			{
+				outError = "quest '" + quest.id + "': step.target must be a non-empty string";
+				return false;
+			}
+
+			EditedStep step{};
+			step.type = typeValue->stringValue;
+			step.target = targetValue->stringValue;
+			step.requiredCount = 1;
+
+			if (const JsonValue* requiredCountValue = FindObjectMember(stepValue, "requiredCount");
+				requiredCountValue != nullptr)
+			{
+				if (!TryGetUint(*requiredCountValue, step.requiredCount) || step.requiredCount == 0)
+				{
+					outError = "quest '" + quest.id + "': step.requiredCount must be a positive integer";
+					return false;
+				}
+			}
+
+			quest.steps.push_back(std::move(step));
+			return true;
+		}
+
+		/// Analyse le bloc `rewards` optionnel (`{xp, gold, items:[{itemId,quantity}]}`)
+		/// et remplit les champs de récompense de \p quest.
+		/// \return false si un champ présent est de mauvais type (échec bloquant).
+		bool ParseEditedRewards(const JsonValue& questValue, EditedQuest& quest, std::string& outError)
+		{
+			const JsonValue* rewardsValue = FindObjectMember(questValue, "rewards");
+			if (rewardsValue == nullptr)
+			{
+				return true;
+			}
+
+			if (rewardsValue->type != JsonType::Object)
+			{
+				outError = "quest '" + quest.id + "': rewards must be an object";
+				return false;
+			}
+
+			if (const JsonValue* xpValue = FindObjectMember(*rewardsValue, "xp"); xpValue != nullptr)
+			{
+				if (!TryGetUint(*xpValue, quest.rewardXp))
+				{
+					outError = "quest '" + quest.id + "': rewards.xp must be a non-negative integer";
+					return false;
+				}
+			}
+
+			if (const JsonValue* goldValue = FindObjectMember(*rewardsValue, "gold"); goldValue != nullptr)
+			{
+				if (!TryGetUint(*goldValue, quest.rewardGold))
+				{
+					outError = "quest '" + quest.id + "': rewards.gold must be a non-negative integer";
+					return false;
+				}
+			}
+
+			const JsonValue* itemsValue = FindObjectMember(*rewardsValue, "items");
+			if (itemsValue == nullptr)
+			{
+				return true;
+			}
+
+			if (itemsValue->type != JsonType::Array)
+			{
+				outError = "quest '" + quest.id + "': rewards.items must be an array";
+				return false;
+			}
+
+			for (const JsonValue& itemValue : itemsValue->arrayValue)
+			{
+				if (itemValue.type != JsonType::Object)
+				{
+					outError = "quest '" + quest.id + "': rewards.items entry must be an object";
+					return false;
+				}
+
+				const JsonValue* itemIdValue = FindObjectMember(itemValue, "itemId");
+				const JsonValue* quantityValue = FindObjectMember(itemValue, "quantity");
+				EditedRewardItem item{};
+				if (itemIdValue == nullptr || quantityValue == nullptr
+					|| !TryGetUint(*itemIdValue, item.itemId)
+					|| !TryGetUint(*quantityValue, item.quantity)
+					|| item.itemId == 0
+					|| item.quantity == 0)
+				{
+					outError = "quest '" + quest.id + "': rewards.items entry must define positive itemId and quantity";
+					return false;
+				}
+
+				quest.rewardItems.push_back(item);
+			}
+
+			return true;
+		}
+
+		/// Analyse une quête complète (`{id, giver, turnIn, prereqs, steps, rewards}`)
+		/// depuis \p questValue et la pousse dans \p out si valide.
+		/// \return false si un champ requis (`id`/`giver`/`turnIn`/`steps` non
+		///         vide) est absent ou invalide (échec bloquant pour tout le
+		///         chargement, cf. `QuestEditIo::Load`).
+		bool ParseEditedQuest(const JsonValue& questValue, std::vector<EditedQuest>& out, std::string& outError)
+		{
+			if (questValue.type != JsonType::Object)
+			{
+				outError = "quests[] entry must be an object";
+				return false;
+			}
+
+			const JsonValue* idValue = FindObjectMember(questValue, "id");
+			if (idValue == nullptr || idValue->type != JsonType::String || idValue->stringValue.empty())
+			{
+				outError = "quest entry: id must be a non-empty string";
+				return false;
+			}
+
+			EditedQuest quest{};
+			quest.id = idValue->stringValue;
+
+			const JsonValue* giverValue = FindObjectMember(questValue, "giver");
+			const JsonValue* turnInValue = FindObjectMember(questValue, "turnIn");
+			if (giverValue == nullptr || giverValue->type != JsonType::String || giverValue->stringValue.empty())
+			{
+				outError = "quest '" + quest.id + "': giver must be a non-empty string";
+				return false;
+			}
+			if (turnInValue == nullptr || turnInValue->type != JsonType::String || turnInValue->stringValue.empty())
+			{
+				outError = "quest '" + quest.id + "': turnIn must be a non-empty string";
+				return false;
+			}
+			quest.giver = giverValue->stringValue;
+			quest.turnIn = turnInValue->stringValue;
+
+			if (const JsonValue* prereqsValue = FindObjectMember(questValue, "prereqs");
+				prereqsValue != nullptr)
+			{
+				if (prereqsValue->type != JsonType::Array)
+				{
+					outError = "quest '" + quest.id + "': prereqs must be an array";
+					return false;
+				}
+
+				for (const JsonValue& prereqValue : prereqsValue->arrayValue)
+				{
+					if (prereqValue.type != JsonType::String || prereqValue.stringValue.empty())
+					{
+						outError = "quest '" + quest.id + "': prereqs entry must be a non-empty string";
+						return false;
+					}
+
+					quest.prereqs.push_back(prereqValue.stringValue);
+				}
+			}
+
+			const JsonValue* stepsValue = FindObjectMember(questValue, "steps");
+			if (stepsValue == nullptr || stepsValue->type != JsonType::Array || stepsValue->arrayValue.empty())
+			{
+				outError = "quest '" + quest.id + "': steps must be a non-empty array";
+				return false;
+			}
+
+			for (const JsonValue& stepValue : stepsValue->arrayValue)
+			{
+				if (!ParseEditedStep(stepValue, quest, outError))
+				{
+					return false;
+				}
+			}
+
+			if (!ParseEditedRewards(questValue, quest, outError))
+			{
+				return false;
+			}
+
+			out.push_back(std::move(quest));
+			return true;
+		}
+
+		/// Fusionne les textes lisibles de `quest_texts.fr.json` (titre,
+		/// description, libellés d'étape) dans \p quests, appariés par `id` de
+		/// quête. Silencieux si \p jsonText est vide/invalide ou si une quête
+		/// n'a pas d'entrée de texte (les champs restent vides, ce n'est pas
+		/// une erreur pour `Load`).
+		void MergeQuestTexts(const std::string& jsonText, std::vector<EditedQuest>& quests)
+		{
+			if (jsonText.empty())
+			{
+				return;
+			}
+
+			JsonValue root;
+			std::string parseError;
+			JsonParser parser(jsonText);
+			if (!parser.Parse(root, parseError) || root.type != JsonType::Object)
+			{
+				return;
+			}
+
+			for (EditedQuest& quest : quests)
+			{
+				const JsonValue* entryValue = FindObjectMember(root, quest.id);
+				if (entryValue == nullptr || entryValue->type != JsonType::Object)
+				{
+					continue;
+				}
+
+				if (const JsonValue* titleValue = FindObjectMember(*entryValue, "title");
+					titleValue != nullptr && titleValue->type == JsonType::String)
+				{
+					quest.title = titleValue->stringValue;
+				}
+
+				if (const JsonValue* descriptionValue = FindObjectMember(*entryValue, "description");
+					descriptionValue != nullptr && descriptionValue->type == JsonType::String)
+				{
+					quest.description = descriptionValue->stringValue;
+				}
+
+				if (const JsonValue* stepsValue = FindObjectMember(*entryValue, "steps");
+					stepsValue != nullptr && stepsValue->type == JsonType::Array)
+				{
+					for (const JsonValue& stepValue : stepsValue->arrayValue)
+					{
+						quest.stepLabels.push_back(stepValue.type == JsonType::String ? stepValue.stringValue : std::string());
+					}
+				}
+			}
+		}
+	}
+
+	bool QuestEditIo::Load(const std::string& contentRoot, std::vector<EditedQuest>& out, std::string& outError) const
+	{
+		out.clear();
+		outError.clear();
+
+		const std::filesystem::path definitionsPath = std::filesystem::path(contentRoot) / "quests" / "quest_definitions.json";
+		const std::string jsonText = engine::platform::FileSystem::ReadAllText(definitionsPath);
+		if (jsonText.empty())
+		{
+			outError = "cannot read quest_definitions.json (path=" + definitionsPath.string() + ")";
+			return false;
+		}
+
+		JsonValue root;
+		std::string parseError;
+		JsonParser parser(jsonText);
+		if (!parser.Parse(root, parseError))
+		{
+			outError = "quest_definitions.json parse error: " + parseError;
+			return false;
+		}
+
+		const JsonValue* questsValue = FindObjectMember(root, "quests");
+		if (questsValue == nullptr || questsValue->type != JsonType::Array)
+		{
+			outError = "quest_definitions.json: root.quests must be an array";
+			return false;
+		}
+
+		std::vector<EditedQuest> parsedQuests;
+		for (const JsonValue& questValue : questsValue->arrayValue)
+		{
+			if (!ParseEditedQuest(questValue, parsedQuests, outError))
+			{
+				return false;
+			}
+		}
+
+		const std::filesystem::path textsPath = std::filesystem::path(contentRoot) / "quests" / "quest_texts.fr.json";
+		const std::string textsJson = engine::platform::FileSystem::ReadAllText(textsPath);
+		MergeQuestTexts(textsJson, parsedQuests);
+
+		out = std::move(parsedQuests);
+		return true;
+	}
+}

--- a/src/world_editor/quests/QuestEditIo.cpp
+++ b/src/world_editor/quests/QuestEditIo.cpp
@@ -6,7 +6,10 @@
 #include <cmath>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <limits>
+#include <map>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -717,6 +720,247 @@ namespace engine::editor::world::quests
 			colors[questId] = VisitColor::Black;
 			return false;
 		}
+
+		/// Échappe une chaîne pour insertion dans un littéral JSON (guillemets +
+		/// antislash + retour à la ligne). Patron dupliqué volontairement depuis
+		/// `BuildingTemplateLibrary.cpp` (pas de lib JSON partagée côté éditeur).
+		std::string JsonEscape(const std::string& s)
+		{
+			std::string out;
+			out.reserve(s.size() + 8);
+			for (char c : s)
+			{
+				if (c == '"' || c == '\\')
+				{
+					out.push_back('\\');
+					out.push_back(c);
+				}
+				else if (c == '\n')
+				{
+					out += "\\n";
+				}
+				else
+				{
+					out.push_back(c);
+				}
+			}
+			return out;
+		}
+
+		/// Formate un entier non signé pour un littéral JSON (pas de zéros
+		/// parasites, pas de séparateur de milliers).
+		std::string Num(uint32_t v)
+		{
+			return std::to_string(v);
+		}
+
+		/// Sérialise une étape éditable (`{type, target, requiredCount}`) en JSON
+		/// pur, indentée à \p indent espaces, sans retour à la ligne final.
+		std::string SerializeStep(const EditedStep& step, int indent)
+		{
+			const std::string pad(static_cast<size_t>(indent), ' ');
+			std::ostringstream os;
+			os << pad << "{ \"type\": \"" << JsonEscape(step.type) << "\", \"target\": \"" << JsonEscape(step.target)
+			   << "\", \"requiredCount\": " << Num(step.requiredCount) << " }";
+			return os.str();
+		}
+
+		/// Sérialise le bloc `rewards` (`{xp, gold, items:[{itemId,quantity}]}`)
+		/// d'une quête éditée en JSON pur, indentée à \p indent espaces.
+		std::string SerializeRewards(const EditedQuest& quest, int indent)
+		{
+			const std::string pad(static_cast<size_t>(indent), ' ');
+			const std::string itemPad(static_cast<size_t>(indent) + 2, ' ');
+			std::ostringstream os;
+			os << pad << "{\n";
+			os << itemPad << "\"xp\": " << Num(quest.rewardXp) << ",\n";
+			os << itemPad << "\"gold\": " << Num(quest.rewardGold) << ",\n";
+			os << itemPad << "\"items\": [";
+			for (size_t i = 0; i < quest.rewardItems.size(); ++i)
+			{
+				const EditedRewardItem& item = quest.rewardItems[i];
+				os << (i == 0 ? "\n" : ",\n") << itemPad << "  { \"itemId\": " << Num(item.itemId)
+				   << ", \"quantity\": " << Num(item.quantity) << " }";
+			}
+			if (!quest.rewardItems.empty())
+			{
+				os << "\n" << itemPad;
+			}
+			os << "]\n";
+			os << pad << "}";
+			return os.str();
+		}
+
+		/// Sérialise une quête éditée complète (`{id, giver, turnIn, prereqs,
+		/// steps, rewards}`) en JSON pur, tableau, indentée à \p indent espaces
+		/// (élément de `quests[]` dans `quest_definitions.json`).
+		std::string SerializeQuestDefinition(const EditedQuest& quest, int indent)
+		{
+			const std::string pad(static_cast<size_t>(indent), ' ');
+			const std::string fieldPad(static_cast<size_t>(indent) + 2, ' ');
+			std::ostringstream os;
+			os << pad << "{\n";
+			os << fieldPad << "\"id\": \"" << JsonEscape(quest.id) << "\",\n";
+			os << fieldPad << "\"giver\": \"" << JsonEscape(quest.giver) << "\",\n";
+			os << fieldPad << "\"turnIn\": \"" << JsonEscape(quest.turnIn) << "\",\n";
+
+			os << fieldPad << "\"prereqs\": [";
+			for (size_t i = 0; i < quest.prereqs.size(); ++i)
+			{
+				os << (i == 0 ? "" : ", ") << "\"" << JsonEscape(quest.prereqs[i]) << "\"";
+			}
+			os << "],\n";
+
+			os << fieldPad << "\"steps\": [";
+			for (size_t i = 0; i < quest.steps.size(); ++i)
+			{
+				os << (i == 0 ? "\n" : ",\n") << SerializeStep(quest.steps[i], indent + 4);
+			}
+			if (!quest.steps.empty())
+			{
+				os << "\n" << fieldPad;
+			}
+			os << "],\n";
+
+			os << fieldPad << "\"rewards\": " << SerializeRewards(quest, indent + 2) << "\n";
+			os << pad << "}";
+			return os.str();
+		}
+
+		/// Sérialise `quest_definitions.json` en entier (`{ "quests": [...] }`,
+		/// JSON pur, tableaux — PAS le format `count`-indexé de `Config`).
+		std::string SerializeQuestDefinitions(const std::vector<EditedQuest>& quests)
+		{
+			std::ostringstream os;
+			os << "{\n  \"quests\": [";
+			for (size_t i = 0; i < quests.size(); ++i)
+			{
+				os << (i == 0 ? "\n" : ",\n") << SerializeQuestDefinition(quests[i], 4);
+			}
+			if (!quests.empty())
+			{
+				os << "\n  ";
+			}
+			os << "]\n}\n";
+			return os.str();
+		}
+
+		/// Sérialise `quest_texts.fr.json` (`{ "<id>": {title, description,
+		/// steps:[...]} }`) à partir des textes portés par chaque `EditedQuest`.
+		/// N'écrit une entrée que pour les quêtes ayant au moins un champ texte
+		/// non vide (title/description/stepLabels), pour ne pas polluer le
+		/// fichier de traductions avec des entrées entièrement vides.
+		std::string SerializeQuestTexts(const std::vector<EditedQuest>& quests)
+		{
+			std::ostringstream os;
+			os << "{";
+			bool first = true;
+			for (const EditedQuest& quest : quests)
+			{
+				if (quest.title.empty() && quest.description.empty() && quest.stepLabels.empty())
+				{
+					continue;
+				}
+
+				os << (first ? "\n" : ",\n") << "  \"" << JsonEscape(quest.id) << "\": {\n";
+				os << "    \"title\": \"" << JsonEscape(quest.title) << "\",\n";
+				os << "    \"description\": \"" << JsonEscape(quest.description) << "\",\n";
+				os << "    \"steps\": [";
+				for (size_t i = 0; i < quest.stepLabels.size(); ++i)
+				{
+					os << (i == 0 ? "\n" : ",\n") << "      \"" << JsonEscape(quest.stepLabels[i]) << "\"";
+				}
+				if (!quest.stepLabels.empty())
+				{
+					os << "\n    ";
+				}
+				os << "]\n  }";
+				first = false;
+			}
+			if (!first)
+			{
+				os << "\n";
+			}
+			os << "}\n";
+			return os.str();
+		}
+
+		/// Une entrée de `quest_givers.json` régénérée : quête + rôle du PNJ
+		/// pour cette quête (0 = donneur `giver`, 1 = receveur `turnIn`).
+		struct GiverEntry
+		{
+			std::string questId;
+			int role = 0;
+		};
+
+		/// Sérialise `quest_givers.json` régénéré à partir de `giver`/`turnIn`
+		/// de chaque quête de \p quests : pour chaque quête, ajoute `{questId,
+		/// role:0}` sous la clé PNJ `giver`, et `{questId, role:1}` sous la clé
+		/// PNJ `turnIn`, puis groupe par PNJ (`std::map` pour un ordre de clés
+		/// stable et déterministe entre deux appels, utile pour les diffs git).
+		/// Un même PNJ peut recevoir plusieurs entrées (plusieurs quêtes, ou
+		/// donneur+receveur d'une même quête) : toutes conservées, dans l'ordre
+		/// de parcours de \p quests.
+		std::string SerializeQuestGivers(const std::vector<EditedQuest>& quests)
+		{
+			std::map<std::string, std::vector<GiverEntry>> byNpc;
+			for (const EditedQuest& quest : quests)
+			{
+				if (!quest.giver.empty())
+				{
+					byNpc[quest.giver].push_back(GiverEntry{ quest.id, 0 });
+				}
+				if (!quest.turnIn.empty())
+				{
+					byNpc[quest.turnIn].push_back(GiverEntry{ quest.id, 1 });
+				}
+			}
+
+			std::ostringstream os;
+			os << "{";
+			bool first = true;
+			for (const auto& npcAndEntries : byNpc)
+			{
+				os << (first ? "\n" : ",\n") << "  \"" << JsonEscape(npcAndEntries.first) << "\": [";
+				const std::vector<GiverEntry>& entries = npcAndEntries.second;
+				for (size_t i = 0; i < entries.size(); ++i)
+				{
+					os << (i == 0 ? "\n" : ",\n") << "    { \"questId\": \"" << JsonEscape(entries[i].questId)
+					   << "\", \"role\": " << entries[i].role << " }";
+				}
+				os << "\n  ]";
+				first = false;
+			}
+			if (!first)
+			{
+				os << "\n";
+			}
+			os << "}\n";
+			return os.str();
+		}
+
+		/// Écrit \p content dans \p path (binaire, tronque un fichier existant).
+		/// \return false et remplit \p outError si le fichier n'a pas pu être ouvert en écriture.
+		///
+		/// Effet de bord : écriture disque (création/écrasement de \p path).
+		bool WriteTextFile(const std::filesystem::path& path, const std::string& content, std::string& outError)
+		{
+			std::ofstream file(path, std::ios::binary | std::ios::trunc);
+			if (!file)
+			{
+				outError = "cannot write file (path=" + path.string() + ")";
+				return false;
+			}
+
+			file << content;
+			if (!file)
+			{
+				outError = "write failed (path=" + path.string() + ")";
+				return false;
+			}
+
+			return true;
+		}
 	}
 
 	bool QuestEditIo::Load(const std::string& contentRoot, std::vector<EditedQuest>& out, std::string& outError) const
@@ -859,5 +1103,36 @@ namespace engine::editor::world::quests
 		}
 
 		return outErrors.empty();
+	}
+
+	bool QuestEditIo::Save(const std::string& contentRoot, const std::vector<EditedQuest>& quests, std::string& outError) const
+	{
+		outError.clear();
+
+		const std::filesystem::path questsDir = std::filesystem::path(contentRoot) / "quests";
+		std::error_code ec;
+		std::filesystem::create_directories(questsDir, ec);
+		if (ec)
+		{
+			outError = "cannot create directory (path=" + questsDir.string() + "): " + ec.message();
+			return false;
+		}
+
+		if (!WriteTextFile(questsDir / "quest_definitions.json", SerializeQuestDefinitions(quests), outError))
+		{
+			return false;
+		}
+
+		if (!WriteTextFile(questsDir / "quest_texts.fr.json", SerializeQuestTexts(quests), outError))
+		{
+			return false;
+		}
+
+		if (!WriteTextFile(questsDir / "quest_givers.json", SerializeQuestGivers(quests), outError))
+		{
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/src/world_editor/quests/QuestEditIo.cpp
+++ b/src/world_editor/quests/QuestEditIo.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace engine::editor::world::quests
@@ -664,6 +665,58 @@ namespace engine::editor::world::quests
 				}
 			}
 		}
+
+		/// Couleur d'un sommet du graphe `prereqs` pendant la détection de cycle
+		/// par DFS (coloriage blanc/gris/noir classique).
+		enum class VisitColor
+		{
+			White, ///< pas encore visité.
+			Grey,  ///< en cours de visite (sur la pile d'appel courante).
+			Black  ///< visite terminée, aucun cycle trouvé sous ce sommet.
+		};
+
+		/// Visite en profondeur le sommet `questId` dans le graphe `prereqs`
+		/// (index construit dans `Validate`) pour détecter un cycle.
+		/// \param questId id de quête à visiter (doit exister dans \p byId).
+		/// \param byId index `id -> EditedQuest*` de l'ensemble complet.
+		/// \param colors coloriage courant de chaque sommet visité (modifié en place).
+		/// \return true si un cycle est atteignable depuis `questId` (un sommet
+		///         gris est réatteint pendant la descente).
+		///
+		/// Effet de bord : met à jour \p colors (Grey à l'entrée, Black à la
+		/// sortie normale). Les prereqs inconnus (dangling, déjà signalés par
+		/// ailleurs) sont ignorés ici pour ne pas fausser la détection de cycle.
+		bool HasCycle(const std::string& questId, const std::unordered_map<std::string, const EditedQuest*>& byId,
+			std::unordered_map<std::string, VisitColor>& colors)
+		{
+			colors[questId] = VisitColor::Grey;
+
+			const auto it = byId.find(questId);
+			if (it != byId.end())
+			{
+				for (const std::string& prereqId : it->second->prereqs)
+				{
+					const auto colorIt = colors.find(prereqId);
+					const VisitColor prereqColor = (colorIt != colors.end()) ? colorIt->second : VisitColor::White;
+
+					if (prereqColor == VisitColor::Grey)
+					{
+						return true;
+					}
+
+					if (prereqColor == VisitColor::White && byId.find(prereqId) != byId.end())
+					{
+						if (HasCycle(prereqId, byId, colors))
+						{
+							return true;
+						}
+					}
+				}
+			}
+
+			colors[questId] = VisitColor::Black;
+			return false;
+		}
 	}
 
 	bool QuestEditIo::Load(const std::string& contentRoot, std::vector<EditedQuest>& out, std::string& outError) const
@@ -710,5 +763,101 @@ namespace engine::editor::world::quests
 
 		out = std::move(parsedQuests);
 		return true;
+	}
+
+	bool QuestEditIo::Validate(const std::vector<EditedQuest>& quests, std::vector<std::string>& outErrors) const
+	{
+		outErrors.clear();
+
+		// Index id -> quête, et détection des doublons d'id au passage.
+		std::unordered_map<std::string, const EditedQuest*> byId;
+		byId.reserve(quests.size());
+		for (const EditedQuest& quest : quests)
+		{
+			if (quest.id.empty())
+			{
+				outErrors.push_back("quête sans id (id vide)");
+				continue;
+			}
+
+			if (byId.find(quest.id) != byId.end())
+			{
+				outErrors.push_back("id de quête dupliqué : '" + quest.id + "'");
+				continue;
+			}
+
+			byId.emplace(quest.id, &quest);
+		}
+
+		static const std::unordered_set<std::string> kValidStepTypes = { "kill", "collect", "talk", "enter" };
+
+		for (const EditedQuest& quest : quests)
+		{
+			const std::string label = quest.id.empty() ? std::string("<sans id>") : quest.id;
+
+			if (quest.giver.empty())
+			{
+				outErrors.push_back("quête '" + label + "': giver ne doit pas être vide");
+			}
+			if (quest.turnIn.empty())
+			{
+				outErrors.push_back("quête '" + label + "': turnIn ne doit pas être vide");
+			}
+
+			if (quest.steps.empty())
+			{
+				outErrors.push_back("quête '" + label + "': doit avoir au moins une étape");
+			}
+			for (size_t stepIndex = 0; stepIndex < quest.steps.size(); ++stepIndex)
+			{
+				const EditedStep& step = quest.steps[stepIndex];
+				if (kValidStepTypes.find(step.type) == kValidStepTypes.end())
+				{
+					outErrors.push_back("quête '" + label + "': étape " + std::to_string(stepIndex)
+						+ ": type '" + step.type + "' invalide (attendu kill/collect/talk/enter)");
+				}
+				if (step.target.empty())
+				{
+					outErrors.push_back("quête '" + label + "': étape " + std::to_string(stepIndex) + ": target ne doit pas être vide");
+				}
+				if (step.requiredCount < 1)
+				{
+					outErrors.push_back("quête '" + label + "': étape " + std::to_string(stepIndex) + ": requiredCount doit être ≥ 1");
+				}
+			}
+
+			for (const std::string& prereqId : quest.prereqs)
+			{
+				if (byId.find(prereqId) == byId.end())
+				{
+					outErrors.push_back("quête '" + label + "': prereq '" + prereqId + "' introuvable dans l'ensemble");
+				}
+			}
+
+			for (size_t itemIndex = 0; itemIndex < quest.rewardItems.size(); ++itemIndex)
+			{
+				const EditedRewardItem& item = quest.rewardItems[itemIndex];
+				if (item.itemId == 0 || item.quantity < 1)
+				{
+					outErrors.push_back("quête '" + label + "': reward item " + std::to_string(itemIndex)
+						+ ": itemId doit être > 0 et quantity ≥ 1");
+				}
+			}
+		}
+
+		// Détection de cycle sur le graphe prereqs, uniquement entre id connus
+		// (les dangling prereqs sont déjà signalés ci-dessus et ignorés ici).
+		std::unordered_map<std::string, VisitColor> colors;
+		colors.reserve(byId.size());
+		for (const auto& idAndQuest : byId)
+		{
+			const std::string& questId = idAndQuest.first;
+			if (colors.find(questId) == colors.end() && HasCycle(questId, byId, colors))
+			{
+				outErrors.push_back("cycle détecté dans le graphe prereqs impliquant la quête '" + questId + "'");
+			}
+		}
+
+		return outErrors.empty();
 	}
 }

--- a/src/world_editor/quests/QuestEditIo.h
+++ b/src/world_editor/quests/QuestEditIo.h
@@ -74,5 +74,22 @@ namespace engine::editor::world::quests
 		/// depuis n'importe quel thread tant que `contentRoot` n'est pas modifié
 		/// concurremment sur disque.
 		bool Load(const std::string& contentRoot, std::vector<EditedQuest>& out, std::string& outError) const;
+
+		/// Valide l'ensemble de quêtes éditées : unicité des `id`, non-vacuité
+		/// de `giver`/`turnIn`, formes des étapes (`type` connu, `target` non
+		/// vide, `requiredCount` ≥ 1), existence des `prereqs` référencés dans
+		/// l'ensemble, absence de cycle dans le graphe `prereqs`, et formes des
+		/// items de récompense (`itemId` > 0, `quantity` ≥ 1).
+		///
+		/// Pure : aucune E/S, aucun état modifié (ni sur `this`, ni global) ;
+		/// utilisable depuis n'importe quel thread sur une copie de \p quests.
+		///
+		/// \param quests ensemble de quêtes à valider (tel que produit par `Load`
+		///        ou construit par l'UI d'édition).
+		/// \param outErrors rempli avec un message d'erreur lisible (français)
+		///        par violation détectée ; vidé en début d'appel. Peut contenir
+		///        plusieurs messages pour une même quête. Vide si tout est valide.
+		/// \return `outErrors.empty()` — true si aucune violation n'a été trouvée.
+		bool Validate(const std::vector<EditedQuest>& quests, std::vector<std::string>& outErrors) const;
 	};
 }

--- a/src/world_editor/quests/QuestEditIo.h
+++ b/src/world_editor/quests/QuestEditIo.h
@@ -91,5 +91,36 @@ namespace engine::editor::world::quests
 		///        plusieurs messages pour une même quête. Vide si tout est valide.
 		/// \return `outErrors.empty()` — true si aucune violation n'a été trouvée.
 		bool Validate(const std::vector<EditedQuest>& quests, std::vector<std::string>& outErrors) const;
+
+		/// Écrit l'ensemble \p quests sous `<contentRoot>/quests/` en 3 fichiers
+		/// JSON purs (sérialisation manuelle, sans passer par `Config`) :
+		/// - `quest_definitions.json` : données mécaniques (id/giver/turnIn/
+		///   prereqs/steps/rewards), format tableaux (`{ "quests": [...] }`),
+		///   compatible avec `QuestEditIo::Load` et avec le parseur JSON pur du
+		///   shard (PAS le format `count`-indexé de `Config`, qui casserait
+		///   `QuestRuntime`).
+		/// - `quest_texts.fr.json` : textes lisibles (`{ "<id>": {title,
+		///   description, steps:[...]} }`), appariés par `id`.
+		/// - `quest_givers.json` : RÉGÉNÉRÉ intégralement à partir de `giver`/
+		///   `turnIn` de chaque quête (ne lit pas l'éventuel fichier existant) ;
+		///   groupé par PNJ cible, chaque entrée `{questId, role}` avec
+		///   `role=0` pour un donneur (`giver`) et `role=1` pour un rendu
+		///   (`turnIn`). Un même PNJ peut apparaître comme donneur ET receveur
+		///   (pour la même quête ou des quêtes différentes) : toutes les
+		///   entrées sont conservées.
+		///
+		/// \param contentRoot dossier de contenu (filesystem) sous lequel écrire
+		///        `quests/` (créé si absent).
+		/// \param quests ensemble de quêtes à écrire, tel quel (aucune validation
+		///        implicite : appeler `Validate` avant `Save` si nécessaire).
+		/// \param outError message d'erreur lisible en cas d'échec d'écriture
+		///        (dossier non créable, fichier non ouvrable). Vide en cas de
+		///        succès.
+		/// \return false si l'un des 3 fichiers n'a pas pu être écrit ; true sinon.
+		///
+		/// Effet de bord : écriture disque (3 fichiers sous `<contentRoot>/quests/`,
+		/// écrasés s'ils existent déjà). À appeler depuis le thread principal de
+		/// l'éditeur (pas de synchronisation interne, comme `Load`/`Validate`).
+		bool Save(const std::string& contentRoot, const std::vector<EditedQuest>& quests, std::string& outError) const;
 	};
 }

--- a/src/world_editor/quests/QuestEditIo.h
+++ b/src/world_editor/quests/QuestEditIo.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::editor::world::quests
+{
+	/// Une étape éditable d'une quête (miroir authoring de `QuestStepDefinition`
+	/// côté serveur, mais en texte brut : pas d'enum `QuestStepType` ici, la
+	/// validation du token `type` est différée à la Tâche 2 (Validate)).
+	struct EditedStep
+	{
+		std::string type;             ///< ex. "kill", "collect", "talk", "enter".
+		std::string target;           ///< identifiant cible (ex. "mob:100", "npc:elder_marn").
+		uint32_t requiredCount = 1;   ///< quantité requise pour compléter l'étape.
+	};
+
+	/// Un item de récompense éditable (itemId + quantité).
+	struct EditedRewardItem
+	{
+		uint32_t itemId = 0;
+		uint32_t quantity = 1;
+	};
+
+	/// Une quête telle qu'éditée dans l'outil d'authoring : fusion des données
+	/// mécaniques (`quest_definitions.json`) et des textes lisibles
+	/// (`quest_texts.<lang>.json`), pour affichage/édition unifiés dans l'éditeur.
+	struct EditedQuest
+	{
+		std::string id;
+		std::string giver;
+		std::string turnIn;
+		std::vector<std::string> prereqs;
+		std::vector<EditedStep> steps;
+		uint32_t rewardXp = 0;
+		uint32_t rewardGold = 0;
+		std::vector<EditedRewardItem> rewardItems;
+
+		// Textes lisibles, fusionnés depuis quest_texts.<lang>.json. Vides si la
+		// quête n'a pas (encore) d'entrée de texte pour la langue chargée.
+		std::string title;
+		std::string description;
+		std::vector<std::string> stepLabels; ///< un libellé brut par étape (même ordre que `steps`).
+	};
+
+	/// Entrées/sorties JSON de l'éditeur de quêtes (authoring, SP4).
+	///
+	/// Pur côté lecture pour cette tâche (Load uniquement) : Validate (Tâche 2)
+	/// et Save (Tâche 3) viendront s'y ajouter. Ne modifie aucun état global ;
+	/// toute l'E/S passe par des lectures disque explicites au moment de l'appel.
+	class QuestEditIo
+	{
+	public:
+		/// Charge les quêtes éditables depuis `<contentRoot>/quests/quest_definitions.json`
+		/// (données mécaniques, JSON pur) puis fusionne les textes lisibles
+		/// trouvés dans `<contentRoot>/quests/quest_texts.fr.json` (titre,
+		/// description, libellés d'étape), appariés par `id` de quête.
+		///
+		/// \param contentRoot chemin de dossier de contenu (filesystem, pas relatif
+		///        à une Config) ; ex. "game/data" en jeu, ou un dossier temporaire
+		///        en test.
+		/// \param out rempli avec une `EditedQuest` par quête trouvée dans
+		///        quest_definitions.json (dans l'ordre du fichier). Vidé en cas
+		///        d'échec.
+		/// \param outError message d'erreur lisible en cas d'échec (fichier
+		///        manquant, JSON invalide, champ requis absent). Vide en cas de
+		///        succès.
+		/// \return false si quest_definitions.json est absent/invalide ou mal
+		///         formé ; true sinon (quest_texts.fr.json manquant n'est PAS
+		///         une erreur : les champs texte restent vides).
+		///
+		/// Effet de bord : lecture disque (aucune écriture). Peut être appelée
+		/// depuis n'importe quel thread tant que `contentRoot` n'est pas modifié
+		/// concurremment sur disque.
+		bool Load(const std::string& contentRoot, std::vector<EditedQuest>& out, std::string& outError) const;
+	};
+}

--- a/src/world_editor/quests/QuestEditIoTests.cpp
+++ b/src/world_editor/quests/QuestEditIoTests.cpp
@@ -1,5 +1,5 @@
-// Tests de QuestEditIo::Load et QuestEditIo::Validate — chargement et
-// validation authoring des quêtes (SP4, Tâches 1 et 2).
+// Tests de QuestEditIo::Load, QuestEditIo::Validate et QuestEditIo::Save —
+// chargement, validation et écriture authoring des quêtes (SP4, Tâches 1, 2, 3).
 //
 // Écrit une fixture (quest_definitions.json + quest_texts.fr.json) dans un
 // répertoire temporaire unique (isolé du vrai contenu du dépôt), à l'instar
@@ -9,6 +9,11 @@
 //
 // QuestEditIo::Validate est pure (pas d'I/O) : les cas ci-dessous construisent
 // des std::vector<EditedQuest> directement en mémoire, sans fixture disque.
+//
+// QuestEditIo::Save écrit sur disque (3 fichiers) : les cas ci-dessous
+// vérifient le round-trip Save -> Load (égalité structurelle) et le contenu
+// brut des fichiers écrits (quest_givers.json régénéré, quest_definitions.json
+// en JSON pur tableaux et non au format `count`-indexé de Config).
 
 #include "src/world_editor/quests/QuestEditIo.h"
 
@@ -16,9 +21,11 @@
 #include <fstream>
 #include <iostream>
 #include <random>
+#include <sstream>
 #include <string>
 
 using engine::editor::world::quests::EditedQuest;
+using engine::editor::world::quests::EditedRewardItem;
 using engine::editor::world::quests::EditedStep;
 using engine::editor::world::quests::QuestEditIo;
 
@@ -84,6 +91,63 @@ namespace
 			std::abort();
 		}
 		file << text;
+	}
+
+	/// Relit intégralement `<contentRoot>/quests/<fileName>` en mémoire (pour
+	/// inspection brute du contenu écrit par `QuestEditIo::Save` dans les tests).
+	/// Abort si le fichier n'a pas pu être ouvert (fixture/écriture invalide sinon).
+	std::string ReadQuestsFile(const std::filesystem::path& contentRoot, const std::string& fileName)
+	{
+		const std::filesystem::path filePath = contentRoot / "quests" / fileName;
+		std::ifstream file(filePath, std::ios::binary);
+		if (!file)
+		{
+			std::cerr << "[FATAL] cannot read written file " << filePath.string() << "\n";
+			std::abort();
+		}
+		std::ostringstream ss;
+		ss << file.rdbuf();
+		return ss.str();
+	}
+
+	/// Construit l'ensemble de quêtes en mémoire utilisé par le test round-trip
+	/// Save -> Load : `kill_10_boars` avec `giver` == `turnIn` == "npc:elder_marn"
+	/// (pour exercer la régénération quest_givers.json avec les 2 rôles sur le
+	/// même PNJ), plus une seconde quête avec prereq et textes complets.
+	std::vector<EditedQuest> MakeRoundTripQuests()
+	{
+		EditedQuest boars;
+		boars.id = "kill_10_boars";
+		boars.giver = "npc:elder_marn";
+		boars.turnIn = "npc:elder_marn";
+		EditedStep boarStep;
+		boarStep.type = "kill";
+		boarStep.target = "mob:100";
+		boarStep.requiredCount = 10;
+		boars.steps.push_back(boarStep);
+		boars.rewardXp = 50;
+		boars.rewardGold = 20;
+		boars.rewardItems.push_back(EditedRewardItem{ 7, 2 });
+		boars.title = "Chasse aux sangliers";
+		boars.description = "Tuez 10 sangliers pour l'aîné Marn.";
+		boars.stepLabels.push_back("Sangliers tués : {current}/{required}");
+
+		EditedQuest scout;
+		scout.id = "talk_to_scout";
+		scout.giver = "npc:scout";
+		scout.turnIn = "npc:scout";
+		scout.prereqs.push_back("kill_10_boars");
+		EditedStep talkStep;
+		talkStep.type = "talk";
+		talkStep.target = "npc:scout";
+		talkStep.requiredCount = 1;
+		scout.steps.push_back(talkStep);
+		scout.rewardXp = 5;
+		scout.title = "Éclaireur";
+		scout.description = "Parlez à l'éclaireur.";
+		scout.stepLabels.push_back("Parlé à l'éclaireur");
+
+		return { boars, scout };
 	}
 }
 
@@ -230,6 +294,86 @@ int main()
 		const bool ok = io.Validate(quests, errors);
 		Check(!ok, "Validate: étape target vide -> false");
 		Check(!errors.empty(), "Validate: étape target vide -> au moins 1 erreur");
+	}
+
+	// --- QuestEditIo::Save ---------------------------------------------------
+
+	// (h) round-trip Save -> Load : égalité structurelle id/giver/turnIn/steps/
+	// rewards/title/stepLabels.
+	{
+		const std::filesystem::path saveRoot = MakeTempContentDir();
+		const std::vector<EditedQuest> original = MakeRoundTripQuests();
+
+		std::string saveError;
+		const bool saved = io.Save(saveRoot.string(), original, saveError);
+		Check(saved, "Save réussit sur un ensemble valide");
+		Check(saveError.empty(), "Save ne renseigne pas outError en cas de succès");
+
+		std::vector<EditedQuest> reloaded;
+		std::string loadError;
+		const bool reloadedOk = io.Load(saveRoot.string(), reloaded, loadError);
+		Check(reloadedOk, "Load réussit après Save (round-trip)");
+		Check(reloaded.size() == original.size(), "round-trip: même nombre de quêtes");
+
+		for (const EditedQuest& orig : original)
+		{
+			const EditedQuest* found = nullptr;
+			for (const EditedQuest& candidate : reloaded)
+			{
+				if (candidate.id == orig.id)
+				{
+					found = &candidate;
+				}
+			}
+
+			const std::string label = "round-trip '" + orig.id + "'";
+			Check(found != nullptr, (label + ": retrouvée après reload").c_str());
+			if (found == nullptr)
+			{
+				continue;
+			}
+
+			Check(found->giver == orig.giver, (label + ": giver identique").c_str());
+			Check(found->turnIn == orig.turnIn, (label + ": turnIn identique").c_str());
+			Check(found->prereqs == orig.prereqs, (label + ": prereqs identiques").c_str());
+			Check(found->steps.size() == orig.steps.size(), (label + ": nombre d'étapes identique").c_str());
+			for (size_t i = 0; i < orig.steps.size() && i < found->steps.size(); ++i)
+			{
+				Check(found->steps[i].type == orig.steps[i].type, (label + ": step.type identique").c_str());
+				Check(found->steps[i].target == orig.steps[i].target, (label + ": step.target identique").c_str());
+				Check(found->steps[i].requiredCount == orig.steps[i].requiredCount, (label + ": step.requiredCount identique").c_str());
+			}
+			Check(found->rewardXp == orig.rewardXp, (label + ": rewardXp identique").c_str());
+			Check(found->rewardGold == orig.rewardGold, (label + ": rewardGold identique").c_str());
+			Check(found->rewardItems.size() == orig.rewardItems.size(), (label + ": nombre d'items de récompense identique").c_str());
+			for (size_t i = 0; i < orig.rewardItems.size() && i < found->rewardItems.size(); ++i)
+			{
+				Check(found->rewardItems[i].itemId == orig.rewardItems[i].itemId, (label + ": rewardItem.itemId identique").c_str());
+				Check(found->rewardItems[i].quantity == orig.rewardItems[i].quantity, (label + ": rewardItem.quantity identique").c_str());
+			}
+			Check(found->title == orig.title, (label + ": title identique").c_str());
+			Check(found->stepLabels == orig.stepLabels, (label + ": stepLabels identiques").c_str());
+		}
+
+		// (i) quest_givers.json régénéré : npc:elder_marn doit avoir à la fois
+		// {kill_10_boars, role 0} (giver) et {kill_10_boars, role 1} (turnIn),
+		// puisque giver == turnIn == "npc:elder_marn" pour cette quête.
+		const std::string giversJson = ReadQuestsFile(saveRoot, "quest_givers.json");
+		Check(giversJson.find("\"npc:elder_marn\"") != std::string::npos, "quest_givers.json: clé npc:elder_marn présente");
+		Check(giversJson.find("\"questId\": \"kill_10_boars\", \"role\": 0") != std::string::npos,
+			"quest_givers.json: entrée role 0 (giver) pour kill_10_boars");
+		Check(giversJson.find("\"questId\": \"kill_10_boars\", \"role\": 1") != std::string::npos,
+			"quest_givers.json: entrée role 1 (turnIn) pour kill_10_boars");
+
+		// (j) quest_definitions.json écrit est du JSON pur (tableaux), pas le
+		// format `count`-indexé de Config.
+		const std::string definitionsJsonWritten = ReadQuestsFile(saveRoot, "quest_definitions.json");
+		Check(definitionsJsonWritten.find("\"quests\"") != std::string::npos, "quest_definitions.json: clé 'quests' présente");
+		Check(definitionsJsonWritten.find('[') != std::string::npos, "quest_definitions.json: contient un tableau JSON '['");
+		Check(definitionsJsonWritten.find("\"count\"") == std::string::npos, "quest_definitions.json: PAS de format count-indexé");
+
+		std::error_code saveCleanupError;
+		std::filesystem::remove_all(saveRoot, saveCleanupError);
 	}
 
 	if (g_failures != 0)

--- a/src/world_editor/quests/QuestEditIoTests.cpp
+++ b/src/world_editor/quests/QuestEditIoTests.cpp
@@ -1,0 +1,137 @@
+// Tests de QuestEditIo::Load — chargement authoring des quêtes (SP4, Tâche 1).
+//
+// Écrit une fixture (quest_definitions.json + quest_texts.fr.json) dans un
+// répertoire temporaire unique (isolé du vrai contenu du dépôt), à l'instar
+// de QuestRuntimeTests.cpp. QuestEditIo::Load prend un contentRoot brut
+// (chemin filesystem, pas de Config) : pas besoin de FileSystem::WriteAllTextContent,
+// un std::ofstream direct suffit.
+
+#include "src/world_editor/quests/QuestEditIo.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <random>
+#include <string>
+
+using engine::editor::world::quests::EditedQuest;
+using engine::editor::world::quests::QuestEditIo;
+
+namespace
+{
+	int g_failures = 0;
+
+	void Check(bool condition, const char* label)
+	{
+		if (!condition)
+		{
+			std::cerr << "[FAIL] " << label << "\n";
+			++g_failures;
+		}
+	}
+
+	/// Construit un répertoire temporaire unique sous temp_directory_path.
+	/// Abort si la création échoue (test invalide sinon).
+	std::filesystem::path MakeTempContentDir()
+	{
+		std::random_device rd;
+		std::mt19937_64 rng(rd());
+		const std::filesystem::path base = std::filesystem::temp_directory_path()
+			/ ("lcdlln_quest_edit_io_test_" + std::to_string(rng()));
+		std::error_code ec;
+		std::filesystem::create_directories(base / "quests", ec);
+		if (ec)
+		{
+			std::cerr << "[FATAL] cannot create temp dir " << base.string() << ": " << ec.message() << "\n";
+			std::abort();
+		}
+		return base;
+	}
+
+	/// Écrit \p text dans `<contentRoot>/quests/<fileName>`. Abort si l'écriture
+	/// échoue (fixture invalide sinon).
+	void WriteQuestsFile(const std::filesystem::path& contentRoot, const std::string& fileName, const std::string& text)
+	{
+		const std::filesystem::path filePath = contentRoot / "quests" / fileName;
+		std::ofstream file(filePath, std::ios::binary | std::ios::trunc);
+		if (!file)
+		{
+			std::cerr << "[FATAL] cannot write fixture file " << filePath.string() << "\n";
+			std::abort();
+		}
+		file << text;
+	}
+}
+
+int main()
+{
+	const std::filesystem::path contentRoot = MakeTempContentDir();
+
+	const std::string definitionsJson = R"JSON({
+      "quests": [
+        { "id": "kill_10_boars", "giver": "npc:elder_marn", "turnIn": "npc:elder_marn",
+          "prereqs": [], "steps": [ { "type": "kill", "target": "mob:100", "requiredCount": 10 } ],
+          "rewards": { "xp": 50, "gold": 20, "items": [] } },
+        { "id": "talk_to_scout", "giver": "npc:scout", "turnIn": "npc:scout",
+          "prereqs": [], "steps": [ { "type": "talk", "target": "npc:scout", "requiredCount": 1 } ],
+          "rewards": { "xp": 5, "gold": 0, "items": [] } }
+      ]
+    })JSON";
+	WriteQuestsFile(contentRoot, "quest_definitions.json", definitionsJson);
+
+	const std::string textsJson = R"JSON({
+      "kill_10_boars": {
+        "title": "Chasse aux sangliers",
+        "description": "Tuez 10 sangliers pour l'aîné Marn.",
+        "steps": [ "Sangliers tués : {current}/{required}" ]
+      }
+    })JSON";
+	WriteQuestsFile(contentRoot, "quest_texts.fr.json", textsJson);
+
+	QuestEditIo io;
+	std::vector<EditedQuest> out;
+	std::string error;
+	const bool loaded = io.Load(contentRoot.string(), out, error);
+
+	Check(loaded, "Load réussit sur une fixture valide");
+	Check(error.empty(), "Load ne renseigne pas outError en cas de succès");
+	Check(out.size() == 2, "2 quêtes chargées");
+
+	const EditedQuest* boars = nullptr;
+	for (const EditedQuest& quest : out)
+	{
+		if (quest.id == "kill_10_boars")
+		{
+			boars = &quest;
+		}
+	}
+
+	Check(boars != nullptr, "kill_10_boars trouvée");
+	if (boars != nullptr)
+	{
+		Check(boars->giver == "npc:elder_marn", "giver parsé");
+		Check(boars->turnIn == "npc:elder_marn", "turnIn parsé");
+		Check(boars->steps.size() == 1, "1 étape");
+		if (!boars->steps.empty())
+		{
+			Check(boars->steps[0].type == "kill", "step.type parsé");
+			Check(boars->steps[0].target == "mob:100", "step.target parsé");
+			Check(boars->steps[0].requiredCount == 10, "step.requiredCount parsé");
+		}
+		Check(boars->rewardXp == 50, "rewardXp parsé");
+		Check(boars->rewardGold == 20, "rewardGold parsé");
+		Check(!boars->title.empty(), "title fusionné depuis quest_texts.fr.json");
+		Check(!boars->stepLabels.empty() && !boars->stepLabels[0].empty(), "stepLabels[0] fusionné et non vide");
+	}
+
+	std::error_code cleanupError;
+	std::filesystem::remove_all(contentRoot, cleanupError);
+
+	if (g_failures != 0)
+	{
+		std::cerr << g_failures << " assertion(s) échouée(s)\n";
+		return 1;
+	}
+	std::cout << "OK\n";
+	return 0;
+}

--- a/src/world_editor/quests/QuestEditIoTests.cpp
+++ b/src/world_editor/quests/QuestEditIoTests.cpp
@@ -1,10 +1,14 @@
-// Tests de QuestEditIo::Load — chargement authoring des quêtes (SP4, Tâche 1).
+// Tests de QuestEditIo::Load et QuestEditIo::Validate — chargement et
+// validation authoring des quêtes (SP4, Tâches 1 et 2).
 //
 // Écrit une fixture (quest_definitions.json + quest_texts.fr.json) dans un
 // répertoire temporaire unique (isolé du vrai contenu du dépôt), à l'instar
 // de QuestRuntimeTests.cpp. QuestEditIo::Load prend un contentRoot brut
 // (chemin filesystem, pas de Config) : pas besoin de FileSystem::WriteAllTextContent,
 // un std::ofstream direct suffit.
+//
+// QuestEditIo::Validate est pure (pas d'I/O) : les cas ci-dessous construisent
+// des std::vector<EditedQuest> directement en mémoire, sans fixture disque.
 
 #include "src/world_editor/quests/QuestEditIo.h"
 
@@ -15,6 +19,7 @@
 #include <string>
 
 using engine::editor::world::quests::EditedQuest;
+using engine::editor::world::quests::EditedStep;
 using engine::editor::world::quests::QuestEditIo;
 
 namespace
@@ -28,6 +33,25 @@ namespace
 			std::cerr << "[FAIL] " << label << "\n";
 			++g_failures;
 		}
+	}
+
+	/// Construit une quête minimale mais valide (un `id` et un `giver`/`turnIn`
+	/// donnés, une seule étape "kill" bien formée). Point de départ pour les
+	/// cas de test de `QuestEditIo::Validate`, modifiée localement par chaque cas.
+	EditedQuest MakeValidQuest(const std::string& id)
+	{
+		EditedQuest quest;
+		quest.id = id;
+		quest.giver = "npc:giver_" + id;
+		quest.turnIn = "npc:giver_" + id;
+
+		EditedStep step;
+		step.type = "kill";
+		step.target = "mob:100";
+		step.requiredCount = 1;
+		quest.steps.push_back(step);
+
+		return quest;
 	}
 
 	/// Construit un répertoire temporaire unique sous temp_directory_path.
@@ -126,6 +150,87 @@ int main()
 
 	std::error_code cleanupError;
 	std::filesystem::remove_all(contentRoot, cleanupError);
+
+	// --- QuestEditIo::Validate ---------------------------------------------
+
+	// (a) ensemble valide → true, 0 erreur.
+	{
+		std::vector<EditedQuest> quests = { MakeValidQuest("quest_a"), MakeValidQuest("quest_b") };
+		quests[1].prereqs.push_back("quest_a");
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(ok, "Validate: ensemble valide -> true");
+		Check(errors.empty(), "Validate: ensemble valide -> 0 erreur");
+	}
+
+	// (b) deux quêtes avec le même id -> false.
+	{
+		std::vector<EditedQuest> quests = { MakeValidQuest("dup"), MakeValidQuest("dup") };
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(!ok, "Validate: id dupliqué -> false");
+		Check(!errors.empty(), "Validate: id dupliqué -> au moins 1 erreur");
+	}
+
+	// (c) prereqs=["inconnu"] -> false (dangling).
+	{
+		std::vector<EditedQuest> quests = { MakeValidQuest("quest_c") };
+		quests[0].prereqs.push_back("inconnu");
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(!ok, "Validate: prereq dangling -> false");
+		Check(!errors.empty(), "Validate: prereq dangling -> au moins 1 erreur");
+	}
+
+	// (d) cycle A.prereqs=[B], B.prereqs=[A] -> false.
+	{
+		EditedQuest questA = MakeValidQuest("quest_cycle_a");
+		EditedQuest questB = MakeValidQuest("quest_cycle_b");
+		questA.prereqs.push_back("quest_cycle_b");
+		questB.prereqs.push_back("quest_cycle_a");
+		std::vector<EditedQuest> quests = { questA, questB };
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(!ok, "Validate: cycle prereqs -> false");
+		Check(!errors.empty(), "Validate: cycle prereqs -> au moins 1 erreur");
+	}
+
+	// (e) giver == "" -> false.
+	{
+		std::vector<EditedQuest> quests = { MakeValidQuest("quest_e") };
+		quests[0].giver.clear();
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(!ok, "Validate: giver vide -> false");
+		Check(!errors.empty(), "Validate: giver vide -> au moins 1 erreur");
+	}
+
+	// (f) quête sans étape -> false.
+	{
+		std::vector<EditedQuest> quests = { MakeValidQuest("quest_f") };
+		quests[0].steps.clear();
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(!ok, "Validate: quête sans étape -> false");
+		Check(!errors.empty(), "Validate: quête sans étape -> au moins 1 erreur");
+	}
+
+	// (g) étape avec target == "" -> false.
+	{
+		std::vector<EditedQuest> quests = { MakeValidQuest("quest_g") };
+		quests[0].steps[0].target.clear();
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(!ok, "Validate: étape target vide -> false");
+		Check(!errors.empty(), "Validate: étape target vide -> au moins 1 erreur");
+	}
 
 	if (g_failures != 0)
 	{


### PR DESCRIPTION
## Résumé

Un panneau **`QuestEditorPanel`** dans l'éditeur monde (`lcdlln_world_editor.exe`) pour **créer/éditer des quêtes** par formulaire, et écrire le contenu.

- **`QuestEditorPanel`** (`src/world_editor/panels/`, `IPanel`) : formulaire (id, giver, turnIn, pré-requis, étapes typées kill/collect/talk/enter, récompenses, textes titre/description/libellés) + bouton **Enregistrer**. Greffé dans `WorldEditorShell::Init` (après `BuildingEditorPanel`) ; rendu automatique.
- **`QuestEditIo`** (`src/world_editor/quests/`, pur, testable) :
  - **Load** : parse `quest_definitions.json` (pur JSON) + fusionne `quest_texts.fr.json`.
  - **Validate** : id unique, giver/turnIn obligatoires, étapes bien formées, pré-requis existants, **détection de cycle** (DFS), items valides.
  - **Save** : écrit les **3 fichiers** — `quest_definitions.json` (pur JSON, **format inchangé** relisible par le shard), `quest_texts.fr.json`, et **régénère `quest_givers.json`** depuis les giver/turnIn (cohérence garantie).

Respecte les contraintes éditeur (CLAUDE.md) : chaque fonction documentée `///`, commentaires FR, PascalCase.

## Tâches (5, subagent-driven, revues + revue finale de branche)

T1 `QuestEditIo::Load` · T2 `Validate` (cycle DFS) · T3 `Save` (3 fichiers pur JSON) · T4 `QuestEditorPanel` + greffe shell · T5 docs. + fix CMake (voir ci-dessous).

## Note CI / fix de link

La revue finale a détecté un **bug de link** (`WorldEditorShell.cpp` est dans `engine_core` et instancie `QuestEditorPanel` ; le binaire jeu `engine_app` linke `engine_core` et instancie `WorldEditorShell` via `--editor-world` runtime → il faut que `QuestEditorPanel.cpp`/`QuestEditIo.cpp` soient dans `engine_core`, pas seulement `world_editor_app`). Corrigé (commit `169f20dd`) en suivant le pattern `QuestTextCatalog` (SP2) : les 2 `.cpp` dans `engine_core`, retirés de `world_editor_app` + des sources directes du test.

Pas de build local possible : cette PR déclenche `build-linux` (compile `engine_app` **et** `world_editor_app` + `ctest`) + `build-windows`, gate final.

## Déploiement

> **✅ outillage éditeur uniquement, pas de redéploiement serveur.** Aucun changement wire/opcode/handler/migration. Toute quête créée/éditée est du **contenu** (`quest_definitions.json` etc.) → **restart shard** pour qu'il la charge.

## Suivis à tracer (hors périmètre)
- Dédup du parser JSON recopié (dette repo-wide, 14+ fichiers).
- `Save` : atomicité si l'écriture du 2ᵉ/3ᵉ fichier échoue (dossier partiel).
- Autocomplete/validation d'existence des références (npc/mob/item).

Specs & plan : `docs/superpowers/specs/2026-07-02-quest-sp4-editor-authoring-design.md`, `docs/superpowers/plans/2026-07-02-quest-sp4-editor-authoring.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)