### PR TITLE
feat(quests): EXT-1 — quêtes mutuellement exclusives / contre-quêtes

### DIFF
--- a/CODEBASE_MAP.md
+++ b/CODEBASE_MAP.md
@@ -2443,6 +2443,8 @@ Le système de quêtes du shard (`src/shardd/gameplay/quest/QuestRuntime`) suit 
 
 Au `Talk` sur un PNJ, le shard renvoie `QuestGiverList` (opcode 92) listant ses quêtes proposées/rendables pour ce joueur, en plus de l'event d'étape `Talk`. Le contenu est data-driven (`game/data/quests/quest_definitions.json`, champs `giver`/`turnIn`). Wire : `kProtocolVersion` 14. Persistance : `CharacterPersistence` sérialise statut + `stepProgressCounts` + `quests.format_version` par personnage. Détails : `docs/superpowers/specs/2026-07-02-quest-*`.
 
+**Exclusion mutuelle / contre-quêtes (EXT-1)** : une définition peut porter un champ **optionnel** `excludes: [questId,…]` (`QuestDefinition::excludedQuestIds`). S'**engager** dans une quête (statut ∈ {Active, ReadyToTurnIn, Completed}) rend indisponibles les quêtes qu'elle exclut — et **réciproquement** : l'exclusion est **symétrique au runtime** (`QuestRuntime::IsBlockedByExclusion`, déclarée d'un seul côté). Deux gates : l'offer-sync (`SyncQuestStates`) garde la quête exclue `Locked` (elle n'apparaît donc ni au journal ni dans la giver-list), et l'accept (`ServerApp::HandleAcceptQuest`) re-vérifie atomiquement (ferme la course où deux quêtes exclusives sont `Offered` simultanément). **100 % serveur** : le client ne voit que le statut résultant via `QuestDelta`, **aucun changement de wire**. Champ optionnel → rétro-compatible. Détails : `docs/superpowers/specs/2026-07-03-quest-ext1-exclusion-design.md`.
+
 ## Quêtes — rendu & interaction client (SP2)
 
 Côté client, le système de quêtes (shard, SP1) est affiché par `QuestImGuiRenderer` (`src/client/render/`) branché dans la boucle ImGui in-game : **journal** (quêtes Active/ReadyToTurnIn, textes via `QuestTextCatalog`), **tracker HUD**, et **panneau donneur** (boutons Accepter/Terminer). Les textes lisibles viennent de `game/data/quests/quest_texts.<lang>.json` (`QuestTextCatalog`) ; le mapping PNJ→quêtes de `game/data/quests/quest_givers.json` (`QuestGiverTable`).
@@ -2454,7 +2456,7 @@ Interaction : les choix de dialogue portent un `questKey` (string) qui déclench
 Dans l'éditeur monde (`lcdlln_world_editor.exe`), le **`QuestEditorPanel`** (`src/world_editor/panels/`, `IPanel`) permet de créer/éditer des quêtes par formulaire (id, giver, turnIn, pré-requis, étapes typées kill/collect/talk/enter, récompenses, textes titre/description/libellés). La logique I/O + validation est isolée dans **`QuestEditIo`** (`src/world_editor/quests/`, pur, testable) :
 
 - **Load** : parse `quest_definitions.json` (pur JSON) + fusionne `quest_texts.fr.json`.
-- **Validate** : id unique, giver/turnIn obligatoires, étapes bien formées, pré-requis existants, **détection de cycle** (DFS), items valides.
+- **Validate** : id unique, giver/turnIn obligatoires, étapes bien formées, pré-requis existants, **détection de cycle** (DFS), items valides, **exclusions** (`excludes`, EXT-1) existantes et sans auto-exclusion (pas de cycle-check : l'exclusion mutuelle A↔B est licite).
 - **Save** : écrit les **3 fichiers** — `quest_definitions.json` (pur JSON, format inchangé relisible par le shard), `quest_texts.fr.json`, et **régénère `quest_givers.json`** depuis les giver/turnIn (cohérence garantie).
 
 Greffé dans `WorldEditorShell::Init` (après `BuildingEditorPanel`) ; rendu automatique via la boucle des panneaux. ⚠️ Toute quête créée/éditée = contenu → **restart shard** pour la charger. Détails : `docs/superpowers/specs/2026-07-02-quest-sp4-editor-authoring-design.md`.

--- a/docs/superpowers/plans/2026-07-03-quest-ext1-exclusion.md
+++ b/docs/superpowers/plans/2026-07-03-quest-ext1-exclusion.md
@@ -1,0 +1,46 @@
+# EXT-1 — Exclusion / contre-quêtes — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Ajouter le champ `excludes` (quêtes mutuellement exclusives) au système B (shard) + support éditeur, sans toucher au wire ni au client. Spec : `docs/superpowers/specs/2026-07-03-quest-ext1-exclusion-design.md`.
+
+## Global Constraints
+- Commentaires FR ; PascalCase nouveaux symboles ; pas de « CMANGOS » nouveau. Pas de build local → CI = gate.
+- Tests **non-strippables** (CI Release `-DNDEBUG` strippe `assert()` nu) : `std::cerr` + compteur + `return 1`, sauf fichier faisant `#undef NDEBUG`.
+- **Aucun changement de wire** : `excludes` est purement serveur (le client ne voit que le statut via `QuestDelta`). Ne pas toucher `ServerProtocol`/`kProtocolVersion`/le client.
+- Règle éditeur (CLAUDE.md) : doc `///` sur **toute** fonction ajoutée dans `src/world_editor/`.
+- **Déploiement** : ⚠️ REDÉPLOIEMENT SHARD ; client inchangé.
+
+---
+
+## Task 1 : Shard — données, gates, tests
+**Files:** `src/shardd/gameplay/quest/QuestRuntime.{h,cpp}`, `src/shared/server_bootstrap/ServerApp.cpp`, `src/shardd/gameplay/quest/QuestRuntimeTests.cpp`.
+
+- [ ] **Step 1 (RED)** — Écrire les tests QuestRuntime AVANT le code (spec §4 a–e) : offer-sync garde B `Locked` si A engagée ; accept refusé si A engagée (via un helper appelable, cf. Step 4) ; symétrie ; pas de blocage si seulement `Offered` ; rétro-compat sans `excludes`. Construire les fixtures via le pattern `MakeRuntimeWithFixture(json)` existant.
+- [ ] **Step 2** — `QuestRuntime.h` : `std::vector<std::string> excludedQuestIds;` dans `QuestDefinition` ; déclarer `bool IsBlockedByExclusion(const std::vector<QuestState>&, const QuestDefinition&) const;` (public) + `bool IsQuestEngaged(const std::vector<QuestState>&, const std::string&) const;` (privé).
+- [ ] **Step 3** — `QuestRuntime.cpp LoadDefinitions` (~885) : parser `"excludes"` optionnel, **miroir exact** du bloc `prereqs` (~885-909).
+- [ ] **Step 4** — `QuestRuntime.cpp` : implémenter `IsQuestEngaged` (status ∈ {Active, ReadyToTurnIn, Completed}) + `IsBlockedByExclusion` (sens direct `def.excludedQuestIds` **ET** sens symétrique : balayer `m_definitions` pour toute def dont `excludedQuestIds` contient `def.questId`).
+- [ ] **Step 5** — `SyncQuestStates` (~612) : ne passer à `Offered` que si `prerequisitesComplete && !IsBlockedByExclusion(states, definition)`.
+- [ ] **Step 6** — `ServerApp::HandleAcceptQuest` (5356) : après `CanAccept` (et cohérent avec le gate `IsClientNearNpc`), ajouter `if (m_questRuntime.IsBlockedByExclusion(client->questStates, *def)) { LOG_WARN(...); return; }`.
+- [ ] **Step 7 (GREEN)** — Vérifier que les tests passent (raisonnement, pas de build local). Ajouter la cible test au `CMakeLists` **si** un nouveau fichier test est créé (sinon étendre `QuestRuntimeTests.cpp` existant, déjà câblé).
+- [ ] **Step 8 : Commit** — `feat(quests): champ excludes (quêtes mutuellement exclusives) côté shard`.
+
+## Task 2 : Éditeur — I/O, panneau, tests
+**Files:** `src/world_editor/quests/QuestEditIo.{h,cpp}`, `src/world_editor/panels/QuestEditorPanel.{h,cpp}`, le test QuestEditIo existant.
+
+- [ ] **Step 1 (RED)** — Tests QuestEditIo : round-trip `excludes` (parse→serialize→parse identiques) ; rejet auto-exclusion (`id` dans son propre `excludes`) ; rejet id inexistant ; sortie relisible.
+- [ ] **Step 2** — `EditableQuest.excludes` (vector<string>) ; parse `"excludes"` (miroir prereqs ~576) ; validation (existence + anti-auto-exclusion) ; **pas** de cycle-check.
+- [ ] **Step 3** — Sérialisation `"excludes"` (miroir prereqs ~807), JSON pur.
+- [ ] **Step 4** — `QuestEditorPanel` : `m_excludesBuffer` + `RenderExcludesSection()` (miroir `RenderPrereqSection`, cases à cocher des autres quêtes, `id != q.id`) ; Load/Save buffer (miroir 45/62/80). Doc `///` sur `RenderExcludesSection` + tout helper.
+- [ ] **Step 5 (GREEN)** — Vérifier tests. Rappel **contrainte CMake** : `QuestEditorPanel.cpp`/`QuestEditIo.cpp` sont dans `engine_core` (car `WorldEditorShell` dans engine_core les instancie, et `engine_app` jeu linke engine_core via `--editor-world`) — ne rien déplacer, juste éditer.
+- [ ] **Step 6 : Commit** — `feat(quests): champ excludes dans l'éditeur de quêtes (I/O + panneau)`.
+
+## Task 3 : Docs + revue finale
+- [ ] **Step 1** — `CODEBASE_MAP.md` : dans la section Quêtes, documenter `excludes` (exclusion mutuelle, serveur-seul, symétrique). Renvoyer à la spec EXT-1.
+- [ ] **Step 2 : Commit** — `docs(quests): champ excludes documenté dans CODEBASE_MAP`.
+- [ ] **Step 3 : Revue finale de branche** — compile-safety (shard + éditeur + engine_app), aucun wire touché, rétro-compat contenu, doc éditeur présente.
+
+## Checklist finale
+- [ ] 2 gates (offer-sync + accept), exclusion symétrique, tests shard 5 cas verts.
+- [ ] Éditeur : I/O + validation + panneau + tests round-trip.
+- [ ] CI verte (shard + éditeur + client inchangé). Rapport : ⚠️ REDÉPLOIEMENT SHARD, client inchangé.

--- a/docs/superpowers/specs/2026-07-03-quest-ext1-exclusion-design.md
+++ b/docs/superpowers/specs/2026-07-03-quest-ext1-exclusion-design.md
@@ -1,0 +1,65 @@
+# EXT-1 — Quêtes mutuellement exclusives / contre-quêtes
+
+**Date** : 2026-07-03
+**Statut** : design (à relire)
+**Doc parent** : `2026-07-02-quest-system-overview-design.md`
+**Portée** : ajouter un champ `excludes: [questId,…]` aux définitions de quête (système B, shard). S'engager dans une quête rend indisponibles les quêtes qu'elle exclut (et réciproquement). Sert aux choix de faction et aux embranchements narratifs mutuellement exclusifs. **Shard + éditeur uniquement — aucun changement de wire.**
+
+---
+
+## 1. Sémantique
+
+- **« Engagée »** = statut ∈ `{Active, ReadyToTurnIn, Completed}`. Le statut `Offered` **ne bloque pas** : on peut se voir proposer deux quêtes exclusives ; **accepter** l'une verrouille l'autre.
+- **Exclusion symétrique au runtime** : si A déclare exclure B, alors B est aussi bloquée quand A est engagée, **même si B ne déclare pas A**. Le GM déclare l'exclusion **une seule fois** (sur A ou B).
+- **Purement côté serveur** : une quête exclue reste `Locked`, ne devient jamais `Offered` → elle n'apparaît ni au journal client, ni dans la giver-list (opcode 92, dérivée des quêtes `Offered`). **Le client n'a pas besoin de connaître `excludes`** ; il ne voit que le statut résultant via `QuestDelta`. → **pas de bump `kProtocolVersion`, client inchangé.**
+
+## 2. Deux gates d'enforcement
+
+1. **Offer-sync** (`QuestRuntime::SyncQuestStates`, `QuestRuntime.cpp:~612`) : au calcul de `desiredStatus`, en plus de `prerequisitesComplete`, exiger `!IsBlockedByExclusion(states, definition)` pour passer à `Offered` ; sinon rester `Locked`. → masque automatiquement les quêtes exclues de la giver-list.
+2. **Accept** (`ServerApp::HandleAcceptQuest`, `ServerApp.cpp:5356`, juste après `CanAccept`) : re-vérif atomique — `if (m_questRuntime.IsBlockedByExclusion(client->questStates, *def)) { LOG_WARN; return; }`. Ferme la **fenêtre de course** où deux quêtes exclusives sont `Offered` simultanément et où un client tenterait d'accepter la seconde après avoir accepté la première (la sync n'a pas encore rétrogradé la seconde).
+
+## 3. Ajouts
+
+### 3.1 Shard — `src/shardd/gameplay/quest/QuestRuntime.{h,cpp}`
+- **`QuestDefinition`** (`QuestRuntime.h:55`, après `prerequisiteQuestIds`) : ajouter `std::vector<std::string> excludedQuestIds;`.
+- **`LoadDefinitions`** (`QuestRuntime.cpp:~885`) : parser le champ **optionnel** `"excludes"` (array de strings non vides), **miroir exact** du bloc `prereqs`. Absent = OK (rétro-compatible).
+- **Nouvelle méthode** `bool QuestRuntime::IsBlockedByExclusion(const std::vector<QuestState>& states, const QuestDefinition& def) const` :
+  - `true` si **(a)** une quête de `def.excludedQuestIds` est engagée, **OU (b)** une autre `QuestDefinition` de `m_definitions` dont `excludedQuestIds` contient `def.questId` est engagée.
+  - Helper privé `bool IsQuestEngaged(const std::vector<QuestState>& states, const std::string& questId) const` : `true` si l'état existe et status ∈ `{Active, ReadyToTurnIn, Completed}`.
+- **`SyncQuestStates`** : intégrer le gate (cf. §2.1).
+
+### 3.2 Shard — `src/shared/server_bootstrap/ServerApp.cpp`
+- **`HandleAcceptQuest`** (5356) : ajouter le gate accept (cf. §2.2), après `CanAccept` et avant le passage à `Active`.
+
+### 3.3 Éditeur — `src/world_editor/quests/QuestEditIo.{h,cpp}`
+- **`EditableQuest`** : ajouter `std::vector<std::string> excludes;`.
+- **Parse** (`QuestEditIo.cpp:~576`) : lire `"excludes"` (miroir `prereqs`).
+- **Validation** : chaque id de `excludes` doit exister parmi les quêtes chargées (comme les prereqs dangling — même politique de message) **et** `id != quest.id` (rejet auto-exclusion). **Pas** de détection de cycle (l'exclusion n'est pas un DAG, aucune contrainte d'acyclicité).
+- **Sérialisation** (`QuestEditIo.cpp:~807`) : émettre `"excludes"` (miroir `prereqs`). `quest_definitions.json` reste du **JSON pur relisible par le shard**.
+
+### 3.4 Éditeur — `src/world_editor/panels/QuestEditorPanel.{h,cpp}`
+- Ajouter `std::vector<std::string> m_excludesBuffer;` + `void RenderExcludesSection();` (miroir `m_prereqBuffer` / `RenderPrereqSection`, liste de cases à cocher des **autres** quêtes, `id != q.id` masqué ou désactivé).
+- Charger/sauver le buffer dans les hooks Load/Save existants (miroir prereqs, `QuestEditorPanel.cpp:45/62/80`).
+- **Doc `///`** obligatoire sur toute nouvelle fonction (règle éditeur monde, CLAUDE.md).
+
+## 4. Tests
+- **`QuestRuntimeTests.cpp`** : (a) offer-sync garde B `Locked` quand A engagée ; (b) accept de B refusé quand A engagée ; (c) direction **symétrique** (A exclut B non déclaré sur B) ; (d) **pas** de blocage quand la quête concurrente est seulement `Offered` ; (e) rétro-compat : quête sans `excludes` inchangée.
+- **`QuestEditIoTests.cpp`** (ou l'équivalent existant) : round-trip `excludes` (parse→serialize→parse) ; rejet auto-exclusion ; rejet id inexistant ; sérialisation relue OK par un `QuestRuntime`.
+- Tests **non-strippables** (CI Release `-DNDEBUG` : pas de `assert()` nu ; `std::cerr` + compteur + `return 1`), sauf si le fichier fait déjà `#undef NDEBUG`.
+
+## 5. Compat / contenu
+- Champ `excludes` **optionnel** → 100 % rétro-compatible, aucune quête existante impactée, pas de migration de contenu.
+- Pas de persistance nouvelle : `excludes` est une **propriété de définition** (statique, JSON), pas un état par joueur. La persistance par personnage (statut + stepProgressCounts) est inchangée.
+
+## 6. Déploiement
+> **⚠️ REDÉPLOIEMENT SHARD requis** — `QuestRuntime` charge et évalue `excludes` au boot et à chaque `SyncQuestStates`. **Client inchangé** (aucun wire). Éditeur = outillage (restart éditeur pour charger la nouvelle UI ; restart shard pour charger le contenu créé).
+
+## 7. Hors périmètre
+- EXT-2 (répétables/quotidiennes) et EXT-3 (groupe/raid) — sous-projets séparés.
+- Exclusion **par tag faction** (« toutes les quêtes faction X ») : ici on exclut quête-à-quête ; un tag faction serait une couche au-dessus, non couverte.
+
+## 8. Definition of Done
+- [ ] `QuestDefinition.excludedQuestIds` + parse `"excludes"` + `IsBlockedByExclusion`/`IsQuestEngaged` ; gate offer-sync + gate accept.
+- [ ] Éditeur : `EditableQuest.excludes` + parse/validate (existence, anti-auto-exclusion)/serialize + `RenderExcludesSection` + Load/Save.
+- [ ] Tests shard (5 cas) + éditeur (round-trip + rejets), non-strippables.
+- [ ] CI verte (shard + éditeur + client — client non modifié mais linke `QuestRuntime`). Rapport : ⚠️ REDÉPLOIEMENT SHARD, client inchangé.

--- a/src/shardd/gameplay/quest/QuestRuntime.cpp
+++ b/src/shardd/gameplay/quest/QuestRuntime.cpp
@@ -609,7 +609,10 @@ namespace engine::server
 				}
 			}
 
-			if (prerequisitesComplete)
+			// EXT-1 — une quête bloquée par exclusion mutuelle ne doit jamais être
+			// proposée : elle reste Locked, donc absente du journal et de la
+			// giver-list (dérivée des quêtes Offered).
+			if (prerequisitesComplete && !IsBlockedByExclusion(states, definition))
 			{
 				// La quête est proposée au joueur (Offered) ; l'acceptation explicite
 				// au PNJ giver (CanAccept) la fait ensuite passer à Active.
@@ -803,6 +806,54 @@ namespace engine::server
 		return &def.rewards;
 	}
 
+	bool QuestRuntime::IsQuestEngaged(const std::vector<QuestState>& states, const std::string& questId) const
+	{
+		const size_t stateIndex = FindQuestStateIndex(states, questId);
+		if (stateIndex == std::string::npos)
+		{
+			return false;
+		}
+
+		const QuestStatus status = states[stateIndex].status;
+		// « Engagée » = le joueur a accepté la quête (ou l'a déjà terminée).
+		// Offered et Locked ne comptent pas : voir une quête proposée ne l'engage pas.
+		return status == QuestStatus::Active
+			|| status == QuestStatus::ReadyToTurnIn
+			|| status == QuestStatus::Completed;
+	}
+
+	bool QuestRuntime::IsBlockedByExclusion(const std::vector<QuestState>& states, const QuestDefinition& def) const
+	{
+		// (a) Sens direct : une quête que `def` exclut explicitement est engagée.
+		for (const std::string& excludedQuestId : def.excludedQuestIds)
+		{
+			if (IsQuestEngaged(states, excludedQuestId))
+			{
+				return true;
+			}
+		}
+
+		// (b) Sens symétrique : une AUTRE définition qui exclut `def` est engagée.
+		// L'exclusion déclarée d'un seul côté bloque bien les deux quêtes.
+		for (const QuestDefinition& other : m_definitions)
+		{
+			if (other.questId == def.questId)
+			{
+				continue;
+			}
+
+			for (const std::string& otherExcludedQuestId : other.excludedQuestIds)
+			{
+				if (otherExcludedQuestId == def.questId && IsQuestEngaged(states, other.questId))
+				{
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
 	bool QuestRuntime::LoadDefinitions()
 	{
 		m_definitions.clear();
@@ -905,6 +956,34 @@ namespace engine::server
 					}
 
 					definition.prerequisiteQuestIds.push_back(prereqValue.stringValue);
+				}
+			}
+
+			// EXT-1 — champ optionnel "excludes" (miroir exact de "prereqs").
+			// Absent = OK (rétro-compatible : aucune exclusion déclarée).
+			if (const JsonValue* excludesValue = FindObjectMember(questValue, "excludes");
+				excludesValue != nullptr)
+			{
+				if (excludesValue->type != JsonType::Array)
+				{
+					LOG_ERROR(Net, "[QuestRuntime] Definition load FAILED: quest '{}'.excludes must be an array", definition.questId);
+					m_definitions.clear();
+					return false;
+				}
+
+				for (size_t excludeIndex = 0; excludeIndex < excludesValue->arrayValue.size(); ++excludeIndex)
+				{
+					const JsonValue& excludeValue = excludesValue->arrayValue[excludeIndex];
+					if (excludeValue.type != JsonType::String || excludeValue.stringValue.empty())
+					{
+						LOG_ERROR(Net, "[QuestRuntime] Definition load FAILED: quest '{}'.excludes[{}] must be a non-empty string",
+							definition.questId,
+							excludeIndex);
+						m_definitions.clear();
+						return false;
+					}
+
+					definition.excludedQuestIds.push_back(excludeValue.stringValue);
 				}
 			}
 

--- a/src/shardd/gameplay/quest/QuestRuntime.h
+++ b/src/shardd/gameplay/quest/QuestRuntime.h
@@ -53,6 +53,10 @@ namespace engine::server
 		std::string giverId;    ///< PNJ qui propose la quête (même espace que targetId du Talk)
 		std::string turnInId;   ///< PNJ où rendre la quête (souvent = giverId)
 		std::vector<std::string> prerequisiteQuestIds;
+		/// EXT-1 : quêtes mutuellement exclusives. S'engager dans cette quête
+		/// (Active/ReadyToTurnIn/Completed) verrouille chacune de ces quêtes, et
+		/// réciproquement (exclusion symétrique évaluée au runtime).
+		std::vector<std::string> excludedQuestIds;
 		std::vector<QuestStepDefinition> steps;
 		QuestReward rewards;
 	};
@@ -123,9 +127,21 @@ namespace engine::server
 		/// Retourne le bundle de récompense à verser au turn-in (jamais nul).
 		const QuestReward* TakeRewardOnTurnIn(const QuestDefinition& def) const;
 
+		/// EXT-1 — Vrai si \p def est actuellement bloquée par exclusion mutuelle
+		/// pour ce joueur : soit (a) une quête listée dans `def.excludedQuestIds`
+		/// est engagée, soit (b) une autre définition dont `excludedQuestIds`
+		/// contient `def.questId` est engagée (symétrie : l'exclusion déclarée d'un
+		/// seul côté bloque les deux). Pur, sans effet de bord.
+		bool IsBlockedByExclusion(const std::vector<QuestState>& states, const QuestDefinition& def) const;
+
 	private:
 		/// Load every quest definition from the configured JSON content file.
 		bool LoadDefinitions();
+
+		/// EXT-1 — Vrai si le joueur a un état pour \p questId dont le statut est
+		/// « engagé » (∈ {Active, ReadyToTurnIn, Completed}). Offered et Locked ne
+		/// comptent pas : voir une quête proposée n'engage pas encore.
+		bool IsQuestEngaged(const std::vector<QuestState>& states, const std::string& questId) const;
 
 		engine::core::Config m_config;
 		std::string m_questDefinitionsRelativePath;

--- a/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
+++ b/src/shardd/gameplay/quest/QuestRuntimeTests.cpp
@@ -173,6 +173,118 @@ int main()
 		Check(reward != nullptr && reward->experience == 10, "reward exposé au turn-in");
 	}
 
+	// EXT-1 — Exclusion mutuelle : A exclut B. Fixture partagée pour les cas
+	// (a)..(d). A et B sont sans prérequis (donc naturellement Offered), A
+	// déclarant "excludes": ["qB"] ; B ne déclare rien (test de symétrie).
+	{
+		const std::string json = R"JSON({
+      "quests": [
+        { "id": "qA", "giver": "npc:marn", "turnIn": "npc:marn",
+          "prereqs": [], "excludes": [ "qB" ],
+          "steps": [ { "type": "kill", "target": "mob:1", "requiredCount": 1 } ],
+          "rewards": { "xp": 10, "gold": 5, "items": [] } },
+        { "id": "qB", "giver": "npc:marn", "turnIn": "npc:marn",
+          "prereqs": [],
+          "steps": [ { "type": "kill", "target": "mob:2", "requiredCount": 1 } ],
+          "rewards": { "xp": 10, "gold": 5, "items": [] } }
+      ]
+    })JSON";
+
+		QuestRuntime runtime = MakeRuntimeWithFixture(json);
+		Check(runtime.Init(), "Init charge qA (excludes qB) + qB");
+
+		const auto* defA = runtime.FindQuestDefinition("qA");
+		const auto* defB = runtime.FindQuestDefinition("qB");
+		Check(defA != nullptr && defB != nullptr, "qA et qB trouvées");
+		if (defA != nullptr && defB != nullptr)
+		{
+			Check(defA->excludedQuestIds.size() == 1 && defA->excludedQuestIds[0] == "qB",
+			      "excludes parsé sur qA");
+			Check(defB->excludedQuestIds.empty(), "qB sans excludes (rétro-compat champ absent)");
+
+			std::vector<QuestState> states;
+			std::vector<QuestProgressDelta> deltas;
+			Check(runtime.SyncQuestStates(states, deltas), "sync initiale OK");
+			// (d) Aucune quête engagée → les deux sont seulement Offered → aucun blocage.
+			const size_t iA = 0, iB = 1; // ordre = ordre des définitions
+			Check(states.size() == 2, "deux états créés");
+			bool bothOffered = states.size() == 2
+				&& states[iA].status == QuestStatus::Offered
+				&& states[iB].status == QuestStatus::Offered;
+			Check(bothOffered, "(d) A et B Offered quand rien n'est engagé");
+			Check(!runtime.IsBlockedByExclusion(states, *defB),
+			      "(d) B non bloquée quand A seulement Offered");
+			Check(!runtime.IsBlockedByExclusion(states, *defA),
+			      "(d) A non bloquée quand B seulement Offered");
+
+			// Engager A (Offered → Active), comme le ferait un accept.
+			states[iA].status = QuestStatus::Active;
+
+			// (b) IsBlockedByExclusion(B) vrai quand A engagée (Active).
+			Check(runtime.IsBlockedByExclusion(states, *defB),
+			      "(b) B bloquée quand A Active (sens direct : A exclut B)");
+			// (c) Symétrie : B ne déclare pas A, mais reste bloquée.
+			Check(runtime.IsBlockedByExclusion(states, *defB),
+			      "(c) symétrie : B bloquée même sans déclarer A");
+			// A n'est pas bloquée par elle-même.
+			Check(!runtime.IsBlockedByExclusion(states, *defA),
+			      "A non bloquée par sa propre exclusion");
+
+			// (a) offer-sync : re-sync ne doit PAS repasser B à Offered (reste Locked).
+			deltas.clear();
+			Check(runtime.SyncQuestStates(states, deltas), "re-sync avec A engagée OK");
+			Check(states[iB].status == QuestStatus::Locked,
+			      "(a) offer-sync garde B Locked quand A engagée");
+
+			// (b) idem quand A est Completed (statut terminal, toujours « engagée »).
+			states[iA].status = QuestStatus::Completed;
+			Check(runtime.IsBlockedByExclusion(states, *defB),
+			      "(b) B bloquée quand A Completed");
+		}
+	}
+
+	// EXT-1 (e) — Rétro-compat : une quête sans "excludes" se comporte à
+	// l'identique (Offered malgré une autre quête engagée).
+	{
+		const std::string json = R"JSON({
+      "quests": [
+        { "id": "qX", "giver": "npc:marn", "turnIn": "npc:marn",
+          "prereqs": [],
+          "steps": [ { "type": "kill", "target": "mob:1", "requiredCount": 1 } ],
+          "rewards": { "xp": 10, "gold": 5, "items": [] } },
+        { "id": "qY", "giver": "npc:marn", "turnIn": "npc:marn",
+          "prereqs": [],
+          "steps": [ { "type": "kill", "target": "mob:2", "requiredCount": 1 } ],
+          "rewards": { "xp": 10, "gold": 5, "items": [] } }
+      ]
+    })JSON";
+
+		QuestRuntime runtime = MakeRuntimeWithFixture(json);
+		Check(runtime.Init(), "(e) Init charge qX/qY sans excludes");
+
+		const auto* defY = runtime.FindQuestDefinition("qY");
+		Check(defY != nullptr, "(e) qY trouvée");
+
+		std::vector<QuestState> states;
+		std::vector<QuestProgressDelta> deltas;
+		Check(runtime.SyncQuestStates(states, deltas), "(e) sync OK");
+		Check(states.size() == 2, "(e) deux états créés");
+		if (states.size() == 2)
+		{
+			states[0].status = QuestStatus::Active; // qX engagée
+			deltas.clear();
+			Check(runtime.SyncQuestStates(states, deltas), "(e) re-sync OK");
+			// Sans excludes, qY reste proposée malgré qX engagée.
+			Check(states[1].status == QuestStatus::Offered,
+			      "(e) qY reste Offered (aucun excludes déclaré)");
+			if (defY != nullptr)
+			{
+				Check(!runtime.IsBlockedByExclusion(states, *defY),
+				      "(e) qY jamais bloquée sans excludes");
+			}
+		}
+	}
+
 	if (g_failures != 0)
 	{
 		std::cerr << g_failures << " assertion(s) échouée(s)\n";

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -5360,6 +5360,17 @@ namespace engine::server
 			return;
 		}
 
+		// EXT-1 — re-vérification atomique de l'exclusion mutuelle : ferme la
+		// fenêtre de course où deux quêtes exclusives sont Offered simultanément et
+		// où le client accepterait la seconde avant que la sync n'ait rétrogradé
+		// l'une des deux à Locked.
+		if (m_questRuntime.IsBlockedByExclusion(client->questStates, *def))
+		{
+			LOG_WARN(Net, "[ServerApp] AcceptQuest refusé (exclusion) (client_id={}, quest_id={})",
+				client->clientId, msg.questId);
+			return;
+		}
+
 		if (!IsClientNearNpc(*client, msg.giverTargetId))
 		{
 			return;

--- a/src/world_editor/panels/QuestEditorPanel.cpp
+++ b/src/world_editor/panels/QuestEditorPanel.cpp
@@ -43,6 +43,7 @@ namespace engine::editor::world::panels
 		std::snprintf(m_giverBuf, sizeof(m_giverBuf), "%s", q.giver.c_str());
 		std::snprintf(m_turnInBuf, sizeof(m_turnInBuf), "%s", q.turnIn.c_str());
 		m_prereqBuffer = q.prereqs;
+		m_excludesBuffer = q.excludes;
 		m_stepsBuffer = q.steps;
 		m_rewardXpBuffer = q.rewardXp;
 		m_rewardGoldBuffer = q.rewardGold;
@@ -60,6 +61,7 @@ namespace engine::editor::world::panels
 		q.giver = m_giverBuf;
 		q.turnIn = m_turnInBuf;
 		q.prereqs = m_prereqBuffer;
+		q.excludes = m_excludesBuffer;
 		q.steps = m_stepsBuffer;
 		q.rewardXp = m_rewardXpBuffer;
 		q.rewardGold = m_rewardGoldBuffer;
@@ -78,6 +80,7 @@ namespace engine::editor::world::panels
 		m_giverBuf[0] = '\0';
 		m_turnInBuf[0] = '\0';
 		m_prereqBuffer.clear();
+		m_excludesBuffer.clear();
 		m_stepsBuffer.clear();
 		m_rewardXpBuffer = 0;
 		m_rewardGoldBuffer = 0;
@@ -148,6 +151,49 @@ namespace engine::editor::world::panels
 				}
 			}
 		}
+	}
+
+	/// Rend la multi-sélection des quêtes mutuellement exclusives (EXT-1) : une
+	/// case à cocher par id de quête connu, HORS la quête en cours d'édition
+	/// (`q.id == m_idBuf` sauté) pour interdire l'auto-exclusion côté UI.
+	/// Cocher ajoute l'id à `m_excludesBuffer`, décocher l'en retire. Miroir de
+	/// `RenderPrereqSection` mais sans cycle-check (l'exclusion mutuelle A<->B
+	/// est autorisée). Effet de bord : état ImGui + `m_excludesBuffer` (modifié
+	/// en place). Thread : main thread (phase ImGui, appelée depuis Render).
+	void QuestEditorPanel::RenderExcludesSection()
+	{
+		ImGui::TextUnformatted("Quetes mutuellement exclusives :");
+		if (m_quests.empty())
+		{
+			ImGui::TextDisabled("(aucune autre quete chargee)");
+			return;
+		}
+		// Namespace ImGui de la section : les cases d'exclusion partagent leur
+		// label (`q.id`) avec celles des prérequis ; sans ce PushID de section,
+		// les deux ensembles de cases entreraient en collision d'id ImGui.
+		ImGui::PushID("excludes_section");
+		for (const auto& q : m_quests)
+		{
+			// Une quête ne peut pas s'exclure elle-même (auto-exclusion interdite,
+			// rejetée aussi par QuestEditIo::Validate).
+			if (q.id == m_idBuf) continue;
+			bool checked = false;
+			for (const auto& e : m_excludesBuffer) if (e == q.id) { checked = true; break; }
+			if (ImGui::Checkbox(q.id.c_str(), &checked))
+			{
+				if (checked)
+				{
+					m_excludesBuffer.push_back(q.id);
+				}
+				else
+				{
+					m_excludesBuffer.erase(
+						std::remove(m_excludesBuffer.begin(), m_excludesBuffer.end(), q.id),
+						m_excludesBuffer.end());
+				}
+			}
+		}
+		ImGui::PopID();
 	}
 
 	void QuestEditorPanel::RenderStepsSection()
@@ -305,6 +351,8 @@ namespace engine::editor::world::panels
 			RenderIdentityFields();
 			ImGui::Separator();
 			RenderPrereqSection();
+			ImGui::Separator();
+			RenderExcludesSection();
 			ImGui::Separator();
 			RenderStepsSection();
 			ImGui::Separator();

--- a/src/world_editor/panels/QuestEditorPanel.cpp
+++ b/src/world_editor/panels/QuestEditorPanel.cpp
@@ -35,6 +35,10 @@ namespace engine::editor::world::panels
 		}
 	}
 
+	/// Copie la quête sélectionnée (`m_selected`) dans les buffers d'édition du
+	/// formulaire (id, giver, turnIn, prérequis, **exclusions**, étapes,
+	/// récompenses, textes). No-op si aucune sélection valide.
+	/// Effet de bord : écrase tous les `m_*Buffer` du panneau. Main thread (ImGui).
 	void QuestEditorPanel::LoadBuffersFromSelected()
 	{
 		if (m_selected < 0 || m_selected >= static_cast<int>(m_quests.size())) return;
@@ -54,6 +58,9 @@ namespace engine::editor::world::panels
 		m_stepLabelsBuffer.resize(m_stepsBuffer.size());
 	}
 
+	/// Construit un `EditedQuest` à partir des buffers d'édition courants
+	/// (opération inverse de \ref LoadBuffersFromSelected), incluant les
+	/// **exclusions** (`m_excludesBuffer`). Pur (ne modifie aucun état du panneau).
 	EditedQuest QuestEditorPanel::BuildQuestFromBuffers() const
 	{
 		EditedQuest q;
@@ -73,6 +80,9 @@ namespace engine::editor::world::panels
 		return q;
 	}
 
+	/// Réinitialise tous les buffers d'édition pour saisir une nouvelle quête
+	/// (dé-sélectionne, vide id/giver/turnIn/prérequis/**exclusions**/étapes/
+	/// récompenses). Effet de bord : écrase tous les `m_*Buffer`. Main thread (ImGui).
 	void QuestEditorPanel::ResetBuffersToNew()
 	{
 		m_selected = -1;

--- a/src/world_editor/panels/QuestEditorPanel.h
+++ b/src/world_editor/panels/QuestEditorPanel.h
@@ -75,6 +75,16 @@ namespace engine::editor::world::panels
 		/// état ImGui + `m_prereqBuffer`.
 		void RenderPrereqSection();
 
+		/// Rend la multi-sélection des quêtes mutuellement exclusives (EXT-1,
+		/// `m_excludesBuffer`) : une case à cocher par id de quête connu, HORS
+		/// la quête en cours d'édition (`q.id != m_idBuf`) pour interdire
+		/// l'auto-exclusion côté UI (règle miroir de `RenderPrereqSection`, mais
+		/// sans cycle-check : l'exclusion mutuelle est permise). Cocher/décocher
+		/// ajoute/retire l'id dans `m_excludesBuffer`.
+		/// Effet de bord : état ImGui + `m_excludesBuffer` (modifié en place).
+		/// Thread : main thread (ImGui).
+		void RenderExcludesSection();
+
 		/// Rend la liste éditable des étapes (`m_stepsBuffer`) : combo type
 		/// (kill/collect/talk/enter), champ target, champ requiredCount,
 		/// boutons Suppr par ligne + bouton « Ajouter une étape » en fin de
@@ -116,6 +126,7 @@ namespace engine::editor::world::panels
 		char m_giverBuf[64] = "";
 		char m_turnInBuf[64] = "";
 		std::vector<std::string> m_prereqBuffer;
+		std::vector<std::string> m_excludesBuffer; // EXT-1 : quêtes mutuellement exclusives
 
 		std::vector<engine::editor::world::quests::EditedStep> m_stepsBuffer;
 		uint32_t m_rewardXpBuffer = 0;

--- a/src/world_editor/quests/QuestEditIo.cpp
+++ b/src/world_editor/quests/QuestEditIo.cpp
@@ -594,6 +594,30 @@ namespace engine::editor::world::quests
 				}
 			}
 
+			// EXT-1 : champ `excludes` OPTIONNEL (quêtes mutuellement exclusives),
+			// miroir exact du bloc `prereqs` ci-dessus. Absent = OK (rétro-compat) ;
+			// la validation d'existence / anti-auto-exclusion est faite dans Validate.
+			if (const JsonValue* excludesValue = FindObjectMember(questValue, "excludes");
+				excludesValue != nullptr)
+			{
+				if (excludesValue->type != JsonType::Array)
+				{
+					outError = "quest '" + quest.id + "': excludes must be an array";
+					return false;
+				}
+
+				for (const JsonValue& excludeValue : excludesValue->arrayValue)
+				{
+					if (excludeValue.type != JsonType::String || excludeValue.stringValue.empty())
+					{
+						outError = "quest '" + quest.id + "': excludes entry must be a non-empty string";
+						return false;
+					}
+
+					quest.excludes.push_back(excludeValue.stringValue);
+				}
+			}
+
 			const JsonValue* stepsValue = FindObjectMember(questValue, "steps");
 			if (stepsValue == nullptr || stepsValue->type != JsonType::Array || stepsValue->arrayValue.empty())
 			{
@@ -792,7 +816,7 @@ namespace engine::editor::world::quests
 		}
 
 		/// Sérialise une quête éditée complète (`{id, giver, turnIn, prereqs,
-		/// steps, rewards}`) en JSON pur, tableau, indentée à \p indent espaces
+		/// excludes, steps, rewards}`) en JSON pur, tableau, indentée à \p indent espaces
 		/// (élément de `quests[]` dans `quest_definitions.json`).
 		std::string SerializeQuestDefinition(const EditedQuest& quest, int indent)
 		{
@@ -808,6 +832,15 @@ namespace engine::editor::world::quests
 			for (size_t i = 0; i < quest.prereqs.size(); ++i)
 			{
 				os << (i == 0 ? "" : ", ") << "\"" << JsonEscape(quest.prereqs[i]) << "\"";
+			}
+			os << "],\n";
+
+			// EXT-1 : `excludes` sérialisé à l'identique de `prereqs` — tableau
+			// TOUJOURS émis (vide -> `[]`), JSON pur relisible par le shard.
+			os << fieldPad << "\"excludes\": [";
+			for (size_t i = 0; i < quest.excludes.size(); ++i)
+			{
+				os << (i == 0 ? "" : ", ") << "\"" << JsonEscape(quest.excludes[i]) << "\"";
 			}
 			os << "],\n";
 
@@ -1075,6 +1108,22 @@ namespace engine::editor::world::quests
 				if (byId.find(prereqId) == byId.end())
 				{
 					outErrors.push_back("quête '" + label + "': prereq '" + prereqId + "' introuvable dans l'ensemble");
+				}
+			}
+
+			// EXT-1 : chaque `exclude` doit exister dans l'ensemble (dangling ->
+			// erreur, même politique que les prereqs) et ne peut pas viser la
+			// quête elle-même (auto-exclusion interdite). PAS de détection de
+			// cycle : l'exclusion mutuelle A<->B est autorisée.
+			for (const std::string& excludeId : quest.excludes)
+			{
+				if (excludeId == quest.id)
+				{
+					outErrors.push_back("quête '" + label + "': ne peut pas s'exclure elle-même ('" + excludeId + "')");
+				}
+				else if (byId.find(excludeId) == byId.end())
+				{
+					outErrors.push_back("quête '" + label + "': exclude '" + excludeId + "' introuvable dans l'ensemble");
 				}
 			}
 

--- a/src/world_editor/quests/QuestEditIo.h
+++ b/src/world_editor/quests/QuestEditIo.h
@@ -32,6 +32,12 @@ namespace engine::editor::world::quests
 		std::string giver;
 		std::string turnIn;
 		std::vector<std::string> prereqs;
+		/// Quêtes mutuellement exclusives (EXT-1) : s'engager dans cette quête
+		/// rend indisponibles celles listées ici (et réciproquement, l'exclusion
+		/// étant symétrique au runtime shard). Champ optionnel — absent = aucune
+		/// exclusion. N'introduit AUCUNE contrainte d'acyclicité (contrairement à
+		/// `prereqs`) : deux quêtes peuvent s'exclure mutuellement.
+		std::vector<std::string> excludes;
 		std::vector<EditedStep> steps;
 		uint32_t rewardXp = 0;
 		uint32_t rewardGold = 0;
@@ -78,7 +84,9 @@ namespace engine::editor::world::quests
 		/// Valide l'ensemble de quêtes éditées : unicité des `id`, non-vacuité
 		/// de `giver`/`turnIn`, formes des étapes (`type` connu, `target` non
 		/// vide, `requiredCount` ≥ 1), existence des `prereqs` référencés dans
-		/// l'ensemble, absence de cycle dans le graphe `prereqs`, et formes des
+		/// l'ensemble, absence de cycle dans le graphe `prereqs`, existence des
+		/// `excludes` référencés + interdiction de l'auto-exclusion (`id` dans
+		/// son propre `excludes`) SANS contrainte d'acyclicité, et formes des
 		/// items de récompense (`itemId` > 0, `quantity` ≥ 1).
 		///
 		/// Pure : aucune E/S, aucun état modifié (ni sur `this`, ni global) ;

--- a/src/world_editor/quests/QuestEditIoTests.cpp
+++ b/src/world_editor/quests/QuestEditIoTests.cpp
@@ -137,6 +137,9 @@ namespace
 		scout.giver = "npc:scout";
 		scout.turnIn = "npc:scout";
 		scout.prereqs.push_back("kill_10_boars");
+		// Exclusion mutuelle (structurelle) exercee par le round-trip : scout
+		// exclut boars (id existant, != scout) -> parse -> serialize -> parse.
+		scout.excludes.push_back("kill_10_boars");
 		EditedStep talkStep;
 		talkStep.type = "talk";
 		talkStep.target = "npc:scout";
@@ -296,6 +299,43 @@ int main()
 		Check(!errors.empty(), "Validate: étape target vide -> au moins 1 erreur");
 	}
 
+	// (k) excludes vers un id existant -> valide (pas de contrainte d'acyclicite :
+	// une exclusion mutuelle declaree dans les deux sens reste valide).
+	{
+		EditedQuest questA = MakeValidQuest("quest_excl_a");
+		EditedQuest questB = MakeValidQuest("quest_excl_b");
+		questA.excludes.push_back("quest_excl_b");
+		questB.excludes.push_back("quest_excl_a");
+		std::vector<EditedQuest> quests = { questA, questB };
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(ok, "Validate: excludes mutuel (A<->B) -> true (pas de cycle-check)");
+		Check(errors.empty(), "Validate: excludes mutuel -> 0 erreur");
+	}
+
+	// (l) auto-exclusion (id dans son propre excludes) -> false.
+	{
+		std::vector<EditedQuest> quests = { MakeValidQuest("quest_self_excl") };
+		quests[0].excludes.push_back("quest_self_excl");
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(!ok, "Validate: auto-exclusion -> false");
+		Check(!errors.empty(), "Validate: auto-exclusion -> au moins 1 erreur");
+	}
+
+	// (m) excludes vers un id inexistant (dangling) -> false.
+	{
+		std::vector<EditedQuest> quests = { MakeValidQuest("quest_m") };
+		quests[0].excludes.push_back("inconnu");
+
+		std::vector<std::string> errors;
+		const bool ok = io.Validate(quests, errors);
+		Check(!ok, "Validate: exclude dangling -> false");
+		Check(!errors.empty(), "Validate: exclude dangling -> au moins 1 erreur");
+	}
+
 	// --- QuestEditIo::Save ---------------------------------------------------
 
 	// (h) round-trip Save -> Load : égalité structurelle id/giver/turnIn/steps/
@@ -336,6 +376,7 @@ int main()
 			Check(found->giver == orig.giver, (label + ": giver identique").c_str());
 			Check(found->turnIn == orig.turnIn, (label + ": turnIn identique").c_str());
 			Check(found->prereqs == orig.prereqs, (label + ": prereqs identiques").c_str());
+			Check(found->excludes == orig.excludes, (label + ": excludes identiques").c_str());
 			Check(found->steps.size() == orig.steps.size(), (label + ": nombre d'étapes identique").c_str());
 			for (size_t i = 0; i < orig.steps.size() && i < found->steps.size(); ++i)
 			{


### PR DESCRIPTION
## Objectif

Ajoute un champ **optionnel** `excludes: [questId,…]` aux définitions de quête (système B, shard). S'**engager** dans une quête rend indisponibles les quêtes qu'elle exclut — et **réciproquement**. Sert aux **choix de faction** et aux **embranchements narratifs mutuellement exclusifs** (contre-quêtes).

Première des 3 extensions demandées (EXT-1 exclusion → EXT-2 répétables → EXT-3 groupe/raid).

## Sémantique

- **« Engagée »** = statut ∈ `{Active, ReadyToTurnIn, Completed}`. Le statut `Offered` **ne bloque pas** : on peut se voir proposer deux quêtes exclusives ; **accepter** l'une verrouille l'autre.
- **Exclusion symétrique au runtime** (`QuestRuntime::IsBlockedByExclusion`) : déclarer l'exclusion d'un seul côté (A exclut B) bloque **les deux** quêtes. Le GM déclare une fois.
- **100 % serveur** : une quête exclue reste `Locked`, n'apparaît ni au journal ni dans la giver-list. Le client ne voit que le statut résultant via `QuestDelta` → **aucun changement de wire**.

## Contenu

**Shard** (`e77b806c`) :
- `QuestDefinition::excludedQuestIds` + parse `"excludes"` (optionnel, miroir de `prereqs`, rétro-compatible).
- `IsBlockedByExclusion` (symétrique) + `IsQuestEngaged` (statut engagé).
- **Deux gates** : offer-sync (`SyncQuestStates` garde la quête exclue `Locked`) + accept (`ServerApp::HandleAcceptQuest` re-vérifie atomiquement, ferme la course où deux quêtes exclusives sont `Offered` simultanément).
- 5 cas de test (`QuestRuntimeTests`), non-strippables.

**Éditeur** (`f1fe1ba8`) :
- `EditedQuest::excludes` + parse/sérialisation `"excludes"` (`quest_definitions.json` reste JSON pur relisible par le shard, `excludes:[]` émis comme `prereqs`).
- **Validation** : ids existants + **anti-auto-exclusion** ; **pas** de cycle-check (l'exclusion mutuelle A↔B est licite).
- `QuestEditorPanel::RenderExcludesSection` (cases à cocher, masque la quête courante, `PushID` anti-collision ImGui) + plumbing Load/Save/Reset.
- Round-trip + rejets testés (`quest_edit_io_tests`). Règle doc `///` (CLAUDE.md) respectée.

**Docs** (`cd55e8d8`, `39...`) : `CODEBASE_MAP.md` (section Quêtes + Validate éditeur), spec+plan (`docs/superpowers/*-quest-ext1-*`).

## Vérifications
- Revue shard : *READY — no issues* (compile-safety, deux gates, symétrie, parse rétro-compat, tests non-strippables).
- Revue finale éditeur : *READY TO MERGE* (compile-safety, ImGui `PushID`/`PopID` équilibrés, validation, sérialisation shard-parseable, CMake `engine_core` intact, doc `///`).
- Scope : shard = 0 fichier client/wire ; éditeur = 0 fichier shard/client/wire.

## Déploiement

> **⚠️ REDÉPLOIEMENT SHARD requis** — `QuestRuntime` charge et évalue `excludes` au boot et à chaque `SyncQuestStates`. **Client inchangé** (aucun wire). Éditeur = outillage (restart shard pour charger le contenu créé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)