### PR TITLE
fix(security): corrections P0/P1 de l'audit 2026-07-03 (F1-F9, F7 différé)

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,6 +14,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      - name: Vérifier la parité des migrations Docker (audit F1)
+        run: |
+          set -e
+          miss=0
+          for f in sql/migrations/*.sql; do
+            b=$(basename "$f")
+            if ! diff -q "$f" "deploy/docker/sql/migrations/$b" >/dev/null 2>&1; then
+              echo "::error::Migration désynchronisée: $b (lancez scripts/sync-db-to-docker-deploy.sh)"
+              miss=1
+            fi
+          done
+          exit $miss
+
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,6 +798,8 @@ add_library(engine_core
   src/shared/network/TradePayloads.cpp
   src/shared/network/ShardPayloads.cpp
   src/shared/network/TermsPayloads.cpp
+  # Audit F3 : tag HMAC-SHA256 préfixe authentifiant SHARD_REGISTER/HEARTBEAT.
+  src/shared/network/ShardWireAuth.cpp
 )
 # Shared gameplay wire codec (Encode*/Decode*); linked into client — must not be server-only.
 target_sources(engine_core PRIVATE src/shared/network/ServerProtocol.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -800,6 +800,8 @@ add_library(engine_core
   src/shared/network/TermsPayloads.cpp
   # Audit F3 : tag HMAC-SHA256 préfixe authentifiant SHARD_REGISTER/HEARTBEAT.
   src/shared/network/ShardWireAuth.cpp
+  # Audit F6 : refus au boot d'un secret HMAC partagé faible/par défaut.
+  src/shared/security/SharedSecretPolicy.cpp
 )
 # Shared gameplay wire codec (Encode*/Decode*); linked into client — must not be server-only.
 target_sources(engine_core PRIVATE src/shared/network/ServerProtocol.cpp)

--- a/deploy/docker/config/master.config.json
+++ b/deploy/docker/config/master.config.json
@@ -7,7 +7,7 @@
   "shard": {
     "heartbeat_timeout_sec": 90,
     "ticket_validity_sec": 60,
-    "ticket_hmac_secret": "dev_secret_change_in_production"
+    "ticket_hmac_secret": ""
   },
   "log": {
     "level": "info",

--- a/deploy/docker/config/shard.config.json
+++ b/deploy/docker/config/shard.config.json
@@ -6,7 +6,7 @@
   },
   "shard": {
     "id": 1,
-    "ticket_hmac_secret": "dev_secret_change_in_production",
+    "ticket_hmac_secret": "",
     "heartbeat_interval_sec": 10,
     "master": {
       "host": "master",

--- a/deploy/docker/server-config/config.json
+++ b/deploy/docker/server-config/config.json
@@ -18,7 +18,7 @@
   "shard": {
     "heartbeat_timeout_sec": 90,
     "ticket_validity_sec": 60,
-    "ticket_hmac_secret": "dev_secret_change_in_production",
+    "ticket_hmac_secret": "",
     "degraded_load_threshold": 0.90
   },
 

--- a/deploy/docker/sql/migrations/0043_phase_1c_account_roles.sql
+++ b/deploy/docker/sql/migrations/0043_phase_1c_account_roles.sql
@@ -5,6 +5,29 @@
 
 SET NAMES utf8mb4;
 
+-- 0) Garantir l'existence de la colonne `role`. Selon lequel des deux fichiers
+--    0023 a été appliqué (doublon de numéro, cf. MigrationRunner + 0066), la
+--    colonne peut ne PAS exister ici : 0023_accounts_profile.sql la crée, mais
+--    0023_accounts_profile_fields.sql non, et 0066 (qui comble le manque) tourne
+--    APRÈS 0043. Sans cette garde, l'UPDATE en (2) échoue avec
+--    « Unknown column 'role' » et le master boucle au boot. On la crée au format
+--    binaire historique ('player','admin') ; l'étape (1) l'étendra ensuite.
+SET @m43_c0 := (
+  SELECT COUNT(*)
+  FROM information_schema.columns
+  WHERE table_schema = DATABASE()
+    AND table_name   = 'accounts'
+    AND column_name  = 'role'
+);
+SET @m43_s0 := IF(@m43_c0 = 0,
+  'ALTER TABLE accounts ADD COLUMN role '
+  'ENUM(''player'',''admin'') NOT NULL DEFAULT ''player'' '
+  'COMMENT ''Role du compte (sera etendu par 0043)''',
+  'SELECT 1');
+PREPARE m43_p0 FROM @m43_s0;
+EXECUTE m43_p0;
+DEALLOCATE PREPARE m43_p0;
+
 -- 1) Vérifier l'état actuel de la colonne `role` et étendre l'ENUM si
 --    elle est encore au format binaire ('player','admin').
 

--- a/deploy/docker/sql/migrations/0050_auction_listings.sql
+++ b/deploy/docker/sql/migrations/0050_auction_listings.sql
@@ -1,0 +1,34 @@
+-- 0050 - Wave 5 Persistence AuctionHouse (Phase 5.09b) : table
+-- auction_listings_v2 pour la nouvelle generation de listings posees
+-- par les handlers wire master (Phase 5.09b). La table 0013_auction_listings
+-- est conservee pour l'ancien schema legacy ; ce migration ajoute une
+-- nouvelle table avec un schema enrichi (item_name, owner_name,
+-- highest_bidder_name, ended/won_by_buyout flags) au lieu de l'etendre
+-- afin de preserver la coherence des deploiements deja partis.
+-- Idempotent.
+--
+-- expires_at_unix_ms : ms epoch system_clock (le runtime gere un
+-- steady_clock derive ; la persistance utilise wallclock pour survivre
+-- au reboot). ended = 1 quand l'auction est cloturee (buyout / cancel /
+-- scan ScanExpired) ; won_by_buyout = 1 seulement si le ended provient
+-- d'un buyout immediat.
+
+CREATE TABLE IF NOT EXISTS auction_listings_v2 (
+    auction_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    item_template_id INT UNSIGNED NOT NULL,
+    item_name VARCHAR(128) NOT NULL,
+    count INT UNSIGNED NOT NULL DEFAULT 1,
+    start_bid_copper BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    current_bid_copper BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    buyout_copper BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    owner_account_id BIGINT UNSIGNED NOT NULL,
+    owner_name VARCHAR(64) NOT NULL,
+    highest_bidder_account_id BIGINT UNSIGNED NULL,
+    highest_bidder_name VARCHAR(64) NULL,
+    expires_at_unix_ms BIGINT UNSIGNED NOT NULL,
+    ended TINYINT(1) NOT NULL DEFAULT 0,
+    won_by_buyout TINYINT(1) NOT NULL DEFAULT 0,
+    INDEX idx_owner (owner_account_id),
+    INDEX idx_expires (expires_at_unix_ms),
+    INDEX idx_ended (ended)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0051_game_events.sql
+++ b/deploy/docker/sql/migrations/0051_game_events.sql
@@ -1,0 +1,35 @@
+-- 0051 - Wave 5 Persistence GameEvents (Phase 5.31b) : table game_events
+-- pour persister la definition des events saisonniers (Halloween, Winter
+-- Veil, etc.). Au boot, le master prefere charger depuis la DB plutot
+-- que le seed hardcode. Si la table est vide ou la DB indisponible, le
+-- seed in-memory du handler s'applique (fallback degrade).
+--
+-- duration_ms / recur_ms : 0 = one-shot / pas de recurrence.
+-- requires_lunar_phase_mask : bitmask 16 bits (0xFFFF = pas de gate).
+--
+-- Le seed V1 est insere via INSERT IGNORE pour rester idempotent : les
+-- ids 1..5 correspondent aux 5 events seedees par SeedV1Events du
+-- GameEventHandler (Halloween, Winter Veil, Lunar Festival, Midsummer
+-- Fire, Nuit de la Lune Noire).
+
+CREATE TABLE IF NOT EXISTS game_events (
+    event_id INT UNSIGNED NOT NULL PRIMARY KEY,
+    name VARCHAR(128) NOT NULL,
+    start_ts_ms BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    duration_ms BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    recur_ms BIGINT UNSIGNED NOT NULL DEFAULT 0,
+    requires_lunar_phase_mask SMALLINT UNSIGNED NOT NULL DEFAULT 65535
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed V1 (5 events). INSERT IGNORE : idempotent sur re-application de
+-- la migration. Les valeurs sont identiques aux constantes hardcodees
+-- dans GameEventHandler::SeedV1Events ; si la DB est vide (table cree
+-- mais pas seedee), le handler fallback sur son seed in-memory.
+INSERT IGNORE INTO game_events
+    (event_id, name, start_ts_ms, duration_ms, recur_ms, requires_lunar_phase_mask)
+VALUES
+    (1, 'Halloween',               1791849600000, 1209600000,  31536000000, 65535),
+    (2, 'Winter Veil',              1797206400000, 1814400000,  31536000000, 65535),
+    (3, 'Lunar Festival',           1769817600000, 1209600000,  31536000000, 65535),
+    (4, 'Midsummer Fire Festival',  1781913600000, 1209600000,  31536000000, 65535),
+    (5, 'Nuit de la Lune Noire',    0,             9223372036854775807, 0, 49153);

--- a/deploy/docker/sql/migrations/0052_arena_teams.sql
+++ b/deploy/docker/sql/migrations/0052_arena_teams.sql
@@ -1,0 +1,27 @@
+-- 0052 - Wave 5 Persistence Arena (Phase 5.21b) : table arena_teams
+-- pour persister la progression ELO + stats hebdo/saison des teams
+-- arene. Idempotent.
+--
+-- account_id_owner : compte qui a cree l'equipe. team_id reste un
+-- identifiant logique partage par tous les players V1 (le seed
+-- starter du handler reutilise les ids 1/2/3 pour 2v2/3v3/5v5
+-- indistinctement). En sub-PR future on basculera vers une cle
+-- composite (account_id_owner, local_team_id) ou un team_id global
+-- AUTO_INCREMENT pour eviter la collision inter-account.
+--
+-- size : 2 / 3 / 5 (mode arena). rating : ELO courant.
+
+CREATE TABLE IF NOT EXISTS arena_teams (
+    team_id INT UNSIGNED NOT NULL,
+    account_id_owner BIGINT UNSIGNED NOT NULL,
+    name VARCHAR(64) NOT NULL,
+    size TINYINT UNSIGNED NOT NULL,
+    rating INT UNSIGNED NOT NULL DEFAULT 1500,
+    weekly_games INT UNSIGNED NOT NULL DEFAULT 0,
+    weekly_wins INT UNSIGNED NOT NULL DEFAULT 0,
+    season_games INT UNSIGNED NOT NULL DEFAULT 0,
+    season_wins INT UNSIGNED NOT NULL DEFAULT 0,
+    PRIMARY KEY (account_id_owner, team_id),
+    INDEX idx_team_size (size),
+    INDEX idx_rating (rating)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0053_character_skills.sql
+++ b/deploy/docker/sql/migrations/0053_character_skills.sql
@@ -1,0 +1,24 @@
+-- 0053 - Wave 5 Persistence Skills (Phase 4.39b) : table character_skills
+-- pour persister la progression per-character (V1 cle = account_id en
+-- attendant le multi-character full ; sub-PR future bascule vers
+-- character_id quand le CharacterStore sera branche). Idempotent.
+--
+-- value : valeur courante du skill (0..cap). cap : plafond apprenable.
+-- bonus : modifier temporaire (item bonus, buff). Le runtime applique
+-- value clamp cap a chaque update via le handler.
+--
+-- Note V1 : le handler in-memory n'expose pas character_id (le master
+-- raisonne par account). On enregistre donc account_id dans la colonne
+-- character_id pour minimiser le refactor. Le rename de la colonne
+-- arrivera quand le CharacterStore sera cable (sub-PR Wave 6).
+
+CREATE TABLE IF NOT EXISTS character_skills (
+    character_id BIGINT UNSIGNED NOT NULL,
+    skill_id INT UNSIGNED NOT NULL,
+    value INT UNSIGNED NOT NULL DEFAULT 0,
+    cap INT UNSIGNED NOT NULL DEFAULT 75,
+    bonus INT UNSIGNED NOT NULL DEFAULT 0,
+    PRIMARY KEY (character_id, skill_id),
+    INDEX idx_character (character_id),
+    INDEX idx_skill (skill_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0054_outdoor_pvp_state.sql
+++ b/deploy/docker/sql/migrations/0054_outdoor_pvp_state.sql
@@ -1,0 +1,25 @@
+-- 0054 - Wave 5 Persistence OutdoorPvP (Phase 5.36b) : table
+-- outdoor_pvp_state pour persister l'etat des objectifs par zone et
+-- les scores Alliance/Horde. Idempotent.
+--
+-- (zone_id, objective_id) compose la cle primaire ; les scores par
+-- faction sont stockes dans une table side outdoor_pvp_scores.
+-- owner = 0 (Alliance), 1 (Horde), 0xFF (neutre) ; capturePct 0..100 ;
+-- capturing_by = faction qui progresse (0xFF si aucune).
+
+CREATE TABLE IF NOT EXISTS outdoor_pvp_state (
+    zone_id INT UNSIGNED NOT NULL,
+    objective_id INT UNSIGNED NOT NULL,
+    owner TINYINT UNSIGNED NOT NULL DEFAULT 255,
+    capture_pct INT UNSIGNED NOT NULL DEFAULT 0,
+    capturing_by TINYINT UNSIGNED NOT NULL DEFAULT 255,
+    PRIMARY KEY (zone_id, objective_id),
+    INDEX idx_zone (zone_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS outdoor_pvp_scores (
+    zone_id INT UNSIGNED NOT NULL,
+    faction TINYINT UNSIGNED NOT NULL,
+    score INT UNSIGNED NOT NULL DEFAULT 0,
+    PRIMARY KEY (zone_id, faction)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0055_guilds_master.sql
+++ b/deploy/docker/sql/migrations/0055_guilds_master.sql
@@ -1,0 +1,101 @@
+-- 0055 - Wave 5 Persistence Guilds (Phase 5.21b) : tables guilds_master,
+-- guild_members_v2 et guild_bank pour persister la definition des guildes
+-- V1 (2 guildes hardcodees + leurs membres + bank tab 0). Au boot, le
+-- master prefere charger depuis la DB plutot que le seed hardcode dans
+-- GuildHandler::SeedV1Guilds. Si la table est vide ou la DB indisponible,
+-- le seed in-memory s'applique (fallback degrade).
+--
+-- guilds_master :
+--   - guild_id : auto-increment PK. V1 ids 1..2 reserves au seed.
+--   - leader_account_id : pointe sur accounts.account_id (mais pas de
+--     FK ici, on garde la table autonome pour permettre des seeds
+--     decorelles des accounts reels).
+--   - created_at_unix_ms : timestamp creation pour l'audit.
+--
+-- guild_members_v2 :
+--   - cle composite (guild_id, account_id) : un account ne peut etre
+--     que dans une seule guilde a la fois (regle V1).
+--   - rank_id : 0=Guild Master .. 9=Initiate, defaut 5=Member.
+--
+-- guild_bank :
+--   - bank tab 0 only en V1 (tab_index hardcode a 0 dans le seed mais
+--     la colonne est presente pour preparer V2).
+--   - cle composite (guild_id, tab_index, slot_index) : un slot ne peut
+--     contenir qu'un item type a la fois (stack au niveau du count).
+--
+-- Le seed V1 est insere via INSERT IGNORE pour rester idempotent.
+-- Les 2 guildes "Les Gardiens" (id=1) et "L Ombre" (id=2, sans
+-- apostrophe car ASCII safe MSVC) correspondent au seed hardcode de
+-- GuildHandler::SeedV1Guilds. Les noms de membres sont stockes via
+-- account_id (1=Garond, 2=Mirelle, 3=Tobrek, 4=Pernel, 5=Sylvane,
+-- 6=Verlin) -- la resolution accountId -> name reste cote handler
+-- (V1 lookup en memoire jusqu'a integration AccountStore).
+
+CREATE TABLE IF NOT EXISTS guilds_master (
+    guild_id            INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name                VARCHAR(64) NOT NULL,
+    motd                VARCHAR(256) NOT NULL DEFAULT '',
+    leader_account_id   BIGINT UNSIGNED NOT NULL,
+    created_at_unix_ms  BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (guild_id),
+    UNIQUE KEY uk_guild_name (name),
+    KEY idx_leader (leader_account_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS guild_members_v2 (
+    guild_id           INT UNSIGNED NOT NULL,
+    account_id         BIGINT UNSIGNED NOT NULL,
+    rank_id            TINYINT UNSIGNED NOT NULL DEFAULT 5,
+    joined_at_unix_ms  BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (guild_id, account_id),
+    KEY idx_account (account_id),
+    CONSTRAINT fk_guild_members_v2_guild FOREIGN KEY (guild_id)
+        REFERENCES guilds_master(guild_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS guild_bank (
+    guild_id           INT UNSIGNED NOT NULL,
+    tab_index          TINYINT UNSIGNED NOT NULL DEFAULT 0,
+    slot_index         INT UNSIGNED NOT NULL,
+    item_template_id   INT UNSIGNED NOT NULL,
+    item_name          VARCHAR(128) NOT NULL,
+    count              INT UNSIGNED NOT NULL DEFAULT 1,
+    PRIMARY KEY (guild_id, tab_index, slot_index),
+    CONSTRAINT fk_guild_bank_guild FOREIGN KEY (guild_id)
+        REFERENCES guilds_master(guild_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed V1 : 2 guildes + 6 membres + 7 items bank. INSERT IGNORE rend
+-- la migration idempotente (re-application = no-op si dej seedee).
+-- Les timestamps created_at_unix_ms / joined_at_unix_ms sont fixes a
+-- 1767225600000 (2025-12-31 19:00:00 UTC) pour donner un repere
+-- stable a travers les redeploys (corresponds approximativement a
+-- la mise en service V1 alpha).
+
+INSERT IGNORE INTO guilds_master (guild_id, name, motd, leader_account_id, created_at_unix_ms) VALUES
+    (1, 'Les Gardiens', 'Soyez courageux',     1, 1767225600000),
+    (2, 'L Ombre',      'Le pouvoir est tout', 5, 1767225600000);
+
+-- account_id mapping V1 (resolu cote handler via lookup local) :
+--   1=Garond (GM), 2=Mirelle (Officer), 3=Tobrek (Member), 4=Pernel (Initiate)
+--   5=Sylvane (GM), 6=Verlin (Member)
+INSERT IGNORE INTO guild_members_v2 (guild_id, account_id, rank_id, joined_at_unix_ms) VALUES
+    (1, 1, 0, 1767225600000),
+    (1, 2, 1, 1767225600000),
+    (1, 3, 5, 1767225600000),
+    (1, 4, 9, 1767225600000),
+    (2, 5, 0, 1767225600000),
+    (2, 6, 5, 1767225600000);
+
+-- Bank tab 0 : 5 items pour Les Gardiens, 2 items pour L Ombre.
+-- itemTemplateId V1 : 1=Minerai de fer, 2=Toile de lin, 3=Tissu mage,
+-- 4=Potion de soin, 5=Potion de mana, 6=Toile noire, 7=Eclat d'ame.
+-- (Aligne sur le seed in-memory hardcode de SeedV1Guilds.)
+INSERT IGNORE INTO guild_bank (guild_id, tab_index, slot_index, item_template_id, item_name, count) VALUES
+    (1, 0, 0, 1, 'Minerai de fer',  100),
+    (1, 0, 1, 2, 'Toile de lin',    250),
+    (1, 0, 2, 3, 'Tissu mage',      80),
+    (1, 0, 3, 4, 'Potion de soin',  30),
+    (1, 0, 4, 5, 'Potion de mana',  20),
+    (2, 0, 0, 6, 'Toile noire',     50),
+    (2, 0, 1, 7, 'Eclat d''ame',    10);

--- a/deploy/docker/sql/migrations/0056_bg_history.sql
+++ b/deploy/docker/sql/migrations/0056_bg_history.sql
@@ -1,0 +1,30 @@
+-- 0056 - Wave 5 Persistence BattleGround (Phase 5.10b) : table
+-- bg_match_history pour persister les resultats de matchs joues. Le
+-- BattleGroundHandler insere une ligne via MysqlBattleGroundStore::InsertMatch
+-- a chaque MatchEnd push. Read API LoadRecent(limit) est expose pour
+-- de futures UI leaderboard / stats (out-of-scope de cette PR cote
+-- wire / opcode).
+--
+-- match_id : auto-increment, sert d'identifiant unique persistant
+-- (distinct du matchId in-memory atomic compteur qui reset au reboot).
+-- bg_type : 1=Gorge de Feyhin, 2=Bassin des Ombres, 3=Vallee Gelee V1.
+-- winner_faction : 0=Alliance, 1=Horde, 2=Draw.
+-- started_at_unix_ms : timestamp de creation du match (avant Push Start).
+-- duration_sec : duree totale entre Start et End push.
+--
+-- Pas de seed : la table reste vide jusqu'au premier MatchEnd execute
+-- par le handler. Une DB vide est un etat valide (premier boot).
+
+CREATE TABLE IF NOT EXISTS bg_match_history (
+    match_id            BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    bg_type             SMALLINT UNSIGNED NOT NULL,
+    map_name            VARCHAR(64) NOT NULL,
+    alliance_score      INT UNSIGNED NOT NULL DEFAULT 0,
+    horde_score         INT UNSIGNED NOT NULL DEFAULT 0,
+    winner_faction      TINYINT UNSIGNED NOT NULL DEFAULT 2,
+    duration_sec        INT UNSIGNED NOT NULL DEFAULT 0,
+    started_at_unix_ms  BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (match_id),
+    KEY idx_started (started_at_unix_ms),
+    KEY idx_bg_type (bg_type)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0057_loot_tables.sql
+++ b/deploy/docker/sql/migrations/0057_loot_tables.sql
@@ -1,0 +1,57 @@
+-- 0057 - Wave 5 Persistence Loot (Phase 3.17b) : tables loot_tables +
+-- loot_table_entries pour persister la definition des tables de loot
+-- V1 (loup_base, lapin_base). Pattern similaire a game_events :
+-- seed via INSERT IGNORE, lecture read-only au boot par le
+-- LootHandler (qui utilise actuellement un tableau hardcode 5 items).
+--
+-- loot_tables :
+--   - table_id : auto-increment PK. V1 ids 1..2 reserves au seed.
+--   - name : identifiant logique unique (loup_base, lapin_base, ...).
+--
+-- loot_table_entries :
+--   - drop_chance_pct : 0..100, probabilite que l'item drop (V1 simple).
+--   - min_count / max_count : range de quantites possibles. min<=max.
+--   - cle composite (entry_id) auto-increment pour pouvoir insere
+--     plusieurs items du meme template_id dans une meme table.
+--
+-- Pas de UNIQUE sur (table_id, item_template_id) volontairement : il
+-- est legitime d'avoir 2 entrees pour le meme item avec des drop_chance
+-- distinctes (ex. drop pity vs drop bonus).
+
+CREATE TABLE IF NOT EXISTS loot_tables (
+    table_id     INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    name         VARCHAR(64) NOT NULL,
+    description  VARCHAR(256) NOT NULL DEFAULT '',
+    PRIMARY KEY (table_id),
+    UNIQUE KEY uk_loot_table_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS loot_table_entries (
+    entry_id           INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    table_id           INT UNSIGNED NOT NULL,
+    item_template_id   INT UNSIGNED NOT NULL,
+    item_name          VARCHAR(128) NOT NULL,
+    drop_chance_pct    INT UNSIGNED NOT NULL DEFAULT 100,
+    min_count          INT UNSIGNED NOT NULL DEFAULT 1,
+    max_count          INT UNSIGNED NOT NULL DEFAULT 1,
+    PRIMARY KEY (entry_id),
+    KEY idx_table (table_id),
+    CONSTRAINT fk_loot_entries_table FOREIGN KEY (table_id)
+        REFERENCES loot_tables(table_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Seed V1 : 2 tables de base (loup_base + lapin_base) avec 3 entries
+-- au total. INSERT IGNORE rend la migration idempotente.
+INSERT IGNORE INTO loot_tables (table_id, name, description) VALUES
+    (1, 'loup_base',   'Butin standard de loup'),
+    (2, 'lapin_base',  'Butin standard de lapin');
+
+-- entry_id explicite pour le seed (sinon AUTO_INCREMENT mais on prefere
+-- des ids stables a travers les re-applications).
+-- Note : item_template_id 1 = Peau de loup (pas Minerai de fer : on suppose
+-- qu'a partir de la table loot_tables le master peut potentiellement
+-- avoir des noms d'items disjoints du LootHandler hardcode 1..5 actuel).
+INSERT IGNORE INTO loot_table_entries (entry_id, table_id, item_template_id, item_name, drop_chance_pct, min_count, max_count) VALUES
+    (1, 1, 1,   'Peau de loup',    80, 1, 2),
+    (2, 1, 100, 'Potion de soin',  10, 1, 1),
+    (3, 2, 2,   'Patte de lapin',  95, 1, 1);

--- a/deploy/docker/sql/migrations/0058_cinematic_seen.sql
+++ b/deploy/docker/sql/migrations/0058_cinematic_seen.sql
@@ -1,0 +1,11 @@
+-- 0058 - Wave 11 Persistence Cinematics : table cinematic_seen pour tracker
+-- les cutscenes deja vues par un account (evite de rejouer l'intro a chaque
+-- login). Cle composite (account_id, sequence_id).
+
+CREATE TABLE IF NOT EXISTS cinematic_seen (
+    account_id         BIGINT UNSIGNED NOT NULL,
+    sequence_id        INT UNSIGNED    NOT NULL,
+    first_seen_ts_ms   BIGINT UNSIGNED NOT NULL,
+    PRIMARY KEY (account_id, sequence_id),
+    KEY idx_account (account_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0059_pool_extensions.sql
+++ b/deploy/docker/sql/migrations/0059_pool_extensions.sql
@@ -1,0 +1,37 @@
+-- 0059 — Wave 20 Pool extensions : nested pools (table pool_pool) +
+-- runtime state persistence (table pool_member_state).
+--
+-- Idempotente : CREATE TABLE IF NOT EXISTS. Rejouable sans erreur.
+
+-- Table pool_pool : permet a un pool d'avoir des sous-pools comme entries.
+-- Quand RollImpl tire un entry "nested", il recurse dans le child_pool_id.
+-- Cycle detection cote moteur (PoolManager.h), pas au niveau DB.
+CREATE TABLE IF NOT EXISTS pool_pool
+(
+	parent_pool_id  INT UNSIGNED NOT NULL,
+	child_pool_id   INT UNSIGNED NOT NULL,
+	weight          FLOAT NOT NULL DEFAULT 1.0,
+	PRIMARY KEY (parent_pool_id, child_pool_id),
+	-- Index inverse pour query "quels parents pointent vers ce pool ?"
+	-- (utile lors d'un cleanup/refactor de la hierarchie).
+	KEY idx_pool_pool_child (child_pool_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table pool_member_state : etat runtime persiste des membres d'une pool.
+-- Permet de survivre a un reboot shard sans tout re-roller (les rare
+-- spawns deja kill restent dead jusqu'a leur respawn_at).
+CREATE TABLE IF NOT EXISTS pool_member_state
+(
+	pool_id        INT UNSIGNED NOT NULL,
+	spawn_id       INT UNSIGNED NOT NULL,
+	status         TINYINT UNSIGNED NOT NULL DEFAULT 0,  -- 0=Alive, 1=Dead, 2=Respawning
+	respawn_at_sec BIGINT NOT NULL DEFAULT 0,             -- Unix timestamp seconds, 0 = aucun
+	updated_at     TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+	               ON UPDATE CURRENT_TIMESTAMP,
+	PRIMARY KEY (pool_id, spawn_id),
+	-- Index pour query par status (ex : "trouve tous les spawns Respawning
+	-- a re-creer au prochain tick").
+	KEY idx_pool_member_state_status (status),
+	-- Index par respawn timer (purge cleanup ou tick respawn scheduler).
+	KEY idx_pool_member_state_respawn (respawn_at_sec)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0060_groups.sql
+++ b/deploy/docker/sql/migrations/0060_groups.sql
@@ -1,0 +1,58 @@
+-- 0060 — Wave 22 Groups master-side : groupes (party/raid) + members + audit
+-- des loot rolls. Master-side car les groupes peuvent etre cross-shard
+-- (raid future).
+--
+-- Idempotente : CREATE TABLE IF NOT EXISTS. Rejouable sans erreur.
+--
+-- Note : la table `groups` est backtick-quotee partout — `GROUPS` est un
+-- mot reserve depuis MySQL 8.0.2 (window functions). Sans les backticks,
+-- `CREATE TABLE groups` et `REFERENCES groups` sont des syntax errors sur
+-- MySQL 8.x (OK sur 5.7, d'ou le passage CI initial).
+
+-- Table groups : 1 ligne par groupe actif (party ou raid). Disband =
+-- DELETE (cascade member rows via FK ON DELETE CASCADE).
+CREATE TABLE IF NOT EXISTS `groups`
+(
+	group_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+	group_type   TINYINT UNSIGNED NOT NULL DEFAULT 0,  -- 0=Party, 1=Raid
+	leader_id    BIGINT UNSIGNED NOT NULL,
+	loot_method  TINYINT UNSIGNED NOT NULL DEFAULT 0,  -- 0=FFA, 1=RR, 2=ML, 3=NBG
+	created_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (group_id),
+	KEY idx_groups_leader (leader_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table group_members : (group_id, player_id) avec role optionnel.
+-- ON DELETE CASCADE assure le cleanup quand un groupe est dissolved.
+CREATE TABLE IF NOT EXISTS group_members
+(
+	group_id    BIGINT UNSIGNED NOT NULL,
+	player_id   BIGINT UNSIGNED NOT NULL,
+	role        TINYINT UNSIGNED NOT NULL DEFAULT 0,  -- 0=Unknown, 1=Tank, 2=Heal, 3=Dps
+	joined_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (group_id, player_id),
+	-- Un player ne peut etre que dans 1 groupe a la fois : index unique
+	-- sur player_id pour enforce cette contrainte au niveau DB aussi.
+	UNIQUE KEY uniq_group_members_player (player_id),
+	KEY idx_group_members_group (group_id),
+	CONSTRAINT fk_group_members_group
+		FOREIGN KEY (group_id) REFERENCES `groups` (group_id)
+		ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Table group_loot_rolls : audit des decisions roll (Need/Greed/Pass) pour
+-- le LootMethod NeedBeforeGreed. Permet de revisiter une dispute ulterieure.
+-- Pas de FK vers groups (un loot roll peut survivre au disband group pour
+-- conserver l'historique audit).
+CREATE TABLE IF NOT EXISTS group_loot_rolls
+(
+	roll_id     BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+	group_id    BIGINT UNSIGNED NOT NULL,
+	item_id     BIGINT UNSIGNED NOT NULL,
+	player_id   BIGINT UNSIGNED NOT NULL,
+	choice      TINYINT UNSIGNED NOT NULL,  -- 0=Pass, 1=Greed, 2=Need
+	rolled_at   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY (roll_id),
+	KEY idx_group_loot_rolls_group (group_id),
+	KEY idx_group_loot_rolls_item (item_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0061_spell_aura.sql
+++ b/deploy/docker/sql/migrations/0061_spell_aura.sql
@@ -1,0 +1,34 @@
+-- 0061 — Wave 23 Spell/Aura/Proc : persistance des auras au logout +
+-- table proc templates data-driven.
+--
+-- Idempotente : CREATE TABLE IF NOT EXISTS. Rejouable sans erreur.
+
+-- Persistance des auras actifs sur un character au logout. Au login, le
+-- shard re-applique chaque ligne (avec verification expiresAtMs > now pour
+-- skip les auras expires entre temps).
+CREATE TABLE IF NOT EXISTS character_auras
+(
+	character_id     BIGINT UNSIGNED NOT NULL,
+	spell_id         INT UNSIGNED NOT NULL,
+	caster_id        BIGINT UNSIGNED NOT NULL,
+	applied_at_ms    BIGINT UNSIGNED NOT NULL,
+	expires_at_ms    BIGINT UNSIGNED NOT NULL,
+	stack_count      INT UNSIGNED NOT NULL DEFAULT 1,
+	PRIMARY KEY (character_id, spell_id, caster_id),
+	KEY idx_character_auras_character (character_id),
+	KEY idx_character_auras_expires (expires_at_ms)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Templates des procs data-driven. Charges au boot, immutable runtime.
+-- Hot-reload via /reload procs (admin GM+, audit).
+CREATE TABLE IF NOT EXISTS spell_proc_template
+(
+	proc_id              INT UNSIGNED NOT NULL,
+	event_type           TINYINT UNSIGNED NOT NULL,  -- ProcEvent enum
+	trigger_spell_id     INT UNSIGNED NOT NULL,
+	proc_chance          TINYINT UNSIGNED NOT NULL DEFAULT 100,  -- 0-100
+	internal_cooldown_ms INT UNSIGNED NOT NULL DEFAULT 0,
+	PRIMARY KEY (proc_id),
+	KEY idx_spell_proc_template_event (event_type),
+	KEY idx_spell_proc_template_trigger (trigger_spell_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0062_creature_movement.sql
+++ b/deploy/docker/sql/migrations/0062_creature_movement.sql
@@ -1,0 +1,22 @@
+-- 0062 — Wave 24 Movement scaffold : table creature_movement pour les
+-- patrouilles waypoints des creatures.
+--
+-- Idempotente : CREATE TABLE IF NOT EXISTS. Rejouable sans erreur.
+--
+-- L'integration recast/detour (path inter-waypoint avec obstacles) viendra
+-- dans une PR ulterieure avec ajout vcpkg recastnavigation. Cette table
+-- est utilisable des maintenant via PathFollowMotion + StubNavmeshProvider
+-- (qui se contente du segment direct).
+
+CREATE TABLE IF NOT EXISTS creature_movement
+(
+	creature_guid  BIGINT UNSIGNED NOT NULL,
+	point_idx      INT UNSIGNED NOT NULL,
+	pos_x          FLOAT NOT NULL,
+	pos_y          FLOAT NOT NULL,
+	pos_z          FLOAT NOT NULL,
+	wait_ms        INT UNSIGNED NOT NULL DEFAULT 0,
+	script_id      INT UNSIGNED NOT NULL DEFAULT 0,  -- 0 = pas de DBScript a executer
+	PRIMARY KEY (creature_guid, point_idx),
+	KEY idx_creature_movement_script (script_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0063_dungeon_instances.sql
+++ b/deploy/docker/sql/migrations/0063_dungeon_instances.sql
@@ -1,0 +1,33 @@
+-- M100.43 — Dungeon Portal System (Phase 11 « Volumes 3D »).
+--
+-- Crée la table `dungeon_instances` qui stocke les donjons actifs (instances
+-- créées par les joueurs au passage par un portail). Idempotente :
+-- CREATE TABLE IF NOT EXISTS. Réjouable au boot serveur après upgrade.
+--
+-- Une instance est créée à la demande quand un joueur déclenche un portail :
+-- handler `EnterDungeonHandler` (à câbler en M100.44) INSERT-era une ligne ici
+-- avec le `owner_character_id` du joueur et le `dungeon_template_id` du portail
+-- (résolu depuis `instances/dungeon_portals.bin` côté éditeur). L'expiration
+-- est gérée par `expires_at` (NULL = pas d'expiration).
+--
+-- Note : `shard_endpoint` reste vide en M100.43. La résolution shard
+-- multi-instance (un shard dédié par dungeon-instance) est M100.44+.
+--
+-- Pas de wire-breaking : aucun opcode existant ne lit ces colonnes.
+-- Les opcodes 197/198 (kOpcodeEnterDungeon{Request,Response}) sont réservés
+-- par M100.43 mais ne sont pas encore câblés à un handler — un client qui
+-- les enverrait recevrait BAD_REQUEST tant que M100.44 n'aura pas câblé
+-- `EnterDungeonHandler`.
+
+CREATE TABLE IF NOT EXISTS dungeon_instances (
+    id BIGINT UNSIGNED PRIMARY KEY AUTO_INCREMENT,
+    dungeon_template_id VARCHAR(64) NOT NULL,
+    owner_character_id BIGINT UNSIGNED NOT NULL,
+    difficulty TINYINT UNSIGNED NOT NULL DEFAULT 1,
+    shard_endpoint VARCHAR(255) NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    expires_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_dungeon_instances_owner (owner_character_id),
+    INDEX idx_dungeon_instances_template (dungeon_template_id),
+    INDEX idx_dungeon_instances_expires (expires_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/docker/sql/migrations/0064_characters_slot_partial_unique.sql
+++ b/deploy/docker/sql/migrations/0064_characters_slot_partial_unique.sql
@@ -1,0 +1,105 @@
+-- Migration 0064 — Slot partial-unique via generated column (fix soft-delete)
+--
+-- Contexte du bug :
+--   CharacterDeleteHandler fait un soft-delete (UPDATE characters
+--   SET deleted_at = NOW()) sans toucher au champ `slot`. La unique key
+--   `uq_characters_account_server_slot` (account_id, server_id, slot) est
+--   globale — MySQL ne supporte pas les partial unique index. Du coup
+--   apres soft-delete d'un perso au slot N :
+--     1. FindNextSlot (filtre WHERE deleted_at IS NULL) ne voit plus la
+--        row, considere le slot N comme libre, retourne N.
+--     2. CharacterCreateHandler INSERT avec slot=N.
+--     3. MySQL rejette : "Duplicate entry 'A-S-N' for key
+--        uq_characters_account_server_slot".
+--     4. Client recoit "character creation failed" (cf. CharacterCreateHandler.cpp:277).
+--
+-- Fix : la unique key cible une *generated column* `slot_active` qui vaut :
+--   - `slot` si la row est vivante (deleted_at IS NULL)
+--   - `NULL` si la row est soft-deletee
+--
+-- Comportement MySQL : NULL n'est pas unique-checke. Plusieurs rows peuvent
+-- avoir slot_active = NULL sans collision. Du coup les soft-deletes ne
+-- bloquent plus la reutilisation du slot.
+--
+-- Strategie :
+--   1. Hard-purge des soft-deletes existants pour debloquer le user (si
+--      des collisions latentes persistent post-migration, la creation
+--      restera bloquee). Aucune perte de donnees gameplay : les persos
+--      soft-deletes sont deja invisibles cote UI/handler.
+--   2. Drop l'ancienne unique key.
+--   3. Add la generated virtual column `slot_active`.
+--   4. Add la nouvelle unique key sur (account_id, server_id, slot_active).
+--
+-- Idempotent : checks d'existence avant chaque ALTER.
+-- Reversible : DROP COLUMN slot_active + recreate l'ancienne unique key.
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+START TRANSACTION;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 1) Hard-purge des soft-deletes (cleanup historique)
+--    Les rows soft-deletees sont deja invisibles cote handlers (filtre
+--    WHERE deleted_at IS NULL partout). On les supprime physiquement pour
+--    eliminer les collisions potentielles avec la nouvelle unique key.
+-- ────────────────────────────────────────────────────────────────────────
+
+DELETE FROM characters WHERE deleted_at IS NOT NULL;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 2) Drop l'ancienne unique key (idempotent)
+-- ────────────────────────────────────────────────────────────────────────
+
+SET @m64_idx_old := (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE() AND table_name = 'characters'
+    AND index_name = 'uq_characters_account_server_slot'
+);
+SET @m64_sql_drop := IF(@m64_idx_old > 0,
+  'ALTER TABLE characters DROP INDEX uq_characters_account_server_slot',
+  'SELECT 1');
+PREPARE m64_p_drop FROM @m64_sql_drop;
+EXECUTE m64_p_drop;
+DEALLOCATE PREPARE m64_p_drop;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 3) Add la generated virtual column `slot_active`
+--    VIRTUAL : pas de stockage disque, calculee a la lecture/index.
+--    Type aligne sur `slot` (TINYINT UNSIGNED).
+-- ────────────────────────────────────────────────────────────────────────
+
+SET @m64_col := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'characters'
+    AND column_name = 'slot_active'
+);
+SET @m64_sql_col := IF(@m64_col = 0,
+  'ALTER TABLE characters ADD COLUMN slot_active TINYINT UNSIGNED GENERATED ALWAYS AS (IF(deleted_at IS NULL, slot, NULL)) VIRTUAL COMMENT ''Generated : slot si vivant, NULL si soft-deleted. Permet partial unique.''',
+  'SELECT 1');
+PREPARE m64_p_col FROM @m64_sql_col;
+EXECUTE m64_p_col;
+DEALLOCATE PREPARE m64_p_col;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 4) Add la nouvelle unique key sur slot_active
+--    Plusieurs rows avec slot_active=NULL sont autorisees (MySQL ne
+--    unique-check pas les NULL). Garantie d'unicite uniquement pour les
+--    rows vivantes au meme (account_id, server_id, slot).
+-- ────────────────────────────────────────────────────────────────────────
+
+SET @m64_idx_new := (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE() AND table_name = 'characters'
+    AND index_name = 'uq_characters_account_server_slot_active'
+);
+SET @m64_sql_idx := IF(@m64_idx_new = 0,
+  'ALTER TABLE characters ADD UNIQUE KEY uq_characters_account_server_slot_active (account_id, server_id, slot_active)',
+  'SELECT 1');
+PREPARE m64_p_idx FROM @m64_sql_idx;
+EXECUTE m64_p_idx;
+DEALLOCATE PREPARE m64_p_idx;
+
+COMMIT;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/deploy/docker/sql/migrations/0065_characters_name_partial_unique.sql
+++ b/deploy/docker/sql/migrations/0065_characters_name_partial_unique.sql
@@ -1,0 +1,94 @@
+-- Migration 0065 — Name partial-unique via generated column (fix soft-delete suite)
+--
+-- Contexte : suite directe de la migration 0064 (slot partial unique).
+-- Le bug "character creation failed" apres soft-delete persistait pour les
+-- noms reutilises. Cause : il existe une seconde unique key globale
+-- `uq_characters_name_server (name, server_id)` (cf. migration 0004) qui
+-- empeche physiquement un INSERT avec un nom deja present dans la table,
+-- meme si l'ancienne row est soft-deletee.
+--
+-- Symptome : "Duplicate entry 'tutu-1' for key uq_characters_name_server"
+-- apres tentative de re-creation avec le nom d'un perso supprime.
+--
+-- Meme remede que 0064 : generated VIRTUAL column `name_active` qui vaut
+--   - `name` si la row est vivante (deleted_at IS NULL)
+--   - `NULL` si la row est soft-deletee
+-- Puis unique key partielle sur (name_active, server_id). MySQL n'unique-
+-- check pas les NULL -> plusieurs soft-deletes au meme nom coexistent
+-- sans collision.
+--
+-- Combine avec le fix `CharacterNameExistsOnServer` cote handler (qui filtre
+-- desormais deleted_at IS NULL), un nom de perso est immediatement reutilisable
+-- apres soft-delete.
+--
+-- Idempotent : checks d'existence avant chaque ALTER.
+-- Reversible : DROP COLUMN name_active + recreate l'ancienne unique key.
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+START TRANSACTION;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 1) Hard-purge des soft-deletes restants (defense-en-profondeur si une
+--    row soft-deletee a survecu a 0064 — ne devrait pas arriver puisque
+--    0064 a deja purge — mais ne nuit pas).
+-- ────────────────────────────────────────────────────────────────────────
+
+DELETE FROM characters WHERE deleted_at IS NOT NULL;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 2) Drop l'ancienne unique key (idempotent)
+-- ────────────────────────────────────────────────────────────────────────
+
+SET @m65_idx_old := (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE() AND table_name = 'characters'
+    AND index_name = 'uq_characters_name_server'
+);
+SET @m65_sql_drop := IF(@m65_idx_old > 0,
+  'ALTER TABLE characters DROP INDEX uq_characters_name_server',
+  'SELECT 1');
+PREPARE m65_p_drop FROM @m65_sql_drop;
+EXECUTE m65_p_drop;
+DEALLOCATE PREPARE m65_p_drop;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 3) Add la generated virtual column `name_active`
+--    VIRTUAL : pas de stockage disque, calculee a la lecture/index.
+--    Type aligne sur `name` (VARCHAR(64)).
+-- ────────────────────────────────────────────────────────────────────────
+
+SET @m65_col := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'characters'
+    AND column_name = 'name_active'
+);
+SET @m65_sql_col := IF(@m65_col = 0,
+  'ALTER TABLE characters ADD COLUMN name_active VARCHAR(64) GENERATED ALWAYS AS (IF(deleted_at IS NULL, name, NULL)) VIRTUAL COMMENT ''Generated : name si vivant, NULL si soft-deleted. Permet partial unique.''',
+  'SELECT 1');
+PREPARE m65_p_col FROM @m65_sql_col;
+EXECUTE m65_p_col;
+DEALLOCATE PREPARE m65_p_col;
+
+-- ────────────────────────────────────────────────────────────────────────
+-- 4) Add la nouvelle unique key sur name_active
+--    Plusieurs rows avec name_active=NULL sont autorisees. Garantie
+--    d'unicite uniquement pour les rows vivantes au meme (name, server_id).
+-- ────────────────────────────────────────────────────────────────────────
+
+SET @m65_idx_new := (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE() AND table_name = 'characters'
+    AND index_name = 'uq_characters_name_server_active'
+);
+SET @m65_sql_idx := IF(@m65_idx_new = 0,
+  'ALTER TABLE characters ADD UNIQUE KEY uq_characters_name_server_active (name_active, server_id)',
+  'SELECT 1');
+PREPARE m65_p_idx FROM @m65_sql_idx;
+EXECUTE m65_p_idx;
+DEALLOCATE PREPARE m65_p_idx;
+
+COMMIT;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/deploy/docker/sql/migrations/0066_accounts_profile_complete.sql
+++ b/deploy/docker/sql/migrations/0066_accounts_profile_complete.sql
@@ -1,0 +1,107 @@
+-- Migration 0066 — Complète les colonnes de profil sur `accounts` (résout le doublon 0023).
+--
+-- Contexte : deux migrations portaient le numéro 0023 (0023_accounts_profile.sql et
+-- 0023_accounts_profile_fields.sql). Le MigrationRunner n'appliquant qu'UN script par
+-- numéro, l'une des deux n'a jamais été appliquée → un sous-ensemble de colonnes manque
+-- selon la base. Cette migration ajoute, de façon IDEMPOTENTE, l'UNION de toutes les
+-- colonnes des deux fichiers 0023 : quelle que soit celle déjà appliquée, les colonnes
+-- manquantes sont comblées (les colonnes déjà présentes sont laissées telles quelles).
+--
+-- Idempotent : chaque colonne n'est ajoutée que si absente (information_schema + PREPARE).
+-- Pas de COMMENT (évite l'échappement d'apostrophes) ; les colonnes restent fonctionnelles.
+
+-- first_name (présent dans les deux 0023 ; ajouté seulement si totalement absent)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'first_name');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN first_name VARCHAR(100) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- last_name
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'last_name');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN last_name VARCHAR(100) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- birth_date (uniquement dans 0023_accounts_profile_fields.sql)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'birth_date');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN birth_date VARCHAR(10) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- address_street (uniquement dans 0023_accounts_profile.sql)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'address_street');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN address_street VARCHAR(255) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- address_city
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'address_city');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN address_city VARCHAR(100) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- address_zip
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'address_zip');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN address_zip VARCHAR(20) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- address_country
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'address_country');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN address_country VARCHAR(100) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- email_pending
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'email_pending');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN email_pending VARCHAR(255) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- email_pending_token
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'email_pending_token');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN email_pending_token VARCHAR(128) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- email_pending_expires_at
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'email_pending_expires_at');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN email_pending_expires_at DATETIME NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- disabled_reason
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'disabled_reason');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN disabled_reason TEXT NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- role (ENUM player/admin ; NOT NULL DEFAULT remplit les lignes existantes)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'role');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN role ENUM(''player'',''admin'') NOT NULL DEFAULT ''player''', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- parental_email
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'parental_email');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN parental_email VARCHAR(255) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- parental_validated (TINYINT NOT NULL DEFAULT 0 remplit les lignes existantes)
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'parental_validated');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN parental_validated TINYINT(1) NOT NULL DEFAULT 0', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- parental_token
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'parental_token');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN parental_token VARCHAR(128) NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;
+
+-- parental_token_expires_at
+SET @c := (SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'accounts' AND column_name = 'parental_token_expires_at');
+SET @s := IF(@c = 0, 'ALTER TABLE accounts ADD COLUMN parental_token_expires_at DATETIME NULL', 'SELECT 1');
+PREPARE p FROM @s; EXECUTE p; DEALLOCATE PREPARE p;

--- a/deploy/docker/sql/migrations/0067_characters_gender.sql
+++ b/deploy/docker/sql/migrations/0067_characters_gender.sql
@@ -1,0 +1,24 @@
+-- Migration 0067 — Genre du personnage persisté en base.
+--
+-- Jusqu'ici le genre de l'avatar était un réglage client global (puis par
+-- personnage côté client uniquement, cf. character_appearance.json). On le
+-- persiste désormais côté serveur : le client l'envoie à la création
+-- (CharacterCreateRequestPayload.gender) et le master le renvoie dans
+-- CharacterListEntry.gender → l'avatar correct (mesh + peau) au relog, quelle
+-- que soit la machine.
+--
+-- Idempotent : colonne ajoutée uniquement si manquante. Défaut 'male' pour les
+-- personnages créés avant cette migration.
+
+SET NAMES utf8mb4;
+
+SET @m67_c := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'characters' AND column_name = 'gender'
+);
+SET @m67_s := IF(@m67_c = 0,
+  'ALTER TABLE characters ADD COLUMN gender VARCHAR(8) NOT NULL DEFAULT ''male''',
+  'SELECT 1');
+PREPARE m67_p FROM @m67_s;
+EXECUTE m67_p;
+DEALLOCATE PREPARE m67_p;

--- a/deploy/docker/sql/migrations/0068_characters_skin_color.sql
+++ b/deploy/docker/sql/migrations/0068_characters_skin_color.sql
@@ -1,0 +1,25 @@
+-- Migration 0068 — Teinte de peau du personnage persistée en base.
+--
+-- Suite du genre (0067) : la teinte de peau (skinColorIdx) était jusqu'ici un
+-- réglage purement client (aperçu de création). On la persiste côté serveur :
+-- le client l'envoie à la création (CharacterCreateRequestPayload.customization
+-- .skinColorIdx) et le master la renvoie dans CharacterListEntry.skin_color_idx
+-- → la bonne teinte au relog, quelle que soit la machine.
+--
+-- Valeurs : 0 = claire (défaut), 1 = foncée (extensible à une palette plus tard).
+--
+-- Idempotent : colonne ajoutée uniquement si manquante. Défaut 0 (claire) pour
+-- les personnages créés avant cette migration.
+
+SET NAMES utf8mb4;
+
+SET @m68_c := (
+  SELECT COUNT(*) FROM information_schema.columns
+  WHERE table_schema = DATABASE() AND table_name = 'characters' AND column_name = 'skin_color_idx'
+);
+SET @m68_s := IF(@m68_c = 0,
+  'ALTER TABLE characters ADD COLUMN skin_color_idx TINYINT UNSIGNED NOT NULL DEFAULT 0',
+  'SELECT 1');
+PREPARE m68_p FROM @m68_s;
+EXECUTE m68_p;
+DEALLOCATE PREPARE m68_p;

--- a/deploy/docker/sql/migrations/0069_add_characters_server_id_index.sql
+++ b/deploy/docker/sql/migrations/0069_add_characters_server_id_index.sql
@@ -1,0 +1,32 @@
+-- ────────────────────────────────────────────────────────────────────────
+-- 0069 — Ajoute l'index `ix_characters_server_id` sur `characters(server_id)`
+-- ────────────────────────────────────────────────────────────────────────
+--
+-- Issu de l'audit codebase 2026-05-27 (PR 2, chantier C — scope ultra-minimal).
+-- Réf : docs/superpowers/audits/closed/2026-05-27-codebase-audit.md
+--       docs/superpowers/plans/2026-05-27-pr2-sql-characters-server-id-index.md
+--
+-- Motivation :
+--   `characters.server_id` est utilisé en `WHERE`/`AND` dans 3 hot handlers
+--   (CharacterCreateHandler:67, :116 ; CharacterListHandler:79). Sans index,
+--   ces queries font un table scan filtré ensuite par `account_id`. Avec
+--   une table characters multi-comptes × multi-personnages qui grandit,
+--   l'absence d'index sur server_id finit par dominer le coût des
+--   requêtes character-list et character-create.
+--
+-- Idempotence : on vérifie INFORMATION_SCHEMA.STATISTICS avant CREATE.
+-- Pattern repris de sql/migrations/0040_factions.sql:101-108 pour la
+-- cohérence stylistique du repo.
+
+SET @idx_exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE table_schema = DATABASE()
+    AND table_name = 'characters'
+    AND index_name = 'ix_characters_server_id'
+);
+SET @stmt := IF(@idx_exists = 0,
+  'CREATE INDEX ix_characters_server_id ON characters (server_id)',
+  'SELECT ''index ix_characters_server_id already exists, skipping'' AS msg');
+PREPARE addidx FROM @stmt;
+EXECUTE addidx;
+DEALLOCATE PREPARE addidx;

--- a/deploy/docker/sql/migrations/0070_add_characters_server_account_index.sql
+++ b/deploy/docker/sql/migrations/0070_add_characters_server_account_index.sql
@@ -1,0 +1,58 @@
+-- ────────────────────────────────────────────────────────────────────────
+-- 0070 — Ajoute l'index compound `ix_characters_server_account`
+--         sur `characters(server_id, account_id)`
+-- ────────────────────────────────────────────────────────────────────────
+--
+-- Issu de l'audit codebase 2026-05-28 (finding N3, ouvert depuis l'audit
+-- 2026-05-27 finding F3 — partiellement résolu par la PR #722 / migration
+-- 0069 qui n'avait ajouté que l'index simple `ix_characters_server_id`).
+-- Réf : docs/superpowers/audits/2026-05-28-codebase-audit-fresh.md
+--
+-- Motivation :
+--   Plusieurs hot handlers du master font des SELECT sur `characters`
+--   avec un WHERE composite `server_id` + `account_id` :
+--     - CharacterListHandler.cpp:78-81
+--         WHERE c.account_id = X AND c.server_id = Y AND c.deleted_at IS NULL
+--         ORDER BY c.slot ASC
+--     - CharacterCreateHandler.cpp:115-117 (FindNextSlot)
+--         WHERE account_id = X AND server_id = Y AND deleted_at IS NULL
+--         ORDER BY slot ASC
+--
+--   Avec uniquement les index single-column `ix_characters_account_id`
+--   (migration 0001) et `ix_characters_server_id` (migration 0069), MySQL
+--   doit choisir l'un OU l'autre et fait un seek puis une lecture de
+--   toutes les lignes correspondantes pour filtrer le second prédicat.
+--   À mesure que la table grossit (multi-comptes × multi-personnages ×
+--   multi-shards), cette double-passe domine le coût de ces requêtes.
+--
+--   Un index compound `(server_id, account_id)` permet à l'optimiseur
+--   de faire un seek unique pour les 2 prédicats. L'ordre des colonnes
+--   suit la recommandation de l'audit 2026-05-27 ; l'ordre du WHERE en
+--   code C++ ne contraint pas l'optimiseur MySQL (qui re-ordonne).
+--
+-- Note de redondance (informationnelle, pas un nettoyage à faire ici) :
+--   L'index single `ix_characters_server_id` ajouté en migration 0069
+--   devient utilisable via le prefix de `ix_characters_server_account` ;
+--   il reste néanmoins en place pour ne pas casser le rollback éventuel
+--   de la migration 0070. Un nettoyage explicite peut être fait dans
+--   une migration ultérieure une fois cette PR validée en prod.
+--   L'index single `ix_characters_account_id` (migration 0001) reste
+--   utile pour les SELECT solo sur `WHERE account_id = ?` (ex :
+--   CharacterEnterWorldHandler:88) où server_id n'est pas dans le WHERE.
+--
+-- Idempotence : on vérifie INFORMATION_SCHEMA.STATISTICS avant CREATE.
+-- Pattern repris de sql/migrations/0040_factions.sql:101-108 et
+-- sql/migrations/0069_add_characters_server_id_index.sql.
+
+SET @idx_exists := (
+  SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE table_schema = DATABASE()
+    AND table_name = 'characters'
+    AND index_name = 'ix_characters_server_account'
+);
+SET @stmt := IF(@idx_exists = 0,
+  'CREATE INDEX ix_characters_server_account ON characters (server_id, account_id)',
+  'SELECT ''index ix_characters_server_account already exists, skipping'' AS msg');
+PREPARE addidx FROM @stmt;
+EXECUTE addidx;
+DEALLOCATE PREPARE addidx;

--- a/deploy/docker/sql/migrations/0071_portal_sessions.sql
+++ b/deploy/docker/sql/migrations/0071_portal_sessions.sql
@@ -1,0 +1,53 @@
+-- Migration 0071 — Table portal_sessions
+--
+-- Refactor sécurité critique : avant cette migration, l'authentification du
+-- web-portal reposait sur deux cookies non signés (`lcdlln_portal_account` =
+-- account_id en clair, `lcdlln_portal_role` = role en clair). Bien que
+-- `httpOnly: true` empêchait le JS de page d'y toucher, DevTools / curl /
+-- proxy / extensions pouvaient les modifier librement, ce qui permettait :
+--   1. Impersonation totale : qui que ce soit pouvait poser
+--      `lcdlln_portal_account=1` et se faire passer pour le compte 1 sans
+--      aucun mot de passe. Les account_id étant auto-increment, deviner un
+--      compte admin était trivial.
+--   2. Escalation de privilèges : un joueur normal pouvait poser
+--      `lcdlln_portal_role=SUPERADMIN` et accéder à 14 routes /api/admin/*
+--      qui faisaient confiance au cookie sans re-vérifier en DB.
+--
+-- Nouveau modèle : un seul cookie `lcdlln_portal_session` contient un
+-- session_token cryptographique random (256 bits, 64 chars hex). À chaque
+-- requête authentifiée, `getSession()` fait une LECTURE DB sur cette table
+-- pour matérialiser la session ; account_id et role viennent donc TOUJOURS
+-- de la DB (table accounts via JOIN), jamais d'un cookie. Modifier le
+-- cookie côté client ne permet plus rien : un token inexistant en DB
+-- retourne null (= non authentifié), et il est impossible de générer un
+-- token valide sans passer par /api/auth/login (qui exige des credentials).
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE IF NOT EXISTS portal_sessions (
+  id              BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  session_token   CHAR(64)        NOT NULL
+                  COMMENT 'Hex 64 chars = 32 octets random = 256 bits. Généré par /api/auth/login via crypto.randomBytes(32).',
+  account_id      BIGINT UNSIGNED NOT NULL
+                  COMMENT 'Compte propriétaire de la session (FK vers accounts.id, CASCADE delete pour purger les sessions d''un compte supprimé).',
+  created_at      DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_seen_at    DATETIME        NOT NULL DEFAULT CURRENT_TIMESTAMP
+                  ON UPDATE CURRENT_TIMESTAMP
+                  COMMENT 'MAJ par getSession() à chaque requête authentifiée. Sert à expirer les sessions inactives indépendamment de expires_at fixe.',
+  expires_at      DATETIME        NOT NULL
+                  COMMENT 'Borne haute absolue de la session (login + 7 jours par défaut, cf. PORTAL_SESSION_MAX_AGE_DAYS).',
+  user_agent      VARCHAR(255)    NULL
+                  COMMENT 'Capture du User-Agent au login pour observabilité (audit, détection abus).',
+  ip              VARCHAR(45)     NULL
+                  COMMENT 'IP au login (IPv6 jusqu''à 45 chars). Idem audit.',
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_session_token (session_token),
+  KEY idx_account_id (account_id),
+  KEY idx_expires_at (expires_at),
+  CONSTRAINT fk_portal_sessions_account
+    FOREIGN KEY (account_id) REFERENCES accounts (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Sessions authentifiées du web-portal. Cookie côté client = session_token random ; identité réelle (account_id, role) lue ici par lookup à chaque requête.';
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/deploy/docker/sql/migrations/README.md
+++ b/deploy/docker/sql/migrations/README.md
@@ -25,3 +25,21 @@
 ## Application dans une transaction
 
 Chaque migration doit être exécutée dans une transaction si le moteur le permet (MySQL : `START TRANSACTION;` … `COMMIT;`). En cas d’erreur : `ROLLBACK;`.
+
+## Cas particulier : doublon historique 0023 (NE PAS SUPPRIMER)
+
+Deux fichiers portent le numéro **0023** (`0023_accounts_profile.sql` et
+`0023_accounts_profile_fields.sql`). C’est un doublon **historique** : selon la base,
+**l’un OU l’autre** a été appliqué (et son checksum est en `schema_version`).
+
+- **Ne supprimez NI l’un NI l’autre.** Le `MigrationRunner` accepte qu’un numéro ait
+  plusieurs fichiers et valide le checksum en base s’il correspond à **n’importe lequel**
+  d’eux ; supprimer le fichier réellement appliqué provoquerait un *checksum mismatch*
+  → **arrêt du master au démarrage**.
+- À l’application (base fraîche), un **seul** script par numéro est exécuté (anti
+  double-`INSERT` sur la PK `version`).
+- Les colonnes du fichier 0023 **non** appliqué sont comblées de façon **idempotente**
+  par `0066_accounts_profile_complete.sql` (union de toutes les colonnes des deux 0023).
+
+**Convention pour l’avenir : un numéro = un fichier.** Ce doublon est une exception gérée,
+pas un modèle à suivre.

--- a/docs/audit/2026-07-03-audit-complet-frais.md
+++ b/docs/audit/2026-07-03-audit-complet-frais.md
@@ -200,6 +200,13 @@ dans le `config.json` livré (ligne 222). Le ticket source M19.6 exigeait pourta
 `BuildUserSettingsJson` + `config.json`) ; n'activer le mode insecure que via une
 macro de build de développement, pas une clé de config modifiable par l'utilisateur.
 
+> **Statut (2026-07-03)** : DIFFÉRÉ. Passer `allow_insecure_dev` à `false` sans
+> `client.server_fingerprint` renseigné bloquerait tous les clients
+> (`TlsVerifyFingerprint` refuse la connexion sur mismatch). Fermeture : fournir
+> le SHA-256 du certificat du master de production dans `client.server_fingerprint`,
+> puis passer `allow_insecure_dev` à `false` (tous les call sites +
+> `BuildUserSettingsJson` + `config.json`).
+
 ### F8 · Code de vérification e-mail brute-forçable (pré-auth, sans throttle) — sécurité
 
 [PasswordResetHandler.cpp:230](src/masterd/handlers/password/PasswordResetHandler.cpp:230) · catégorie **sécurité**

--- a/docs/audit/2026-07-03-audit-complet-frais.md
+++ b/docs/audit/2026-07-03-audit-complet-frais.md
@@ -1,0 +1,493 @@
+# Audit complet frais — 2026-07-03
+
+Audit statique de l'ensemble du code du projet (hors `legacy/`), à la recherche
+d'anomalies, de problèmes de sécurité et d'optimisations. Audit *frais* : il ne
+s'appuie pas sur les audits de juin (`docs/audit/2026-06-*`).
+
+## Méthode
+
+Workflow multi-agents (53 agents au total) en 4 phases :
+
+1. **Audit** — 15 cellules sous-système × dimension (sécurité / bug / perf), un
+   agent auditeur chacune, lecture du code réel.
+2. **Dédup** — fusion des doublons inter-agents (38 findings bruts → 38 uniques).
+3. **Vérification adversariale** — chaque finding P0/P1 soumis à un agent
+   sceptique chargé de le **réfuter** en relisant le code ; P2/P3 en vérification
+   simple. **2 findings réfutés**, 36 retenus.
+4. **Synthèse** — ce rapport.
+
+**Limites** : analyse **statique** uniquement (pas de toolchain de build ni de
+profiling local). Les findings de catégorie **perf** sont des **candidats à
+mesurer**, pas des certitudes. `legacy/` et `game/data` (hors
+`slash_commands.json`) sont exclus.
+
+## Résumé exécutif
+
+| Sévérité | Nombre | Catégories |
+|----------|--------|------------|
+| **P0** — critique | 4 | 3 sécurité, 1 bug |
+| **P1** — sérieux | 5 | 4 sécurité, 1 bug |
+| **P2** — mineur / perf | 21 | 6 sécurité, 8 perf, 7 bug |
+| **P3** — qualité | 6 | 1 sécurité, 5 bug |
+| **Total** | **36** | 14 sécurité, 7 perf, 15 bug |
+
+**Aucune cellule d'audit n'a échoué** — les 15 cellules ont produit un résultat.
+
+Les points les plus importants :
+
+1. **Le canal shard↔master n'est pas authentifié** (F2, F3). N'importe quel pair
+   pouvant atteindre le port TCP public 3840 peut s'enregistrer comme un shard
+   légitime et forger des heartbeats, jusqu'à intercepter des données de session
+   de personnages. C'est la faille la plus grave du lot.
+2. **Deux connexions « HTTPS » ne vérifient pas le certificat TLS** : la
+   vérification CAPTCHA côté serveur (F4, fuite du `secret_key` + bypass anti-bot
+   total sous MITM) et le pinning TLS client désactivé par défaut (F7).
+3. **Le répertoire de migrations packagé dans l'image Docker master est tronqué**
+   (F1) : un `docker build` manuel sur un checkout git saute 22 migrations
+   (0050–0071). ⚠️ Nuance importante ci-dessous — le pipeline CI officiel
+   régénère ce dossier et n'est donc pas affecté.
+4. **Trois vecteurs de brute-force / injection sur l'auth** : code de vérification
+   e-mail brute-forçable (F8), injection SMTP via l'adresse e-mail (F9), absence
+   de rate-limiting sur le login du portail web (F28).
+
+---
+
+## P0 — Sécurité critique
+
+### F1 · Migrations 0050–0071 absentes de l'image Docker master — bug
+
+[deploy/docker/Dockerfile.master:30](deploy/docker/Dockerfile.master:30) · catégorie **bug**
+
+`Dockerfile.master` fait `COPY sql/migrations /app/sql/migrations` avec pour
+contexte de build `deploy/docker/`. Or `deploy/docker/sql/migrations/` contient
+0001..0049 puis saute directement à `0072_factions_v2.sql` : les 22 fichiers 0050
+à 0071 (auction_listings, game_events, arena_teams, character_skills,
+outdoor_pvp_state, guilds_master, bg_history, loot_tables, groups, spell_aura,
+creature_movement, dungeon_instances + les correctifs d'index/colonnes 0064-0071)
+sont absents de cette copie, bien que présents dans `sql/migrations/` à la racine.
+`MigrationRunner` ([MigrationRunner.cpp:99](src/masterd/migrations/MigrationRunner.cpp:99))
+applique les fichiers présents dans l'ordre de leur nom sans détecter les « trous »
+de version : un déploiement Docker frais applique 0072 directement après 0049,
+sans créer les tables correspondantes.
+
+> ⚠️ **Nuance (vérification)** : `deploy/docker/sql/migrations/` est un **artefact
+> régénéré** par `scripts/sync-db-to-docker-deploy.sh`, exécuté automatiquement en
+> CI (`build-linux.yml`, via `pack-linux-docker-bundle.sh`) avant l'assemblage du
+> bundle de déploiement officiel. Un déploiement via le pipeline CI **n'est donc
+> pas affecté** — la sync écrase la copie périmée. Le risque ne se matérialise que
+> pour un `docker compose build` / `docker build` lancé **manuellement** sur un
+> checkout git sans exécuter d'abord le script de sync. Ce dossier committé
+> obsolète a déjà été signalé par les audits de juin.
+
+**Recommandation** : ne pas committer un artefact généré divergent — soit générer
+`deploy/docker/sql/migrations/` au packaging sans le versionner, soit faire pointer
+le `COPY` vers `../../sql/migrations`. Ajouter un test CI qui diffe les deux
+répertoires et échoue en cas de divergence.
+
+### F2 · Canal shard→master : heartbeat spoofable (shard_id non lié à la connexion) — sécurité
+
+[ShardRegisterHandler.cpp:127](src/masterd/handlers/shard/ShardRegisterHandler.cpp:127) · catégorie **sécurité**
+
+`HandleHeartbeat` appelle `m_registry->UpdateHeartbeat(parsed->shard_id, …)` et
+`m_presenceCache->Update(parsed->shard_id, parsed->players)` en utilisant
+directement le `shard_id` du **payload client**, sans vérifier que la `connId`
+courante est bien celle enregistrée pour ce `shard_id` (le paramètre `connId` est
+explicitement ignoré, `uint32_t /*connId*/`). Combiné à F3, un pair réseau peut
+forger des heartbeats pour n'importe quel `shard_id` actif (falsifiant sa charge
+et sa liste de joueurs) ou faire un ré-REGISTER avec le même `name` pour détourner
+`SetShardConnection` et **intercepter les push `AdmitCharacter`** (contenant
+`account_id`/`character_id`) destinés au vrai shard.
+
+**Recommandation** : lier chaque `shard_id` à la `connId` ayant réalisé le REGISTER
+(déjà mémorisée via `SetShardConnection`) et rejeter tout heartbeat dont la `connId`
+ne correspond pas à `GetShardConnection(shard_id)`. À combiner avec F3.
+
+### F3 · SHARD_REGISTER / SHARD_HEARTBEAT sans aucune authentification — sécurité
+
+[ShardRegisterHandler.cpp:49](src/masterd/handlers/shard/ShardRegisterHandler.cpp:49) · catégorie **sécurité**
+
+`HandlePacket` route `kOpcodeShardRegister` et `kOpcodeShardHeartbeat` sans
+vérifier ni session, ni secret partagé, ni IP source. Ces opcodes sont dispatchés
+par le **même `NetServer` que les opcodes joueurs**, sur le port TCP public 3840
+([main_linux.cpp:1091](src/masterd/main_linux.cpp:1091)). Le pattern HMAC existe
+pourtant dans la codebase (`ShardTicketHandler` utilise `shard.ticket_hmac_secret`)
+mais n'est **pas** appliqué à l'enregistrement de shard. N'importe quel client TCP
+capable de forger un payload `SHARD_REGISTER` valide peut s'enregistrer comme un
+shard légitime dans le `ShardRegistry` avec un endpoint arbitraire.
+
+**Recommandation** : exiger un secret partagé (HMAC ou mTLS) dans `SHARD_REGISTER`,
+ou déplacer ces opcodes sur un listener réseau séparé restreint à l'infrastructure
+interne (allowlist IP / VPN), avant tout traitement.
+
+### F4 · CAPTCHA : certificat TLS non vérifié (MITM + fuite du secret) — sécurité
+
+[CaptchaVerifier.cpp:215](src/shared/security/CaptchaVerifier.cpp:215) · catégorie **sécurité**
+
+`VerifyHttp()` crée un `SSL_CTX` avec `SSL_CTX_new(TLS_client_method())` et fait
+`SSL_connect()` **sans jamais** appeler `SSL_CTX_set_verify(…, SSL_VERIFY_PEER, …)`,
+sans charger de trust store, et sans vérifier `SSL_get_verify_result()` ni le
+CN/SAN du certificat. Le mode par défaut d'OpenSSL étant `SSL_VERIFY_NONE`, la
+connexion réussit face à un certificat auto-signé, expiré ou d'un autre domaine.
+Un attaquant en position réseau (Wi-Fi malveillant, DNS spoofing, proxy d'egress)
+peut MITM cet appel « HTTPS » vers hcaptcha/google : il **reçoit le `secret_key`
+CAPTCHA en clair** (concaténé dans le body, ligne 165-166) et peut renvoyer un
+`{"success":true}` forgé, faisant passer toute vérification CAPTCHA — bypass total
+du contrôle anti-bot serveur (inscriptions de masse / credential stuffing).
+
+> Note connexe : sur Windows, `Verify()` bypasse entièrement l'appel réseau et
+> retourne `true` sans vérifier — problème distinct mais tout aussi grave.
+
+**Recommandation** : activer la validation complète — `SSL_CTX_set_verify(ctx,
+SSL_VERIFY_PEER, nullptr)`, `SSL_CTX_set_default_verify_paths(ctx)`,
+`SSL_set1_host(ssl, host)` avant `SSL_connect`, et contrôler
+`SSL_get_verify_result() == X509_V_OK` après le handshake.
+
+---
+
+## P1 — Bug sérieux / sécurité modérée
+
+### F5 · Renvoi de code de vérification totalement inopérant (opcode non routé) — bug
+
+[main_linux.cpp:1097](src/masterd/main_linux.cpp:1097) · catégorie **bug**
+
+Le client envoie `kOpcodeResendVerificationRequest`
+([AuthUiPresenterCore.cpp:2617](src/client/auth/AuthUiPresenterCore.cpp:2617)) et
+`PasswordResetHandler` sait le traiter, mais la table de dispatch du master ne
+route que `kOpcodeForgotPasswordRequest`, `kOpcodeResetPasswordRequest` et
+`kOpcodeVerifyEmailRequest` vers `passwordResetHandler`. `kOpcodeResendVerification­Request`
+(=37) est absent de la condition : le paquet tombe dans le `else` final et
+`HandleResendVerification` n'est jamais atteint. Les utilisateurs qui n'ont pas
+reçu ou ont laissé expirer leur code ne peuvent **jamais** en obtenir un nouveau.
+
+**Recommandation** : ajouter `|| opcode == kOpcodeResendVerificationRequest` à la
+condition de dispatch (lignes 1097-1099).
+**Déploiement** : ⚠️ ce fix nécessite un redéploiement du master.
+
+### F6 · Secret HMAC de ticket shard faible et committé en dur — sécurité
+
+[master.config.json:10](deploy/docker/config/master.config.json:10) · catégorie **sécurité**
+
+`master.config.json:10`, `shard.config.json:9` et `server-config/config.json:21`
+définissent tous la **même** valeur `"ticket_hmac_secret":
+"dev_secret_change_in_production"`, committée dans le repo. Ce secret signe en
+HMAC-SHA256 les tickets de connexion client→shard. Le seul garde-fou côté code est
+`if (m_secret.empty())` — qui ne rejette que la chaîne **vide**, pas cette valeur
+par défaut connue. Ces fichiers sont bind-montés tels quels dans les conteneurs
+(le compose référence un vrai domaine de prod). Un opérateur qui oublie de changer
+la valeur laisse un attaquant connaissant ce secret public forger des tickets
+shard valides et usurper des sessions client→shard.
+
+**Recommandation** : refuser au boot toute valeur égale à un jeu de valeurs de dev
+connues (pas seulement vide), ou générer un secret aléatoire au premier démarrage,
+et faire échouer le boot si le secret par défaut est détecté hors environnement dev.
+
+### F7 · Pinning TLS client désactivé par défaut (`allow_insecure_dev=true`) — sécurité
+
+[AuthUiPresenterCore.cpp:2217](src/client/auth/AuthUiPresenterCore.cpp:2217) · catégorie **sécurité**
+
+`client.allow_insecure_dev` est lu avec un défaut **`true`** codé en dur à tous les
+points de connexion (Login/Register/VerifyEmail/ForgotPassword) et transmis à
+`NetClient::SetAllowInsecureDev()`. Quand ce flag est vrai, un mismatch de
+fingerprint de certificat est accepté silencieusement (simple `LOG_WARN`) au lieu
+de refuser la connexion ([NetClient.cpp:141](src/shared/network/NetClient.cpp:141)).
+Le même défaut `true` est écrit dans le JSON généré pour tout nouvel utilisateur et
+dans le `config.json` livré (ligne 222). Le ticket source M19.6 exigeait pourtant
+« ne pas fallback silencieusement en insecure » — c'est une régression par rapport
+à l'intention documentée. Exploitation conditionnée à une position MITM active
+(d'où P1 et non P0). Même pattern côté shard→master.
+
+**Recommandation** : passer le défaut à `false` (tous les call sites +
+`BuildUserSettingsJson` + `config.json`) ; n'activer le mode insecure que via une
+macro de build de développement, pas une clé de config modifiable par l'utilisateur.
+
+### F8 · Code de vérification e-mail brute-forçable (pré-auth, sans throttle) — sécurité
+
+[PasswordResetHandler.cpp:230](src/masterd/handlers/password/PasswordResetHandler.cpp:230) · catégorie **sécurité**
+
+`HandleVerifyEmail` lit un `account_id` **arbitraire** depuis le payload client
+(opcode traité avant toute authentification de session) et valide un code à 6
+chiffres via `ValidateVerificationCode`, qui ne vérifie qu'un TTL de 15 minutes,
+**sans aucune limite de tentatives**. Le membre `m_rateLimit` est câblé
+(`SetRateLimitAndBan`) mais **jamais utilisé** dans ce fichier — seul l'envoi
+d'e-mail est limité, pas la vérification. Un attaquant connaissant/énumérant un
+`account_id` peut soumettre jusqu'à 10⁶ codes en 15 minutes sans blocage réseau.
+
+**Recommandation** : appliquer `m_rateLimit` (déjà disponible) sur les tentatives
+`HandleVerifyEmail` par `account_id`/IP, avec verrouillage après N échecs, en plus
+du TTL.
+
+### F9 · Injection SMTP via l'adresse e-mail (CR/LF non filtrés) — sécurité
+
+[AccountValidation.cpp:36](src/shared/account/AccountValidation.cpp:36) · catégorie **sécurité**
+
+`ValidateEmail()` ne vérifie qu'un `@` non initial, la longueur et un `.` dans le
+domaine — **aucun caractère de contrôle interdit**. `NormaliseEmail()` ne trim que
+les extrémités : un CR/LF au **milieu** de la chaîne (ex.
+`a@b.com\r\nRCPT TO:<victim@evil.tld>\r\nDATA\r\n…`) survit. Cette valeur, lue
+brute du payload réseau, est persistée puis passée telle quelle à
+`SmtpMailer::Send()` comme `to`, insérée sans échappement dans les commandes SMTP
+brutes `RCPT TO:<to>` ([SmtpMailer.cpp:439](src/masterd/email/SmtpMailer.cpp:439))
+et l'en-tête `To:` — permettant l'injection de commandes/headers SMTP arbitraires.
+Le prepared-statement protège du SQL, pas du SMTP.
+
+**Recommandation** : rejeter dans `ValidateEmail()`/`NormaliseEmail()` tout octet
+de contrôle (0x00-0x1F, 0x7F) **n'importe où** dans la chaîne, et en défense en
+profondeur sanitiser `to`/`subject`/`from` dans `SmtpMailer::Send()`.
+
+---
+
+## P2 — Bug mineur / optimisation probable
+
+### Sécurité
+
+**F25 · /setlevel sans RBAC réel côté shard** —
+[slash_commands.json:457](game/data/config/slash_commands.json:457).
+La commande de triche `/setlevel` (minRole `administrator`) est routée shard et son
+gating effectif repose sur un simple booléen `ConnectedClient.chatModeratorRole`
+qui ne distingue pas moderator/game_master/administrator. Un compte `moderator`
+pourrait invoquer une commande censée être réservée aux administrateurs.
+*Reco* : propager le rôle réel du compte au shard et exiger `administrator` dans
+`ChatCommandParser` / `HandleChatSlashCommand`.
+
+**F26 · Position serveur appliquée sans validation NaN/Inf côté client** —
+[ClientPrediction.cpp:268](src/client/gameplay/ClientPrediction.cpp:268).
+`OnServerSnapshot` copie `snap.position`/`velocity` sans `std::isfinite` ni bornes.
+Le canal gameplay UDP n'authentifie pas fortement chaque champ : un paquet corrompu
+NaN/Inf propage indéfiniment via le lerp de `UpdateSmoothing`, corrompant l'état
+local sans récupération. *Reco* : valider `isfinite` + bornes de map, sinon
+ignorer/loguer et garder le dernier état valide.
+
+**F27 · Comparaison HMAC de ticket shard non à temps constant** —
+[ShardTicketCrypto.cpp:43](src/masterd/handlers/shard/ShardTicketCrypto.cpp:43).
+`std::memcmp` court-circuite au premier octet différent. Le `ticket_id` aléatoire à
+usage unique et TTL court limite fortement l'exploitabilité, mais c'est un écart
+aux bonnes pratiques. *Reco* : `CRYPTO_memcmp` d'OpenSSL (déjà lié).
+
+**F28 · Aucun rate-limiting sur le login du portail web** —
+[login/route.ts:16](web-portal/app/api/auth/login/route.ts:16).
+`/api/auth/login` et `/api/password-recovery/reset` n'ont aucun throttling/lockout
+(`verifyPortalCredentials` sans compteur d'échecs). Argon2id ralentit mais
+n'empêche pas un brute-force ciblé à faible volume. `requestPasswordRecovery` a bien
+un plafond de 3 tokens/h, mais pas le reset ni le login. *Reco* : rate limiting par
+IP/compte (DB ou Redis) avec verrouillage temporaire.
+
+**F29 · Token de reset écrit en clair dans les logs (fallback sans SMTP)** —
+[passwordRecovery.ts:292](web-portal/lib/auth/passwordRecovery.ts:292).
+Quand `SMTP_HOST`/`SMTP_FROM` sont absents, `logWarn` journalise le `resetUrl`
+complet (token valide 10 min). Si les logs sont centralisés/persistés et plus
+largement accessibles que le SMTP, cela offre une prise de contrôle de compte.
+*Reco* : ne jamais loguer le token/lien complet ; identifiant tronqué ou
+`account_id` uniquement, et s'assurer que ce chemin n'est pas actif en prod.
+
+**F30 · Injection HTML dans les e-mails via `{{var}}` non échappé** —
+[sender.ts:51](web-portal/lib/email/sender.ts:51).
+`loadTemplate()` fait `html.replaceAll("{{key}}", value)` sans échapper `< > & "`.
+`sendEmailChange()` injecte `newEmail` — validé seulement par `.includes('@')` —
+dans le template : une adresse `x"><script>…</script>@evil.com` passe la validation
+et le HTML/JS injecté finit dans l'e-mail envoyé. *Reco* : échapper les valeurs
+interpolées en entités HTML, ou valider `newEmail` avec un vrai regex strict.
+
+### Bug
+
+**F10 · Copie déployée de la migration 0043 obsolète (sans garde de colonne)** —
+[0043_phase_1c_account_roles.sql:1](deploy/docker/sql/migrations/0043_phase_1c_account_roles.sql:1).
+La version racine de 0043 contient une étape 0 qui garantit l'existence de
+`accounts.role` via `information_schema` (à cause du doublon de version 0023) ; la
+copie sous `deploy/docker/` ne l'a pas. Même mitigation CI que F1 (dossier
+régénéré). *Reco* : synchroniser depuis la version canonique.
+
+**F11 · Anti-flood chat contournable une fois `maxTrackedAccounts` atteint** —
+[ChatGate.cpp:158](src/masterd/chat/ChatGate.cpp:158).
+`m_windows` n'évince jamais d'entrée individuelle (`PurgeWindow` vide le deque mais
+pas la map ; seuls `ResetState`/`Reconfigure` la vident). Une fois 4096 comptes
+distincts trackés, tout **nouveau** compte reçoit `Allowed` sans passer par
+l'anti-flood — indéfiniment sur un serveur qui tourne des semaines. Le commentaire
+du header prétend à tort qu'une éviction LRU existe. *Reco* : éviction LRU réelle
+ou balayage périodique des entrées à deque vide.
+
+**F12 · Objet interactif : ni portée ni droit avant broadcast global** —
+[InteractiveHandler.cpp:52](src/masterd/handlers/interactive/InteractiveHandler.cpp:52).
+`HandlePacket` ne valide que l'existence d'une session : n'importe quel joueur
+authentifié peut changer l'état de n'importe quel objet interactif (porte, coffre)
+sans vérification de distance ni de droit, changement répercuté à toutes les
+connexions. Absence assumée dans le commentaire (M100.32). *Reco* : contrôle de
+portée/droits une fois la position serveur disponible côté master.
+
+**F13 · Craft : destruction définitive d'ingrédients sans output ni remboursement** —
+[CraftingSystem.cpp:413](src/shardd/gameplay/crafting/CraftingSystem.cpp:413).
+Les ingrédients sont validés une seule fois à `TryStartCraft`, pas réservés. À la
+complétion, la boucle appelle `RemoveItemFromInventory` par ingrédient ; cette
+fonction retire toujours ce qui est présent puis renvoie `false` si insuffisant, et
+la boucle `break` au premier manquant — mais les ingrédients déjà traités et la
+quantité partielle sont perdus, **sans output ni rollback**. Reproductible en
+vendant/tradant un ingrédient entre le start et le tick. *Reco* : re-valider la
+présence complète de **tous** les ingrédients avant d'en retirer un seul.
+
+**F14 · Parseur JSON de Config récursif sans limite de profondeur (stack overflow)** —
+[Config.cpp:125](src/shared/core/Config.cpp:125).
+`ParseObject`/`ParseArray` s'appellent mutuellement via `ParseValue` sans compteur
+de profondeur. Un fichier `[[[[…]]]]` de quelques Ko fortement imbriqué provoque un
+dépassement de pile au chargement de `config.json`, `server.config.json`,
+`zone.json` ou `scenery.json` (dont du contenu de zone potentiellement externe via
+`LoadActiveZone`). Même défaut dans `RoutineSerialization.cpp`. *Reco* : compteur de
+profondeur (seuil 64-128) renvoyant une erreur propre.
+
+**F15 · `DecodeRoutinesBin` : `reserve(count)` non borné depuis le fichier** —
+[RoutineSegmentCodec.cpp:68](src/shared/routine/RoutineSegmentCodec.cpp:68).
+`count` (u32) est lu du fichier et passé à `graphs.reserve(count)` sans validation
+vs `bytes.size()`. Un `routines.bin` corrompu avec `count=0xFFFFFFFF` déclenche un
+`std::bad_alloc`/`length_error` non catché → crash, au lieu du retour d'erreur
+propre appliqué aux autres champs. *Reco* : borner `count` vs la taille restante
+avant `reserve`.
+
+**F16 · `LoadDungeonPortalsBin` : `reserve()` non borné (crash éditeur)** —
+[DungeonPortalIo.cpp:147](src/world_editor/volumes/dungeons/DungeonPortalIo.cpp:147).
+Même pattern : `instanceCount` (u32) du header passé à `reserve()` avant validation
+par item. Un `.bin` corrompu/forgé fait tenter une réservation de centaines de Go →
+crash de l'éditeur à l'ouverture. *Reco* : borner `instanceCount` vs octets
+restants.
+
+**F17 · `LoadMeshInsertsBin` : même `reserve()` non borné** —
+[MeshInsertIo.cpp:149](src/world_editor/volumes/MeshInsertIo.cpp:149).
+Identique à F16 pour les instances de mesh insert. *Reco* : idem.
+
+### Perf *(candidats non mesurés)*
+
+**F18 · Purge O(n²) de `m_remoteSmoothed`/`m_remoteAnims` deux fois par frame** —
+[Engine.cpp:15417](src/client/app/Engine.cpp:15417).
+Deux boucles de purge scannent chacune tout le vecteur `remotes` par entrée de map,
+en O(n·m) répété deux fois par frame à ~60 FPS. En zone dense (AoI large) le coût
+croît quadratiquement. *Reco* : construire un `unordered_set<EntityId>` une fois par
+frame et purger les deux maps en O(n+m).
+
+**F19 · `emitBarriersBeforePass` alloue plusieurs conteneurs par passe et par frame** —
+[FrameGraph.cpp:291](src/client/render/FrameGraph.cpp:291).
+À chaque passe compilée de chaque frame, la fonction alloue sur le tas un
+`unordered_map` + plusieurs `vector` (barrières). Avec N passes (shadow, geometry,
+lighting, bloom, TAA, SSAO, water…), 3-5 alloc/désalloc par passe par frame. *Reco*
+: conteneurs membres pré-alloués (`clear()`) ou frame arena existant.
+
+**F20 · `vkDeviceWaitIdle` sur le thread de rendu à chaque éviction de chunk terrain** —
+[TerrainChunkRenderer.cpp:1150](src/client/render/terrain_chunk/TerrainChunkRenderer.cpp:1150).
+`Tick()` appelle `vkDeviceWaitIdle` pour libérer sûrement les buffers/images de
+chunks évincés — ce qui stall **toute la frame** (perte du parallélisme CPU/GPU) à
+chaque éviction pendant le streaming (déplacement joueur, changement de zone). Le
+`DeferredDestroyQueue` prévu existe et est déjà collecté par frame, mais son
+`PushBuffer`/`PushImage` n'est câblé nulle part. *Reco* : enfiler les ressources
+évincées dans `m_deferredDestroyQueue` au lieu du wait synchrone.
+
+**F21 · `QuestRuntime::ApplyEvent` : cascade O(quêtes²) à chaque événement gameplay** —
+[QuestRuntime.cpp:730](src/shardd/gameplay/quest/QuestRuntime.cpp:730).
+Appelé par kill/loot/talk/zone-enter, `ApplyEvent` appelle deux fois
+`SyncQuestStates`, qui itère toutes les définitions avec des scans linéaires
+`FindQuestStateIndex` (comparaison de chaînes) et une boucle imbriquée d'exclusion
+→ O(Q²)–O(Q³) par événement par joueur. OK pour un petit catalogue, ne scalera pas.
+*Reco* : `unordered_map<questId,index>` + graphe d'exclusion précalculé.
+
+**F22 · `FindMobByEntityId` reste un scan linéaire (index O(1) non appliqué aux mobs)** —
+[ServerApp.cpp:2452](src/shared/server_bootstrap/ServerApp.cpp:2452).
+`UpdateSpawners` appelle `FindMobByEntityId` par slot par spawner à chaque tick, en
+O(spawners·slots·mobs). Le même antipattern a déjà été corrigé pour les clients
+(`m_clientIndexByEntityId`, commenté « TG.2 — O(1) ») mais pas pour les mobs, malgré
+15+ appels dont plusieurs en boucle chaude. *Reco* : index
+`unordered_map<EntityId,size_t>` analogue.
+
+**F23 · Rasterisation polyline macro O(cellules × segments)** —
+[PolylineMacroCore.cpp:189](src/world_editor/terrain/PolylineMacroCore.cpp:189).
+`RasterizeMacroPolyline` teste, pour chaque cellule de la bbox, **tous** les
+segments de la polyline. Pour une longue polyline (chaîne de montagnes/vallée) ou
+un preset de zone automatisé, O(aire_bbox × nb_sommets). *Reco* : structure
+d'accélération spatiale (buckets par chunk).
+
+**F24 · Copie complète du heightmap à chaque tick de brosse Smooth** —
+[TerrainBrush.cpp:135](src/world_editor/terrain/TerrainBrush.cpp:135).
+En mode Smooth, `ApplyBrushKernel` fait `snapshot = chunk.heights` (257×257 =
+~258 Ko) à chaque tick de déplacement souris, alors que seule la bbox de la brosse
+est lue. Churn heap et memcpy inutiles à cadence interactive, × chunks touchés.
+*Reco* : ne copier que la sous-région de la bbox (+ halo de 1 cellule).
+
+---
+
+## P3 — Qualité / suggestions
+
+**F31 · Fuite latente d'image VMA dans `FrameGraph::destroy()`** —
+[FrameGraph.cpp:502](src/client/render/FrameGraph.cpp:502).
+Si `allocatedWithVma` est vrai mais l'allocateur nul, la destruction est sautée et
+la VkImage/VmaAllocation reste orpheline. Chemin **actuellement mort**
+(`ensureImageResources` force `allocatedWithVma=false`, bypass STAB.7) mais piège
+latent si le bypass est levé. *Reco* : voie de secours (`vkDestroyImage` direct) ou
+`LOG_ERROR` explicite.
+
+**F32 · Reset password envoyé à l'adresse fournie par le client, pas celle en base** —
+[PasswordResetHandler.cpp:130](src/masterd/handlers/password/PasswordResetHandler.cpp:130).
+`HandleForgotPassword` envoie à `email` (entrée réseau normalisée) plutôt qu'à
+`optAccount->email` (valeur DB canonique). Impact nul en nominal (FindByEmail matche
+exact), mais dérive possible si la normalisation applicative diverge un jour de la
+collation SQL. Incohérent avec `TermsHandler`/`AuthRegisterHandler`. *Reco* :
+utiliser `optAccount->email`.
+
+**F33 · `UpdateField` stocke un pointeur brut vers le mask de l'objet propriétaire** —
+[UpdateField.h:67](src/shardd/entities/UpdateField.h:67).
+`Unit`/`Creature`/`Player`/`WorldObject` construisent chaque `UpdateField<T>` avec
+`&Mask()` mais ne déclarent aucun constructeur/opérateur de copie supprimé : une
+copie par valeur (ex. `std::vector<Player>` qui réalloue) laisserait les pointeurs
+de mask pointer vers l'objet **original** → corruption de réplication ou
+use-after-free. Aucun call site ne copie ces types aujourd'hui — footgun latent.
+*Reco* : `= delete` sur la copie de `Object` tant qu'une deep-copy correcte n'existe
+pas.
+
+**F34 · Statement caché reste cassé après échec de `Reset()` sur un hit** —
+[SqlPreparedStatement.cpp:377](src/shared/db/SqlPreparedStatement.cpp:377).
+Sur un cache hit, si `stmt->Reset()` échoue, `Acquire()` renvoie `nullptr` mais
+l'entrée reste dans `m_lru`/`m_index` : les `Acquire()` suivants pour le même SQL
+échoueront en boucle. Impact faible (le `ConnectionPool` reset tout le cache sur
+échec de connexion) mais l'auto-guérison au niveau statement manque. *Reco* :
+évincer l'entrée sur échec de `Reset()`.
+
+**F35 · Même `reserve()` non borné pour les proxies de collision de volume** —
+[VMapBridge.cpp:265](src/world_editor/volumes/bridge/VMapBridge.cpp:265).
+`outProxies.reserve(count)` depuis un champ header non validé. Sévérité moindre que
+F16/F17 (POD sans strings, ~128 Go au pire) mais vecteur de crash sur fichier
+corrompu. *Reco* : valider `count` vs octets restants, cohérent avec les autres
+loaders.
+
+**F36 · Géolocalisation IP en clair (HTTP, pas HTTPS)** —
+[IpApiGeoProvider.cpp:65](src/client/localization/IpApiGeoProvider.cpp:65).
+`FetchCountryCode` utilise `WinHttpOpenRequest(…, 0)` (pas `WINHTTP_FLAG_SECURE`) et
+le port HTTP par défaut. Un attaquant réseau observe le lancement du client
+(fingerprinting) et peut falsifier la réponse JSON pour influencer la langue
+suggérée (impact fonctionnel mineur). *Reco* : passer en HTTPS (port 443,
+`WINHTTP_FLAG_SECURE`) comme les autres appels WinHTTP du module auth.
+
+---
+
+## Couverture & limites
+
+**Cellules auditées (15/15, aucune échouée)** : masterd (handlers/wire, auth,
+autres), shardd (net/anticheat, gameplay/entities, autres), shared
+(net/messager, security/auth/db, core/util/formulas), client (render, app/net,
+gameplay/UI), world_editor, web-portal, sql + tools + deploy/config.
+
+**Exclusions** : `legacy/` (consigne permanente), `game/data` hors
+`slash_commands.json`, `tickets/`, `docs/`, assets binaires.
+
+**Rappels méthodologiques** :
+- Analyse **statique** — aucun build ni profiling local. Les 7 findings **perf**
+  sont des **candidats à mesurer** avant optimisation.
+- Chaque finding P0/P1 a été soumis à une réfutation adversariale ; 2 findings
+  (sur 38 bruts) ont été réfutés et écartés.
+- F1 et F10 concernent un dossier (`deploy/docker/sql/migrations/`) **régénéré en
+  CI** : le chemin de déploiement officiel n'est pas affecté, seul un build Docker
+  manuel l'est. Déjà signalé par les audits de juin.
+
+## Priorisation suggérée
+
+1. **F2 + F3** (auth du canal shard) — traiter ensemble, plus grave impact.
+2. **F4** (TLS CAPTCHA) et **F7** (pinning client) — corrections TLS localisées.
+3. **F5** (renvoi de code, une ligne) et **F8/F9** (brute-force/injection auth).
+4. **F1/F10** — décider du sort du dossier `deploy/docker/sql/migrations` committé.
+
+**Déploiement** : ✅ docs uniquement, pas de redéploiement serveur. *(Les
+corrections issues de ce rapport, elles, seront pour la plupart wire/serveur —
+F1–F6, F8–F13, F21, F22, F25 touchent le master ou le shard et exigeront un
+redéploiement lock-step quand elles seront livrées.)*

--- a/docs/superpowers/plans/2026-07-03-audit-complet-frais.md
+++ b/docs/superpowers/plans/2026-07-03-audit-complet-frais.md
@@ -1,0 +1,178 @@
+# Audit complet frais — plan d'exécution
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Produire un rapport d'audit unique (`docs/audit/2026-07-03-audit-complet-frais.md`) recensant anomalies, problèmes de sécurité et optimisations candidates sur tout le code du projet hors `legacy/`, sans modifier de code applicatif.
+
+**Architecture:** Workflow multi-agents en 4 phases — audit (fan-out par cellule sous-système × dimension), dédup (barrière, code), vérification adversariale (réfutation des P0/P1), synthèse (rédaction). Chaque agent d'audit et de vérification retourne des données structurées via schéma JSON.
+
+**Tech Stack:** Outil `Workflow` (JS), agents `Explore`/`general-purpose`, schémas JSON pour la sortie structurée. Aucun build local (pas de toolchain), analyse statique de lecture uniquement.
+
+## Global Constraints
+
+- Livrable en **français** ; identifiants/commandes/chemins restent en anglais.
+- **Aucune modification de code applicatif** dans cette session — seul le fichier rapport (et éventuels artefacts de travail dans le scratchpad) est écrit.
+- Exclure **totalement** `legacy/` de tout scan.
+- Ne pas employer le terme « CMANGOS » dans le rapport.
+- Classement des sévérités : **P0** sécurité critique / **P1** bug sérieux ou sécurité modérée / **P2** bug mineur ou perf probable / **P3** qualité.
+- Chaque finding : `fichier:ligne` cliquable (chemin relatif à la racine repo), catégorie (sécurité/bug/perf), description, recommandation.
+- Findings perf = candidats à mesurer (pas de profiling possible), le signaler comme tel.
+- Zéro finding P0/P1 non contre-vérifié dans le rapport final.
+- Toute cellule qui échoue doit être mentionnée dans le rapport (pas d'abandon silencieux — règle « no silent caps »).
+- Rapport committé + poussé sur la branche `claude/funny-bardeen-f6f803`.
+- Déploiement : ✅ docs uniquement, pas de redéploiement serveur.
+
+---
+
+## Découpage en cellules (Phase 1)
+
+Chaque cellule = un agent d'audit. Dimensions notées S (sécurité), B (bug/anomalie), P (perf).
+
+| # | Cellule | Chemins | Dimensions | Priorité risque |
+|---|---------|---------|------------|-----------------|
+| C1 | masterd — handlers & wire | `src/masterd/handlers`, `src/masterd/*/` handlers d'opcodes | S, B | Élevée (surface réseau) |
+| C2 | masterd — auth/account/session | `src/masterd/account`, `src/masterd/admin`, `src/masterd/email` | S, B | Élevée (gating) |
+| C3 | masterd — autres sous-systèmes | `src/masterd/{arena,auction,battleground,chat,cinematics,events,gmtickets,guild,lfg,loot,mail,metrics,Groups}` | S, B | Moyenne |
+| C4 | shardd — net & anticheat | `src/shardd/net`, `src/shardd/anticheat`, `src/shardd/app` | S, B | Élevée |
+| C5 | shardd — gameplay & entities | `src/shardd/{gameplay,entities,combat,Movement,ai,maps,internals,dbscripts}` | B, P | Moyenne |
+| C6 | shardd — autres sous-systèmes | `src/shardd/{arena,auction,battleground,cinematics,guild,loot}` | S, B | Moyenne |
+| C7 | shared — net/network/messager | `src/shared/{net,network,messager}` | S, B | Élevée (parsing wire partagé) |
+| C8 | shared — security/auth/account/db | `src/shared/{security,auth,account,db}` | S, B | Élevée |
+| C9 | shared — core/util/formulas/math/world/routine/platform | `src/shared/{core,util,formulas,math,world,routine,platform,server_bootstrap,metric}` | B, P | Moyenne |
+| C10 | client — render | `src/client/render` | B, P | Moyenne (Vulkan, races, fuites) |
+| C11 | client — app & net | `src/client/app`, `src/client/net` | B, P, S | Élevée (threads réseau vs rendu — précédent crash géoloc) |
+| C12 | client — gameplay/UI/systèmes | `src/client/{quest,combat,inventory,trade,chat,auth,grimoire,hud,dialogue,social,guild,mail,loot,economy,crafting,skills,reputation,character_creation,settings,localization,gameplay,world,weather,audio,fx,ui_common,main.cpp}` | B, S | Moyenne |
+| C13 | world_editor | `src/world_editor`, `src/client/render/terrain/TerrainEditingTools.*` | B, P | Faible-moyenne |
+| C14 | web-portal | `web-portal/{app,lib,components,middleware.ts,email-templates,nginx,next.config.mjs}` | S, B | Élevée (XSS/CSRF/secrets/injection) |
+| C15 | sql + tools + deploy/config | `sql/migrations`, `tools/{hlod_builder,zone_builder,impostor_builder,load_tester}`, `deploy/docker`, `config.json`, `game/data/config/slash_commands.json` | S, B | Moyenne (injection SQL, secrets, RBAC) |
+
+**Consigne commune à toutes les cellules d'audit** (incluse dans le prompt de chaque agent) :
+- Lire le code réel, ne pas deviner. Exclure `legacy/`.
+- Pour chaque finding, fournir : `file` (relatif racine), `line` (1-indexé), `severity` (P0/P1/P2/P3), `category` (securite/bug/perf), `summary` (1 phrase), `detail` (mécanisme + condition de déclenchement), `recommendation`.
+- Perf : indiquer que c'est un candidat non mesuré.
+- Ne pas inventer de findings pour « remplir » ; retourner une liste vide est acceptable.
+
+---
+
+## Task 1 : Écrire et lancer le workflow d'audit (Phases 1–3)
+
+**Files:**
+- Create (scratchpad, artefact de travail) : script du workflow via l'outil `Workflow` (persisté automatiquement sous la session)
+- Aucun fichier du repo modifié à cette étape
+
+**Interfaces:**
+- Produces : un tableau JS `findingsVerifies` — liste d'objets `{file, line, severity, category, summary, detail, recommendation, verdict, cellule}` où `verdict ∈ {CONFIRMED, PLAUSIBLE, REFUTED}` ; les REFUTED sont exclus ou rétrogradés.
+
+- [ ] **Step 1 : Définir les schémas JSON**
+
+Schéma finding (sortie des agents d'audit) :
+```
+FINDINGS_SCHEMA = {
+  type: "object",
+  required: ["findings"],
+  properties: {
+    findings: {
+      type: "array",
+      items: {
+        type: "object",
+        required: ["file","line","severity","category","summary","detail","recommendation"],
+        properties: {
+          file:   {type:"string"},
+          line:   {type:"integer"},
+          severity:{type:"string", enum:["P0","P1","P2","P3"]},
+          category:{type:"string", enum:["securite","bug","perf"]},
+          summary:{type:"string"},
+          detail: {type:"string"},
+          recommendation:{type:"string"}
+        }
+      }
+    }
+  }
+}
+```
+Schéma verdict (sortie des agents de vérification) :
+```
+VERDICT_SCHEMA = {
+  type:"object",
+  required:["verdict","justification"],
+  properties:{
+    verdict:{type:"string", enum:["CONFIRMED","PLAUSIBLE","REFUTED"]},
+    severiteCorrigee:{type:"string", enum:["P0","P1","P2","P3"]},
+    justification:{type:"string"}
+  }
+}
+```
+
+- [ ] **Step 2 : Phase 1 — fan-out des 15 cellules**
+
+Utiliser `pipeline()` sur les 15 cellules décrites dans la table ci-dessus. Stage 1 = agent d'audit (agentType `Explore`, schéma `FINDINGS_SCHEMA`), label `audit:C<n>`, phase `Audit`. Le prompt de chaque agent contient : les chemins de la cellule, les dimensions à couvrir, et la **consigne commune** ci-dessus verbatim.
+
+- [ ] **Step 3 : Phase 2 — dédup (barrière implicite dans la 2e étape du pipeline)**
+
+Après collecte, dédupliquer en code : clé = `file` + `line` arrondie à ±3 lignes + `category`. En cas de doublon, conserver la sévérité la plus haute et concaténer les détails distincts. (La dédup se fait sur le tableau agrégé — c'est le seul point nécessitant tous les résultats d'audit, donc collecter via `.flat()` avant vérification.)
+
+- [ ] **Step 4 : Phase 3 — vérification adversariale**
+
+Pour chaque finding dédupliqué de sévérité **P0 ou P1** : agent sceptique (`general-purpose`, schéma `VERDICT_SCHEMA`), prompt = « Tente de RÉFUTER ce finding en relisant le code réel à `file:line`. Par défaut, considère-le douteux : ne le confirme que si le mécanisme et la condition de déclenchement tiennent. Renvoie REFUTED si le code cité ne correspond pas, si la garde manquante existe en réalité ailleurs, ou si la condition n'est pas atteignable. » Label `verify:<file>`, phase `Verify`.
+Pour chaque finding **P2/P3** : vérification simple (`Explore`, `VERDICT_SCHEMA`) — le code cité existe-t-il et le finding est-il plausible ? Renvoyer REFUTED si le code cité est absent/erroné.
+Filtrer : exclure les `verdict === "REFUTED"`. Appliquer `severiteCorrigee` si présente.
+
+- [ ] **Step 5 : Retourner le tableau `findingsVerifies`**
+
+Le workflow retourne `{findingsVerifies, cellulesEchouees}` où `cellulesEchouees` liste les cellules dont l'agent a renvoyé `null` (skip/erreur).
+
+- [ ] **Step 6 : Lancer le workflow**
+
+Invoquer `Workflow` avec le script. Attendre la notification de complétion. Récupérer le tableau retourné.
+
+---
+
+## Task 2 : Rédiger le rapport d'audit
+
+**Files:**
+- Create : `docs/audit/2026-07-03-audit-complet-frais.md`
+
+**Interfaces:**
+- Consumes : `{findingsVerifies, cellulesEchouees}` de Task 1.
+
+- [ ] **Step 1 : Écrire l'en-tête et le résumé exécutif**
+
+En-tête : titre, date, périmètre audité (lister les 15 cellules), méthode (workflow multi-agents, vérification adversariale), rappel « analyse statique, findings perf non mesurés ». Résumé exécutif : compte de findings par sévérité (tableau), et les 3-5 points les plus importants en prose.
+
+- [ ] **Step 2 : Écrire les sections par sévérité**
+
+Quatre sections : P0, P1, P2, P3. Dans chaque section, un sous-titre par finding avec : localisation `[fichier:ligne](chemin:ligne)` cliquable, catégorie, description (mécanisme + condition), recommandation. Trier au sein de chaque section par catégorie puis par fichier.
+
+- [ ] **Step 3 : Écrire la section « Couverture & limites »**
+
+Lister les cellules couvertes, les cellules échouées (`cellulesEchouees`) le cas échéant, et rappeler explicitement : pas de build/profiling local, `legacy/` exclu, `game/data` (hors slash_commands.json) exclu.
+
+- [ ] **Step 4 : Ligne de déploiement**
+
+Terminer par : `**Déploiement** : ✅ docs uniquement, pas de redéploiement serveur.`
+
+- [ ] **Step 5 : Commit + push**
+
+```bash
+git add docs/audit/2026-07-03-audit-complet-frais.md
+git commit -m "docs(audit): audit complet frais 2026-07-03 — anomalies, sécurité, perf"
+git push -u origin claude/funny-bardeen-f6f803
+```
+
+---
+
+## Task 3 : Restituer à l'utilisateur
+
+**Files:** aucun.
+
+- [ ] **Step 1 : Message de synthèse final**
+
+Dans le dernier message : nombre de findings par sévérité, les findings P0/P1 en clair (localisation + une phrase chacun), lien vers le rapport committé, mention des cellules échouées s'il y en a, et la ligne de déploiement. Proposer (sans l'exécuter) de cadrer les corrections P0/P1 en PRs séparées.
+
+---
+
+## Self-Review
+
+- **Couverture spec** : périmètre (15 cellules couvrent src/*, web-portal, sql, tools, deploy/config → C1–C15) ✅ ; 3 dimensions (S/B/P réparties par cellule) ✅ ; workflow 4 phases (Task 1 steps 2–4 + Task 2) ✅ ; livrable rapport classé P0→P3 (Task 2) ✅ ; vérification adversariale P0/P1 (Task 1 step 4) ✅ ; français + pas de correction code + legacy exclu + pas de « CMANGOS » (Global Constraints) ✅ ; commit+push (Task 2 step 5) ✅ ; cellules échouées signalées (Task 1 step 5 → Task 2 step 3) ✅.
+- **Placeholders** : les schémas et prompts sont donnés en toutes lettres ; pas de « TBD ».
+- **Cohérence des types** : `FINDINGS_SCHEMA`/`VERDICT_SCHEMA` définis en Task 1 step 1 et réutilisés steps 2/4 ; champ `verdict` produit step 4 et consommé step 5 ; `findingsVerifies`/`cellulesEchouees` produits Task 1 et consommés Task 2. Cohérent.

--- a/docs/superpowers/plans/2026-07-03-corrections-p0-p1-audit.md
+++ b/docs/superpowers/plans/2026-07-03-corrections-p0-p1-audit.md
@@ -1,0 +1,844 @@
+# Corrections P0/P1 de l'audit 2026-07-03 — plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Corriger 8 findings P0/P1 de l'audit (F1-F6, F8, F9) ; F7 différé (documenté).
+
+**Architecture:** Corrections serveur + deploy, sur la branche `claude/funny-bardeen-f6f803`, server-first, un commit par finding. F3 introduit un tag HMAC en **préfixe** (32 octets de tête) sur les payloads REGISTER/HEARTBEAT pour éviter l'ambiguïté avec le tableau optionnel de joueurs en queue du heartbeat.
+
+**Tech Stack:** C++17, OpenSSL (HMAC-SHA256, `CRYPTO_memcmp`), CMake, tests standalone `int main()` façon `ShardPayloadsTests.cpp`, CI Linux `ctest`.
+
+## Global Constraints
+
+- Commentaires et messages en **français** ; identifiants/commandes en anglais.
+- **Aucune modification du binaire client de jeu** (F7 différé ; le REGISTER shard part de `shardd`).
+- Ne pas utiliser le terme « CMANGOS ».
+- Nouveau code / fichier / dossier en **PascalCase** ; `m_camelCase`/`kPascalCase` conservés pour le style existant.
+- **Piège `assert`+`NDEBUG`** : ne jamais mettre de logique de validation dans un `assert` (la CI build en release).
+- **`server_app` ne linke pas `engine_core`** : tout nouveau `.cpp` partagé utilisé côté serveur doit être ajouté **aussi** à la liste `server_app` dans `src/CMakeLists.txt`.
+- **Pas de build local** (ni cmake/MSVC/vcpkg) : compilation et `ctest` via la CI uniquement. Les steps « run test » décrivent le résultat CI attendu.
+- F3 est **wire-breaking** + F6 change le **boot** → déploiement **lock-step master+shard**.
+- Constantes utiles : `kShardTicketHmacSize = 32` (`src/shared/network/ShardTicketPayloads.h:17`), `kOpcodeResendVerificationRequest = 37`, `kOpcodeShardRegister = 10`, `kOpcodeShardHeartbeat = 13`, `shard.ticket_hmac_secret` = clé du secret partagé.
+
+---
+
+## Cartographie des fichiers
+
+| Finding | Fichiers touchés |
+|---------|------------------|
+| F9 | `src/shared/account/AccountValidation.cpp`, `src/masterd/email/SmtpMailer.cpp`, test `AccountValidation` |
+| F5 | `src/masterd/main_linux.cpp` (dispatch ~1097) |
+| F8 | `src/masterd/handlers/password/PasswordResetHandler.cpp` (`HandleVerifyEmail`) |
+| F2 | `src/masterd/handlers/shard/ShardRegisterHandler.cpp` (`HandleHeartbeat`) |
+| F4 | `src/shared/security/CaptchaVerifier.cpp` (`VerifyHttp`) |
+| F3 | **Create** `src/shared/network/ShardWireAuth.{h,cpp}` ; `src/shared/network/ShardToMasterClient.{h,cpp}` ; `src/masterd/handlers/shard/ShardRegisterHandler.{h,cpp}` ; `src/masterd/main_linux.cpp` ; `src/shardd/main_linux.cpp` ; `src/CMakeLists.txt` ; test `src/shared/network/ShardWireAuthTests.cpp` |
+| F6 | **Create** `src/shared/security/SharedSecretPolicy.{h,cpp}` ; `src/masterd/main_linux.cpp` ; `src/shardd/main_linux.cpp` ; 3 configs `deploy/docker/config/master.config.json`, `deploy/docker/config/shard.config.json`, `deploy/docker/server-config/config.json` ; `src/CMakeLists.txt` ; test `src/shared/security/SharedSecretPolicyTests.cpp` |
+| F1/F10 | `deploy/docker/sql/migrations/` (resync) ; garde CI `.github/workflows/` |
+| F7 | `docs/audit/2026-07-03-audit-complet-frais.md` (marquer différé) |
+
+---
+
+## Task 1 : F9 — rejeter les caractères de contrôle dans l'e-mail
+
+**Files:**
+- Modify: `src/shared/account/AccountValidation.cpp:36` (`ValidateEmail`)
+- Modify: `src/masterd/email/SmtpMailer.cpp` (`Send`, défense en profondeur)
+- Test: fichier de test `AccountValidation` (voir Step 1 pour la localisation)
+
+**Interfaces:**
+- Consumes: `engine::network::NetErrorCode`, `engine::server::ValidateEmail(std::string_view)`.
+- Produces: `ValidateEmail` rejette désormais tout octet `< 0x20` ou `== 0x7F`.
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Localiser le test unitaire d'`AccountValidation` : `grep -rln "ValidateEmail" src --include=*Test*`. S'il existe, y ajouter les cas ci-dessous ; sinon créer `src/shared/account/AccountValidationTests.cpp` sur le modèle de `src/shared/network/ShardPayloadsTests.cpp` (fonction `Assert`, `int main()` renvoyant `s_failCount != 0`) et l'enregistrer dans le `CMakeLists.txt` du dossier comme les autres tests.
+
+```cpp
+// Cas à ajouter :
+using engine::server::ValidateEmail;
+using engine::network::NetErrorCode;
+Assert(ValidateEmail("a@b.com") == NetErrorCode::OK, "email valide accepté");
+Assert(ValidateEmail(std::string("a@b.com\r\nRCPT TO:<x@evil>")) == NetErrorCode::INVALID_EMAIL,
+       "CRLF au milieu rejeté");
+Assert(ValidateEmail(std::string("a\tb@c.com")) == NetErrorCode::INVALID_EMAIL, "TAB rejeté");
+{ std::string withNul = "a@b.com"; withNul.push_back('\0'); withNul += "x";
+  Assert(ValidateEmail(withNul) == NetErrorCode::INVALID_EMAIL, "NUL rejeté"); }
+```
+
+- [ ] **Step 2 : Vérifier l'échec (CI)**
+
+En CI, `ctest` sur la cible de test `AccountValidation` doit **échouer** : `ValidateEmail` accepte encore CR/LF/TAB/NUL (aucune vérification de caractères de contrôle). Résultat attendu : `[FAIL] CRLF au milieu rejeté`.
+
+- [ ] **Step 3 : Implémenter**
+
+Dans `src/shared/account/AccountValidation.cpp`, ajouter la vérification en tête de `ValidateEmail` (après le test `empty`, avant le reste) :
+
+```cpp
+	engine::network::NetErrorCode ValidateEmail(std::string_view normalisedEmail)
+	{
+		if (normalisedEmail.empty())
+			return engine::network::NetErrorCode::INVALID_EMAIL;
+		// Sécurité (audit F9) : aucun caractère de contrôle (0x00-0x1F, 0x7F) où que ce soit —
+		// empêche l'injection SMTP (CR/LF vers RCPT TO/headers) via l'adresse enregistrée.
+		for (unsigned char c : normalisedEmail)
+		{
+			if (c < 0x20u || c == 0x7Fu)
+				return engine::network::NetErrorCode::INVALID_EMAIL;
+		}
+		if (normalisedEmail.size() > kAccountEmailMaxLength)
+			return engine::network::NetErrorCode::INVALID_EMAIL;
+		// ... reste inchangé (@, domaine, '.') ...
+```
+
+Défense en profondeur — dans `src/masterd/email/SmtpMailer.cpp`, au début de `Send` (repérer la signature via `grep -n "::Send" src/masterd/email/SmtpMailer.cpp`), rejeter tout CR/LF dans les champs insérés dans le protocole :
+
+```cpp
+	// Sécurité (audit F9) : refuser CR/LF dans les champs injectés dans les commandes/headers SMTP.
+	auto hasCrlf = [](std::string_view s) { return s.find('\r') != std::string_view::npos || s.find('\n') != std::string_view::npos; };
+	if (hasCrlf(to) || hasCrlf(subject) || hasCrlf(from_address))
+	{
+		LOG_WARN(Core, "[SmtpMailer] Send refusé : CR/LF détecté dans to/subject/from");
+		return false; // adapter au type de retour réel de Send (bool attendu)
+	}
+```
+
+Adapter les noms de paramètres (`to`/`subject`/`from_address`) à la signature réelle et le `return false` au type de retour effectif.
+
+- [ ] **Step 4 : Vérifier le passage (CI)**
+
+`ctest` sur la cible `AccountValidation` doit **passer** (4 cas verts).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add src/shared/account/AccountValidation.cpp src/masterd/email/SmtpMailer.cpp src/shared/account/AccountValidationTests.cpp
+git commit -m "fix(security): F9 — rejet des caractères de contrôle dans l'e-mail (anti-injection SMTP)"
+```
+
+---
+
+## Task 2 : F5 — router `kOpcodeResendVerificationRequest`
+
+**Files:**
+- Modify: `src/masterd/main_linux.cpp:1097-1099` (condition de dispatch)
+
+**Interfaces:**
+- Consumes: `kOpcodeResendVerificationRequest` (=37), `passwordResetHandler.HandlePacket(...)` qui sait déjà traiter cet opcode.
+- Produces: l'opcode 37 est routé vers `PasswordResetHandler`.
+
+- [ ] **Step 1 : Implémenter (une ligne)**
+
+Dans `src/masterd/main_linux.cpp`, la condition (lignes ~1097-1099) :
+
+```cpp
+		else if (opcode == kOpcodeForgotPasswordRequest
+		      || opcode == kOpcodeResetPasswordRequest
+		      || opcode == kOpcodeVerifyEmailRequest)
+			passwordResetHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+```
+
+devient :
+
+```cpp
+		else if (opcode == kOpcodeForgotPasswordRequest
+		      || opcode == kOpcodeResetPasswordRequest
+		      || opcode == kOpcodeVerifyEmailRequest
+		      || opcode == kOpcodeResendVerificationRequest)
+			passwordResetHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+```
+
+- [ ] **Step 2 : Vérifier (revue)**
+
+Pas de test unitaire isolé du `main`. Vérifier par lecture que `PasswordResetHandler::HandlePacket` route bien `kOpcodeResendVerificationRequest` vers `HandleResendVerification` (déjà le cas, PasswordResetHandler.cpp:~49) et que la condition compile.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add src/masterd/main_linux.cpp
+git commit -m "fix(auth): F5 — router kOpcodeResendVerificationRequest vers PasswordResetHandler"
+```
+
+---
+
+## Task 3 : F8 — rate-limit sur `HandleVerifyEmail`
+
+**Files:**
+- Modify: `src/masterd/handlers/password/PasswordResetHandler.cpp:230-291` (`HandleVerifyEmail`)
+- Test: `src/masterd/handlers/password/` (test existant du handler ; voir Step 1)
+
+**Interfaces:**
+- Consumes: `m_rateLimit` (`engine::server::RateLimitAndBan*`, déjà injecté via `SetRateLimitAndBan`, actuellement inutilisé). API : `bool IsBanned(std::string_view) const`, `void RecordAuthFailure(std::string_view)` (bannit après `max_failures_before_ban`, défaut 5, pour `ban_duration_sec`, défaut 3600s).
+- Produces: `HandleVerifyEmail` refuse les tentatives après N codes erronés, clé `"vemail:"+account_id`.
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Localiser le test du handler : `grep -rln "PasswordResetHandler\|HandleVerifyEmail" src/masterd --include=*Test*`. Ajouter un cas (ou créer le fichier sur le modèle standalone) : construire un `PasswordResetHandler` avec un `RateLimitAndBan` réel (`SetConfig` par défaut, `max_failures_before_ban=5`), un `AccountStore` en mémoire avec un compte non vérifié, un `PasswordResetStore` avec un code connu. Envoyer 5 `HandleVerifyEmail` avec un **mauvais** code puis un 6ᵉ avec le **bon** code ; asserter que le 6ᵉ est refusé (compte verrouillé) malgré le bon code.
+
+```cpp
+// Pseudo-cas (adapter aux helpers de test existants du handler) :
+for (int i = 0; i < 5; ++i) handler.HandleVerifyEmail(conn, req, sess, badPayload.data(), badPayload.size());
+handler.HandleVerifyEmail(conn, req, sess, goodPayload.data(), goodPayload.size());
+Assert(!account.email_verified, "verrouillé après 5 échecs : bon code refusé");
+```
+
+- [ ] **Step 2 : Vérifier l'échec (CI)**
+
+Sans rate-limit, le 6ᵉ appel avec le bon code marque `email_verified=true` → l'assert échoue.
+
+- [ ] **Step 3 : Implémenter**
+
+Dans `src/masterd/handlers/password/PasswordResetHandler.cpp`, `HandleVerifyEmail`, après avoir obtenu `account_id` (ligne ~252) et **avant** `ValidateVerificationCode` :
+
+```cpp
+		const uint64_t account_id = parsed->account_id;
+		// Sécurité (audit F8) : verrou anti-brute-force sur le code à 6 chiffres, clé par compte.
+		const std::string rlKey = "vemail:" + std::to_string(account_id);
+		if (m_rateLimit && m_rateLimit->IsBanned(rlKey))
+		{
+			LOG_WARN(Auth, "[PasswordResetHandler] VerifyEmail: verrouillé (trop d'échecs) account_id={}", account_id);
+			auto pkt = BuildVerifyEmailResponseErrorPacket(NetErrorCode::VERIFICATION_CODE_INVALID, requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+```
+
+Puis, dans la branche « code invalide » (ligne ~274-280), enregistrer l'échec :
+
+```cpp
+		if (!m_resetStore->ValidateVerificationCode(account_id, parsed->code))
+		{
+			if (m_rateLimit) m_rateLimit->RecordAuthFailure(rlKey); // audit F8 : bannit après N échecs
+			LOG_WARN(Auth, "[PasswordResetHandler] VerifyEmail: invalid or expired code (account_id={})", account_id);
+			auto pkt = BuildVerifyEmailResponseErrorPacket(NetErrorCode::VERIFICATION_CODE_INVALID, requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+```
+
+Note : la réponse en cas de verrou est **identique** à celle d'un code invalide (`VERIFICATION_CODE_INVALID`) — pas de divulgation « verrouillé » qui aiderait l'énumération. La clé par `account_id` limite le verrou au seul compte visé (DoS mineur assumé sur l'email-verify de ce compte).
+
+- [ ] **Step 4 : Vérifier le passage (CI)**
+
+Le 6ᵉ appel est rejeté par `IsBanned` → `email_verified` reste `false` → assert vert.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add src/masterd/handlers/password/PasswordResetHandler.cpp <fichier de test>
+git commit -m "fix(security): F8 — rate-limit anti-brute-force sur la vérification d'e-mail"
+```
+
+---
+
+## Task 4 : F2 — lier le heartbeat shard à la connexion enregistrée
+
+**Files:**
+- Modify: `src/masterd/handlers/shard/ShardRegisterHandler.cpp:127-148` (`HandleHeartbeat`)
+
+**Interfaces:**
+- Consumes: `m_registry->GetShardConnection(uint32_t shard_id)` (déclaré `ShardRegistry.h:96-99`, renvoie la `connId` enregistrée ; vérifier le type de retour exact — probablement `uint32_t`, 0 si absent).
+- Produces: `HandleHeartbeat` rejette un heartbeat dont la `connId` ne correspond pas au shard enregistré.
+
+- [ ] **Step 1 : Vérifier l'API `GetShardConnection`**
+
+`grep -n "GetShardConnection" src/masterd/shards/ShardRegistry.h` pour confirmer la signature exacte (paramètre `shard_id`, type de retour). Adapter le code du Step 2 en conséquence (ex. `std::optional<uint32_t>` vs `uint32_t` sentinelle 0).
+
+- [ ] **Step 2 : Implémenter**
+
+Dans `src/masterd/handlers/shard/ShardRegisterHandler.cpp`, remplacer la signature `HandleHeartbeat(uint32_t /*connId*/, …)` par `HandleHeartbeat(uint32_t connId, …)` et ajouter la vérification après le parse réussi, avant `UpdateHeartbeat` :
+
+```cpp
+	void ShardRegisterHandler::HandleHeartbeat(uint32_t connId, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		auto parsed = ParseShardHeartbeatPayload(payload, payloadSize);
+		if (!parsed)
+		{
+			LOG_WARN(Server, "[SREG] HandleHeartbeat: parse failed");
+			return;
+		}
+		// Sécurité (audit F2) : le shard_id du heartbeat doit correspondre à la connId qui a
+		// réalisé le REGISTER. Rejette un heartbeat forgé pour un shard_id qu'on ne possède pas.
+		const uint32_t registered = m_registry->GetShardConnection(parsed->shard_id); // adapter si optional
+		if (registered == 0u || registered != connId)
+		{
+			LOG_WARN(Server, "[SREG] HandleHeartbeat rejeté : connId={} ne correspond pas au shard_id={} (attendu connId={})",
+				connId, parsed->shard_id, registered);
+			return;
+		}
+		m_registry->UpdateHeartbeat(parsed->shard_id, parsed->current_load);
+		if (m_presenceCache)
+			m_presenceCache->Update(parsed->shard_id, parsed->players);
+	}
+```
+
+Mettre à jour la déclaration correspondante dans `src/masterd/handlers/shard/ShardRegisterHandler.h` (paramètre `connId` nommé). L'appel `HandleHeartbeat(connId, payload, payloadSize)` existe déjà (ShardRegisterHandler.cpp:44).
+
+- [ ] **Step 3 : Vérifier (revue + CI compile)**
+
+Revue : le chemin REGISTER appelle bien `SetShardConnection(shard_id, connId)` (lignes 93/115), donc `GetShardConnection` est peuplé avant tout heartbeat légitime. Compilation CI verte.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add src/masterd/handlers/shard/ShardRegisterHandler.cpp src/masterd/handlers/shard/ShardRegisterHandler.h
+git commit -m "fix(security): F2 — lier le heartbeat shard à la connId enregistrée"
+```
+
+---
+
+## Task 5 : F4 — vérifier le certificat TLS dans `CaptchaVerifier`
+
+**Files:**
+- Modify: `src/shared/security/CaptchaVerifier.cpp:215` (`VerifyHttp`)
+
+**Interfaces:**
+- Consumes: OpenSSL (`SSL_CTX`, `SSL`), la variable locale `host` de `VerifyHttp`.
+- Produces: `VerifyHttp` échoue si le certificat serveur n'est pas validé par le trust store système.
+
+- [ ] **Step 1 : Vérifier le trust store Docker**
+
+`ca-certificates` est **déjà** installé dans `deploy/docker/Dockerfile.master:14` — aucun changement Docker requis. Confirmer par lecture.
+
+- [ ] **Step 2 : Implémenter**
+
+Dans `src/shared/security/CaptchaVerifier.cpp`, après `SSL_CTX_new(TLS_client_method())` (~ligne 215) et avant `SSL_connect` :
+
+```cpp
+	// Sécurité (audit F4) : vérifier le certificat serveur (défaut OpenSSL = SSL_VERIFY_NONE).
+	SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nullptr);
+	if (SSL_CTX_set_default_verify_paths(ctx) != 1)
+	{
+		LOG_WARN(Core, "[CaptchaVerifier] trust store système indisponible");
+		// poursuivre : SSL_get_verify_result rejettera si le cert n'est pas validable.
+	}
+	// ... création de SSL* ssl = SSL_new(ctx); ... (code existant) ...
+	// Avant SSL_connect, épingler le hostname attendu :
+	SSL_set1_host(ssl, host.c_str()); // host = domaine cible (hcaptcha.com / google.com)
+```
+
+Après le handshake `SSL_connect` réussi, ajouter :
+
+```cpp
+	// Sécurité (audit F4) : refuser si la chaîne/hostname n'est pas validée.
+	const long verifyResult = SSL_get_verify_result(ssl);
+	if (verifyResult != X509_V_OK)
+	{
+		LOG_WARN(Core, "[CaptchaVerifier] validation certificat échouée (code={})", verifyResult);
+		/* fermeture/cleanup identique au chemin d'erreur existant */
+		return false; // adapter au type/chemin de sortie réel de VerifyHttp
+	}
+```
+
+Adapter les noms (`ctx`, `ssl`, `host`) et le chemin de cleanup/retour à la structure réelle de la fonction. Includes nécessaires : `<openssl/x509.h>` (pour `X509_V_OK`), déjà tiré indirectement par `<openssl/ssl.h>`.
+
+- [ ] **Step 3 : Vérifier (compile CI + revue)**
+
+Difficile à tester en unitaire (réseau réel). Vérifier : compilation CI verte, présence des 3 gardes (`SSL_VERIFY_PEER`, `SSL_set1_host`, `SSL_get_verify_result`). Note : le chemin Windows (`Verify()` renvoyant `true` sans réseau) est un stub dev hors périmètre (serveur = Linux).
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add src/shared/security/CaptchaVerifier.cpp
+git commit -m "fix(security): F4 — vérification du certificat TLS sur l'appel CAPTCHA"
+```
+
+---
+
+## Task 6 : F3 — authentifier `SHARD_REGISTER` / `SHARD_HEARTBEAT` (wire-breaking)
+
+**Files:**
+- Create: `src/shared/network/ShardWireAuth.h`, `src/shared/network/ShardWireAuth.cpp`
+- Create: `src/shared/network/ShardWireAuthTests.cpp`
+- Modify: `src/shared/network/ShardToMasterClient.h`, `src/shared/network/ShardToMasterClient.cpp`
+- Modify: `src/masterd/handlers/shard/ShardRegisterHandler.h`, `src/masterd/handlers/shard/ShardRegisterHandler.cpp`
+- Modify: `src/masterd/main_linux.cpp` (câbler le secret), `src/shardd/main_linux.cpp` (câbler le secret)
+- Modify: `src/CMakeLists.txt` (ajouter `ShardWireAuth.cpp` à la lib réseau partagée **et** à `server_app`)
+
+**Interfaces:**
+- Produces:
+  - `constexpr size_t engine::network::kShardAuthTagSize = 32u;`
+  - `std::vector<uint8_t> engine::network::WrapShardAuth(std::string_view secret, const std::vector<uint8_t>& body);` — renvoie `tag(32)||body`, ou `{}` si secret vide/erreur.
+  - `std::optional<std::pair<const uint8_t*, size_t>> engine::network::UnwrapShardAuth(std::string_view secret, const uint8_t* payload, size_t size);` — vérifie le tag préfixe (temps constant) et renvoie `{body, bodySize}` (pointeur après le tag), `nullopt` si trop court / tag invalide / secret vide.
+  - `void ShardToMasterClient::SetSharedSecret(std::string secret);`
+  - `void ShardRegisterHandler::SetSecret(std::string secret);`
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Créer `src/shared/network/ShardWireAuthTests.cpp` sur le modèle de `ShardPayloadsTests.cpp` (fonction `Assert`, `int main()` renvoyant non-zéro si échec) et l'enregistrer dans le `CMakeLists.txt` qui déclare `ShardPayloadsTests` (repérer via `grep -rn "ShardPayloadsTests" src`).
+
+```cpp
+#include "src/shared/network/ShardWireAuth.h"
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+using engine::network::WrapShardAuth;
+using engine::network::UnwrapShardAuth;
+using engine::network::kShardAuthTagSize;
+
+int main()
+{
+	int fails = 0;
+	auto A = [&](bool c, const char* m){ if(!c){ ++fails; std::cerr << "[FAIL] " << m << "\n"; } };
+	const std::string secret = "un-secret-fort-de-test";
+	std::vector<uint8_t> body = {1,2,3,4,5};
+
+	auto wrapped = WrapShardAuth(secret, body);
+	A(wrapped.size() == kShardAuthTagSize + body.size(), "wrap = tag(32) + body");
+
+	auto ok = UnwrapShardAuth(secret, wrapped.data(), wrapped.size());
+	A(ok.has_value(), "unwrap avec bon secret réussit");
+	A(ok && ok->second == body.size(), "body de bonne taille");
+	A(ok && std::equal(body.begin(), body.end(), ok->first), "body identique");
+
+	auto bad = UnwrapShardAuth("mauvais-secret", wrapped.data(), wrapped.size());
+	A(!bad.has_value(), "unwrap avec mauvais secret rejeté");
+
+	std::vector<uint8_t> tampered = wrapped; tampered.back() ^= 0xFF;
+	A(!UnwrapShardAuth(secret, tampered.data(), tampered.size()).has_value(), "body falsifié rejeté");
+
+	A(WrapShardAuth("", body).empty(), "wrap avec secret vide -> vide");
+	A(!UnwrapShardAuth(secret, wrapped.data(), kShardAuthTagSize - 1).has_value(), "trop court rejeté");
+
+	if (fails) { std::cerr << fails << " FAIL\n"; return 1; }
+	std::cout << "OK\n"; return 0;
+}
+```
+
+- [ ] **Step 2 : Vérifier l'échec (CI)**
+
+`ShardWireAuth.h` n'existe pas → la cible ne compile pas / le test échoue.
+
+- [ ] **Step 3 : Implémenter `ShardWireAuth`**
+
+`src/shared/network/ShardWireAuth.h` :
+
+```cpp
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace engine::network
+{
+	/// Taille du tag d'authentification HMAC-SHA256 préfixé aux payloads shard↔master.
+	constexpr size_t kShardAuthTagSize = 32u;
+
+	/// Préfixe un tag HMAC-SHA256(secret, body) de 32 octets à \a body.
+	/// Renvoie tag||body, ou {} si \a secret est vide ou en cas d'erreur OpenSSL.
+	std::vector<uint8_t> WrapShardAuth(std::string_view secret, const std::vector<uint8_t>& body);
+
+	/// Vérifie le tag préfixe (comparaison à temps constant) sur les octets restants.
+	/// Renvoie {pointeur_body, taille_body} après le tag, ou nullopt si trop court,
+	/// tag invalide, ou secret vide.
+	std::optional<std::pair<const uint8_t*, size_t>> UnwrapShardAuth(
+		std::string_view secret, const uint8_t* payload, size_t size);
+}
+```
+
+`src/shared/network/ShardWireAuth.cpp` :
+
+```cpp
+#include "src/shared/network/ShardWireAuth.h"
+
+#include <openssl/hmac.h>
+#include <openssl/evp.h>
+#include <openssl/crypto.h>
+
+#include <cstring>
+
+namespace engine::network
+{
+	namespace
+	{
+		bool ComputeTag(std::string_view secret, const uint8_t* body, size_t bodySize, uint8_t* outTag)
+		{
+			unsigned int len = 0;
+			unsigned char* r = HMAC(EVP_sha256(), secret.data(), static_cast<int>(secret.size()),
+				body, bodySize, outTag, &len);
+			return r != nullptr && len == kShardAuthTagSize;
+		}
+	}
+
+	std::vector<uint8_t> WrapShardAuth(std::string_view secret, const std::vector<uint8_t>& body)
+	{
+		if (secret.empty())
+			return {};
+		std::vector<uint8_t> out(kShardAuthTagSize + body.size(), 0u);
+		if (!ComputeTag(secret, body.data(), body.size(), out.data()))
+			return {};
+		std::memcpy(out.data() + kShardAuthTagSize, body.data(), body.size());
+		return out;
+	}
+
+	std::optional<std::pair<const uint8_t*, size_t>> UnwrapShardAuth(
+		std::string_view secret, const uint8_t* payload, size_t size)
+	{
+		if (secret.empty() || payload == nullptr || size < kShardAuthTagSize)
+			return std::nullopt;
+		const uint8_t* body = payload + kShardAuthTagSize;
+		const size_t bodySize = size - kShardAuthTagSize;
+		uint8_t expected[kShardAuthTagSize];
+		if (!ComputeTag(secret, body, bodySize, expected))
+			return std::nullopt;
+		// Comparaison à temps constant (corrige aussi F27 pour ce chemin).
+		if (CRYPTO_memcmp(expected, payload, kShardAuthTagSize) != 0)
+			return std::nullopt;
+		return std::make_pair(body, bodySize);
+	}
+}
+```
+
+Dans `src/CMakeLists.txt`, ajouter `src/shared/network/ShardWireAuth.cpp` à la même liste de sources que `ShardPayloads.cpp` (lib réseau partagée) **et** à la liste `server_app` (`grep -n "ShardPayloads.cpp" src/CMakeLists.txt` pour trouver les emplacements). Enregistrer `ShardWireAuthTests.cpp` comme cible de test à côté de `ShardPayloadsTests`.
+
+- [ ] **Step 4 : Vérifier le passage (CI)**
+
+`ctest` sur `ShardWireAuthTests` doit **passer** (tous les `Assert` verts).
+
+- [ ] **Step 5 : Côté shard — joindre le tag à l'émission**
+
+Dans `src/shared/network/ShardToMasterClient.h`, ajouter un membre et un setter :
+
+```cpp
+	void SetSharedSecret(std::string secret);
+	// ...
+	std::string m_shared_secret;
+```
+
+Dans `src/shared/network/ShardToMasterClient.cpp` : `#include "src/shared/network/ShardWireAuth.h"`, définir le setter, et envelopper les payloads dans `SendRegister` et `SendHeartbeat` **avant** de les écrire dans le `PacketBuilder`.
+
+```cpp
+	void ShardToMasterClient::SetSharedSecret(std::string secret) { m_shared_secret = std::move(secret); }
+```
+
+Dans `SendRegister`, après `auto payload = BuildShardRegisterPayload(...)` et le test `payload.empty()` :
+
+```cpp
+		// Sécurité (audit F3) : authentifier le REGISTER par tag HMAC préfixe.
+		payload = WrapShardAuth(m_shared_secret, payload);
+		if (payload.empty())
+		{
+			LOG_ERROR(Core, "[ShardToMasterClient] WrapShardAuth register échoué (secret vide ?)");
+			return;
+		}
+```
+
+(La suite écrit déjà `payload` dans le `PacketBuilder` — inchangée.) Idem dans `SendHeartbeat`, après `auto payload = BuildShardHeartbeatPayload(...)` et le test `payload.empty()` :
+
+```cpp
+		payload = WrapShardAuth(m_shared_secret, payload); // audit F3
+		if (payload.empty())
+			return;
+```
+
+- [ ] **Step 6 : Côté master — vérifier et retirer le tag avant parse**
+
+Dans `src/masterd/handlers/shard/ShardRegisterHandler.h`, ajouter `void SetSecret(std::string secret);` et un membre `std::string m_secret;`.
+
+Dans `src/masterd/handlers/shard/ShardRegisterHandler.cpp` : `#include "src/shared/network/ShardWireAuth.h"`, définir le setter, et dans `HandlePacket`, vérifier le tag **avant** de dispatcher :
+
+```cpp
+	void ShardRegisterHandler::SetSecret(std::string secret) { m_secret = std::move(secret); }
+
+	void ShardRegisterHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t /*sessionIdHeader*/,
+		const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		if (!m_server || !m_registry)
+		{
+			LOG_WARN(Core, "[ShardRegisterHandler] HandlePacket: server or registry not set");
+			return;
+		}
+		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
+		{
+			// Sécurité (audit F3) : le canal shard↔master est authentifié par un tag HMAC préfixe.
+			auto body = UnwrapShardAuth(m_secret, payload, payloadSize);
+			if (!body)
+			{
+				LOG_WARN(Server, "[SREG] paquet shard rejeté : authentification HMAC invalide (opcode={}, connId={})", opcode, connId);
+				return;
+			}
+			if (opcode == kOpcodeShardRegister)
+				HandleRegister(connId, requestId, body->first, body->second);
+			else
+				HandleHeartbeat(connId, body->first, body->second);
+		}
+	}
+```
+
+- [ ] **Step 7 : Câbler le secret dans les deux `main`**
+
+Master — `src/masterd/main_linux.cpp`, près de la ligne 1051 (`shardRegisterHandler.SetServer(&server);`), ajouter :
+
+```cpp
+	shardRegisterHandler.SetSecret(config.GetString("shard.ticket_hmac_secret", ""));
+```
+
+Shard — `src/shardd/main_linux.cpp`, là où le `ShardToMasterClient` est configuré (`grep -n "ShardToMasterClient\|SetShardIdentity\|SetMasterAddress" src/shardd/main_linux.cpp`), ajouter, à côté des autres setters :
+
+```cpp
+	shardToMaster.SetSharedSecret(config.GetString("shard.ticket_hmac_secret", ""));
+```
+
+(adapter le nom de l'instance à celui réellement utilisé).
+
+- [ ] **Step 8 : Vérifier (CI)**
+
+Compilation master + shard verte ; `ShardWireAuthTests` vert. Le round-trip protocole est couvert par le test unitaire (Step 1) ; l'intégration réelle est validée en déploiement lock-step.
+
+- [ ] **Step 9 : Commit**
+
+```bash
+git add src/shared/network/ShardWireAuth.h src/shared/network/ShardWireAuth.cpp src/shared/network/ShardWireAuthTests.cpp \
+        src/shared/network/ShardToMasterClient.h src/shared/network/ShardToMasterClient.cpp \
+        src/masterd/handlers/shard/ShardRegisterHandler.h src/masterd/handlers/shard/ShardRegisterHandler.cpp \
+        src/masterd/main_linux.cpp src/shardd/main_linux.cpp src/CMakeLists.txt
+git commit -m "fix(security): F3 — authentifier SHARD_REGISTER/HEARTBEAT par tag HMAC (wire-breaking)"
+```
+
+---
+
+## Task 7 : F6 — refuser le secret HMAC par défaut au boot
+
+**Files:**
+- Create: `src/shared/security/SharedSecretPolicy.h`, `src/shared/security/SharedSecretPolicy.cpp`
+- Create: `src/shared/security/SharedSecretPolicyTests.cpp`
+- Modify: `src/masterd/main_linux.cpp`, `src/shardd/main_linux.cpp`
+- Modify: `deploy/docker/config/master.config.json:10`, `deploy/docker/config/shard.config.json:9`, `deploy/docker/server-config/config.json`
+- Modify: `src/CMakeLists.txt` (ajouter `SharedSecretPolicy.cpp` à la lib partagée **et** `server_app`)
+
+**Interfaces:**
+- Produces:
+  - `bool engine::security::IsWeakSharedSecret(std::string_view secret);` — true si vide ou valeur de dev connue.
+  - `bool engine::security::DevSecretOverrideEnabled();` — true si `LCDLLN_ALLOW_DEV_SECRET == "1"`.
+
+- [ ] **Step 1 : Écrire le test qui échoue**
+
+Créer `src/shared/security/SharedSecretPolicyTests.cpp` (modèle standalone, `int main()`), enregistré dans le `CMakeLists.txt` des tests de `src/shared/security` :
+
+```cpp
+#include "src/shared/security/SharedSecretPolicy.h"
+#include <iostream>
+using engine::security::IsWeakSharedSecret;
+int main()
+{
+	int fails = 0;
+	auto A = [&](bool c, const char* m){ if(!c){ ++fails; std::cerr << "[FAIL] " << m << "\n"; } };
+	A(IsWeakSharedSecret("") == true, "vide = faible");
+	A(IsWeakSharedSecret("dev_secret_change_in_production") == true, "valeur dev connue = faible");
+	A(IsWeakSharedSecret("un-vrai-secret-aleatoire-long-9f3a") == false, "secret fort = OK");
+	if (fails) return 1;
+	std::cout << "OK\n"; return 0;
+}
+```
+
+- [ ] **Step 2 : Vérifier l'échec (CI)**
+
+`SharedSecretPolicy.h` absent → ne compile pas.
+
+- [ ] **Step 3 : Implémenter le helper**
+
+`src/shared/security/SharedSecretPolicy.h` :
+
+```cpp
+#pragma once
+#include <string_view>
+
+namespace engine::security
+{
+	/// Vrai si le secret partagé est vide ou égal à une valeur de développement connue
+	/// (committée dans le repo) — donc impropre à la production.
+	bool IsWeakSharedSecret(std::string_view secret);
+
+	/// Vrai si l'opérateur a explicitement autorisé un secret de dev via
+	/// la variable d'environnement LCDLLN_ALLOW_DEV_SECRET=1.
+	bool DevSecretOverrideEnabled();
+}
+```
+
+`src/shared/security/SharedSecretPolicy.cpp` :
+
+```cpp
+#include "src/shared/security/SharedSecretPolicy.h"
+
+#include <array>
+#include <cstdlib>
+#include <string_view>
+
+namespace engine::security
+{
+	bool IsWeakSharedSecret(std::string_view secret)
+	{
+		if (secret.empty())
+			return true;
+		static constexpr std::array<std::string_view, 2> kKnownDevSecrets = {
+			"dev_secret_change_in_production",
+			"changeme",
+		};
+		for (std::string_view weak : kKnownDevSecrets)
+			if (secret == weak)
+				return true;
+		return false;
+	}
+
+	bool DevSecretOverrideEnabled()
+	{
+		const char* v = std::getenv("LCDLLN_ALLOW_DEV_SECRET");
+		return v != nullptr && std::string_view(v) == "1";
+	}
+}
+```
+
+Ajouter `src/shared/security/SharedSecretPolicy.cpp` à `src/CMakeLists.txt` (lib partagée **et** `server_app`).
+
+- [ ] **Step 4 : Vérifier le passage (CI)**
+
+`ctest` sur `SharedSecretPolicyTests` vert.
+
+- [ ] **Step 5 : Garde au boot (master + shard)**
+
+Master — `src/masterd/main_linux.cpp`, juste après la lecture du secret (près de la ligne 1059, mais idéalement **avant** l'ouverture du port ; placer tôt dans `main`, après le chargement de `config`). Ajouter `#include "src/shared/security/SharedSecretPolicy.h"` et :
+
+```cpp
+	{
+		const std::string shardSecret = config.GetString("shard.ticket_hmac_secret", "");
+		if (engine::security::IsWeakSharedSecret(shardSecret) && !engine::security::DevSecretOverrideEnabled())
+		{
+			LOG_ERROR(Core, "[Boot] shard.ticket_hmac_secret vide ou par défaut : refus de démarrer. "
+				"Définir un vrai secret, ou poser LCDLLN_ALLOW_DEV_SECRET=1 en développement.");
+			return 1;
+		}
+	}
+```
+
+Shard — `src/shardd/main_linux.cpp`, même garde après le chargement de `config`, avant de lancer le `ShardToMasterClient`. Adapter le type de retour de `main` (renvoyer un code non-zéro).
+
+- [ ] **Step 6 : Retirer la valeur faible des configs livrées**
+
+Dans les 3 fichiers, remplacer `"dev_secret_change_in_production"` par `""` :
+- `deploy/docker/config/master.config.json:10`
+- `deploy/docker/config/shard.config.json:9`
+- `deploy/docker/server-config/config.json` (ligne du `ticket_hmac_secret`)
+
+Ainsi la config livrée **force** l'opérateur à renseigner un vrai secret (ou poser le flag dev).
+
+- [ ] **Step 7 : Vérifier (CI + revue)**
+
+Compilation verte ; les 3 configs ne contiennent plus la valeur faible ; le helper est testé. Revue : la garde est placée **avant** l'ouverture du port réseau.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add src/shared/security/SharedSecretPolicy.h src/shared/security/SharedSecretPolicy.cpp src/shared/security/SharedSecretPolicyTests.cpp \
+        src/masterd/main_linux.cpp src/shardd/main_linux.cpp src/CMakeLists.txt \
+        deploy/docker/config/master.config.json deploy/docker/config/shard.config.json deploy/docker/server-config/config.json
+git commit -m "fix(security): F6 — refus au boot d'un secret HMAC faible/par défaut (sauf flag dev)"
+```
+
+---
+
+## Task 8 : F1 (+F10) — synchroniser les migrations Docker + garde CI
+
+**Files:**
+- Modify: `deploy/docker/sql/migrations/` (resync depuis `sql/migrations/`)
+- Modify/Create: garde CI dans `.github/workflows/` (ex. `build-linux.yml` ou un step dédié)
+
+**Interfaces:** aucune (deploy/CI).
+
+- [ ] **Step 1 : Resynchroniser le répertoire**
+
+Exécuter le script de sync existant :
+
+```bash
+bash scripts/sync-db-to-docker-deploy.sh
+```
+
+Vérifier qu'il copie bien 0050–0071 et remplace la copie obsolète de 0043 (F10). S'il ne couvre pas tout, compléter par une copie explicite :
+
+```bash
+cp -f sql/migrations/*.sql deploy/docker/sql/migrations/
+git status deploy/docker/sql/migrations/   # doit montrer 0050-0071 ajoutés + 0043 modifié
+```
+
+- [ ] **Step 2 : Vérifier la parité**
+
+```bash
+diff <(ls sql/migrations) <(ls deploy/docker/sql/migrations) && echo "IDENTIQUE"
+```
+Attendu : `IDENTIQUE` (mêmes noms de fichiers). Puis vérifier les contenus :
+```bash
+for f in sql/migrations/*.sql; do b=$(basename "$f"); diff -q "$f" "deploy/docker/sql/migrations/$b" || echo "DIVERGE: $b"; done
+```
+Attendu : aucune ligne `DIVERGE`.
+
+- [ ] **Step 3 : Ajouter la garde CI**
+
+Dans `.github/workflows/build-linux.yml` (ou un workflow dédié), ajouter un step **avant** le build qui échoue si les deux répertoires divergent :
+
+```yaml
+      - name: Vérifier la parité des migrations Docker (audit F1)
+        run: |
+          set -e
+          miss=0
+          for f in sql/migrations/*.sql; do
+            b=$(basename "$f")
+            if ! diff -q "$f" "deploy/docker/sql/migrations/$b" >/dev/null 2>&1; then
+              echo "::error::Migration désynchronisée: $b (lancez scripts/sync-db-to-docker-deploy.sh)"
+              miss=1
+            fi
+          done
+          exit $miss
+```
+
+- [ ] **Step 4 : Vérifier (revue)**
+
+Le step CI échouerait sur toute future divergence. Sur cette branche, après resync, il passe.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add deploy/docker/sql/migrations/ .github/workflows/
+git commit -m "fix(deploy): F1/F10 — resync des migrations Docker + garde CI anti-divergence"
+```
+
+---
+
+## Task 9 : F7 — marquer différé dans le rapport d'audit
+
+**Files:**
+- Modify: `docs/audit/2026-07-03-audit-complet-frais.md` (section F7)
+
+**Interfaces:** aucune.
+
+- [ ] **Step 1 : Annoter F7**
+
+Dans la section F7 du rapport, ajouter une note de statut :
+
+```markdown
+> **Statut (2026-07-03)** : DIFFÉRÉ. Passer `allow_insecure_dev` à `false` sans
+> `client.server_fingerprint` renseigné bloquerait tous les clients
+> (`TlsVerifyFingerprint` refuse la connexion sur mismatch). Fermeture : fournir
+> le SHA-256 du certificat du master de production dans `client.server_fingerprint`,
+> puis passer `allow_insecure_dev` à `false` (tous les call sites +
+> `BuildUserSettingsJson` + `config.json`).
+```
+
+- [ ] **Step 2 : Commit**
+
+```bash
+git add docs/audit/2026-07-03-audit-complet-frais.md
+git commit -m "docs(audit): F7 marqué différé (nécessite le fingerprint du cert master)"
+```
+
+---
+
+## Self-Review
+
+- **Couverture spec** : F9 (Task 1), F5 (Task 2), F8 (Task 3), F2 (Task 4), F4 (Task 5), F3 (Task 6), F6 (Task 7), F1/F10 (Task 8), F7 différé documenté (Task 9). Toutes les corrections du spec sont couvertes ✅. Décisions validées respectées : F7 différé, F6 fail-fast + retrait valeur faible, F3 réutilise `shard.ticket_hmac_secret`, une branche server-first ✅.
+- **Placeholders** : les steps de code portent du code concret ; les rares « adapter au type de retour réel » ciblent des signatures que l'implémenteur lit sur place (SmtpMailer::Send, VerifyHttp, GetShardConnection) — pas des TODO de logique.
+- **Cohérence des types** : `WrapShardAuth`/`UnwrapShardAuth`/`kShardAuthTagSize` définis Task 6 step 3, consommés steps 5-6 ; `SetSharedSecret`/`SetSecret` définis et câblés Task 6 ; `IsWeakSharedSecret`/`DevSecretOverrideEnabled` définis Task 7 step 3, consommés step 5. `HandleHeartbeat(connId, …)` : signature changée en Task 4, re-touchée en Task 6 step 6 (l'appel passe `body->first/second`) — cohérent (Task 4 puis Task 6 dans l'ordre). Note d'ordre : **Task 4 avant Task 6** (Task 6 s'appuie sur la signature `connId` nommée de Task 4).
+- **CMake** : `ShardWireAuth.cpp` et `SharedSecretPolicy.cpp` ajoutés à la lib partagée **et** à `server_app` (contrainte connue).
+- **Déploiement** : ⚠️ **redéploiement lock-step master+shard** (F3 wire-breaking + F6 boot). Action opérateur : définir un vrai `shard.ticket_hmac_secret` identique des deux côtés avant démarrage (sinon boot en échec), ou `LCDLLN_ALLOW_DEV_SECRET=1` en dev. F1 = rejouer le build de l'image master.

--- a/docs/superpowers/specs/2026-07-03-audit-complet-frais-design.md
+++ b/docs/superpowers/specs/2026-07-03-audit-complet-frais-design.md
@@ -1,0 +1,91 @@
+# Audit complet frais du code — design (2026-07-03)
+
+## Objectif
+
+Balayer l'ensemble du code du projet (hors `legacy/`) à la recherche
+d'**anomalies** (bugs, UB, races, fuites), de **problèmes de sécurité** et
+d'**optimisations** candidates. Audit *frais* : il ne s'appuie pas sur les
+audits de juin (`docs/audit/2026-06-*`) et ne cherche pas à en dédupliquer
+les findings.
+
+## Livrable
+
+Un rapport unique : `docs/audit/2026-07-03-audit-complet-frais.md`, en
+français, **sans aucune correction de code dans cette session**. Les
+corrections éventuelles seront décidées ensuite par l'utilisateur et
+livrées en PRs séparées cadrées.
+
+Classement des findings par sévérité :
+
+| Niveau | Signification |
+|--------|---------------|
+| **P0** | Sécurité critique (exploitable à distance, fuite de secrets, corruption mémoire déclenchable par un pair) |
+| **P1** | Bug sérieux ou sécurité modérée (crash, perte de données, contournement de gating nécessitant des conditions) |
+| **P2** | Bug mineur ou optimisation probable (candidat à mesurer) |
+| **P3** | Qualité / suggestion |
+
+Chaque finding comporte : localisation `fichier:ligne` cliquable, catégorie
+(sécurité / bug / perf), description, recommandation.
+
+Déploiement : ✅ docs uniquement, pas de redéploiement serveur.
+
+## Périmètre
+
+**Inclus :**
+
+- `src/client`, `src/masterd`, `src/shardd`, `src/shared`, `src/world_editor`
+- `web-portal/` (app, lib, components, email-templates)
+- `sql/migrations/`
+- Tools C++ : `tools/hlod_builder`, `tools/zone_builder`,
+  `tools/impostor_builder`, `tools/load_tester`
+- Passe légère : `deploy/docker`, `config.json` (secrets, ports exposés,
+  clés sensibles), `game/data/config/slash_commands.json` (RBAC)
+
+**Exclus :**
+
+- `legacy/` (consigne permanente utilisateur)
+- `game/data` hors slash_commands.json (données, pas du code)
+- `tickets/`, `docs/`
+- Assets binaires (`.fbx` du pipeline, textures, etc.)
+
+## Dimensions d'analyse
+
+1. **Sécurité** : parsing wire sans borne dans les handlers masterd/shardd,
+   auth/sessions/RBAC (SessionManager, ConnectionSessionMap,
+   AuthRegisterHandler, AccountStore), injection SQL dans les stores,
+   web-portal (XSS, CSRF, secrets en dur, validation d'entrée), parsing de
+   fichiers chargés depuis disque (buildings.bin, props.bin, config).
+2. **Anomalies / bugs** : UB (débordements, use-after-free, variables non
+   initialisées), data races (threads réseau vs rendu — précédent réel :
+   crash géoloc PR #915/#918), fuites de ressources (objets Vulkan,
+   handles, sockets), erreurs logiques.
+3. **Optimisations** : allocations/copies par frame côté rendu, algorithmes
+   O(n²) (collisions, réplication), requêtes DB dans des boucles,
+   gaspillage GPU évident. **Analyse statique uniquement** (pas de
+   toolchain de build locale) : les findings perf sont des candidats à
+   mesurer, pas des certitudes.
+
+## Méthode : workflow multi-agents
+
+Opt-in explicite de l'utilisateur pour l'orchestration multi-agents
+(choix « Workflow multi-agents » au cadrage).
+
+- **Phase 1 — Audit** : un agent par cellule sous-système × dimension
+  pertinente (~15 cellules). Le client (687 fichiers) est subdivisé en
+  render / app / net+UI. Chaque agent retourne des findings structurés
+  (fichier:ligne, sévérité, catégorie, description) via schéma JSON.
+- **Phase 2 — Dédup** : barrière ; fusion des doublons inter-agents en
+  code (clé fichier+ligne±ε+catégorie).
+- **Phase 3 — Vérification adversariale** : chaque finding P0/P1 est soumis
+  à un agent sceptique chargé de le **réfuter** en relisant le code réel ;
+  les findings réfutés sont éliminés ou rétrogradés. Les P2/P3 passent une
+  vérification simple (existence du code cité, plausibilité).
+- **Phase 4 — Synthèse** : rédaction du rapport final classé P0→P3.
+
+## Critères de succès
+
+- Toutes les cellules du périmètre couvertes (aucune abandonnée en silence ;
+  si une cellule échoue, le rapport le mentionne).
+- Zéro finding P0/P1 non contre-vérifié dans le rapport.
+- Chaque finding localisé précisément et actionnable.
+- Rapport committé et poussé sur la branche de travail.

--- a/docs/superpowers/specs/2026-07-03-corrections-p0-p1-audit-design.md
+++ b/docs/superpowers/specs/2026-07-03-corrections-p0-p1-audit-design.md
@@ -1,0 +1,171 @@
+# Corrections P0/P1 de l'audit 2026-07-03 — design
+
+## Objectif
+
+Corriger les findings **P0 et P1** du rapport
+[docs/audit/2026-07-03-audit-complet-frais.md](../../audit/2026-07-03-audit-complet-frais.md).
+8 findings corrigés (F1-F6, F8, F9) ; **F7 différé** (dépend d'une valeur
+opérationnelle absente).
+
+## Périmètre & livraison
+
+- **Aucun changement du binaire client de jeu** : le REGISTER shard part de
+  `shardd` (serveur), pas du client. F7 (seul finding client) est différé.
+- Livraison sur la branche courante `claude/funny-bardeen-f6f803`, **server-first**,
+  un commit par finding (ou par groupe cohérent).
+- Tout est serveur + deploy.
+
+## Décisions de cadrage (validées avec l'utilisateur)
+
+1. **F7 différé** — passer `allow_insecure_dev` à `false` avec
+   `server_fingerprint` vide bloquerait tous les clients
+   ([NetClient.cpp:147](../../../src/shared/network/NetClient.cpp:147) :
+   `serverFp != expected && !allowInsecure` → `return false`). Nécessite le vrai
+   SHA-256 du cert master, non disponible. Documenté, non implémenté.
+2. **F6 fail-fast** — le boot échoue si le secret HMAC est faible/vide, sauf flag
+   dev explicite `LCDLLN_ALLOW_DEV_SECRET=1`. La valeur faible est retirée des
+   configs livrées.
+3. **F3 réutilise `shard.ticket_hmac_secret`** comme clé d'authentification (ancre
+   de confiance shard↔master existante, protégée par F6).
+4. **Une branche, commits groupés, server-first.**
+
+---
+
+## Findings & corrections
+
+### Groupe 1 — serveur sûr, non wire-breaking
+
+#### F5 — router `kOpcodeResendVerificationRequest`
+- **Fichier** : `src/masterd/main_linux.cpp` (~ligne 1097).
+- **Correction** : ajouter `|| opcode == kOpcodeResendVerificationRequest` à la
+  condition de dispatch qui route vers `passwordResetHandler.HandlePacket`.
+- **Test** : dispatch d'intégration (couvert par revue ; pas de test unitaire
+  isolé du `main`).
+
+#### F8 — rate-limit sur `HandleVerifyEmail`
+- **Fichier** : `src/masterd/handlers/password/PasswordResetHandler.cpp`
+  (`HandleVerifyEmail`, ~230-291).
+- **Correction** : utiliser `m_rateLimit` (déjà injecté via `SetRateLimitAndBan`,
+  actuellement inutilisé) pour compter les échecs de vérification par
+  `account_id` (et IP si disponible dans le contexte du handler). Après N échecs
+  consécutifs (constante nommée, ex. `kMaxVerifyAttempts = 5`), rejeter les
+  tentatives suivantes pendant une fenêtre de verrouillage, en **plus** du TTL de
+  15 min existant. Un succès réinitialise le compteur.
+- **Comportement après verrouillage** : renvoyer la même réponse d'échec générique
+  que pour un code invalide (pas de divulgation « compte verrouillé » qui
+  aiderait l'énumération).
+- **Test** : `PasswordResetHandler` — N échecs → tentative suivante rejetée même
+  avec le bon code pendant la fenêtre.
+
+#### F9 — rejeter les caractères de contrôle dans l'e-mail
+- **Fichiers** : `src/shared/account/AccountValidation.cpp` (`ValidateEmail`) ;
+  défense en profondeur dans `src/masterd/email/SmtpMailer.cpp` (`Send`).
+- **Correction** : `ValidateEmail` rejette tout octet `< 0x20` ou `== 0x7F`
+  **n'importe où** dans la chaîne. `SmtpMailer::Send` refuse (ou strip) tout CR/LF
+  dans `to`/`subject`/`from_address` avant construction des commandes/headers SMTP.
+- **Test** : `AccountValidation` — `a@b.com\r\nRCPT TO:<x>` rejeté ; e-mail valide
+  accepté.
+
+#### F2 — lier le heartbeat shard à la connexion enregistrée
+- **Fichier** : `src/masterd/handlers/shard/ShardRegisterHandler.cpp`
+  (`HandleHeartbeat`, ~127-148).
+- **Correction** : récupérer `GetShardConnection(parsed->shard_id)` et rejeter le
+  heartbeat (log WARN + drop) si la `connId` courante ne correspond pas. Master
+  seul, pas de changement wire.
+- **Test** : couvert par la revue + les tests de F3 (le heartbeat authentifié
+  valide la `connId`).
+
+#### F4 — vérifier le certificat TLS dans `CaptchaVerifier`
+- **Fichiers** : `src/shared/security/CaptchaVerifier.cpp` (`VerifyHttp`) ;
+  `deploy/docker/Dockerfile.master` (paquet `ca-certificates`).
+- **Correction** : après `SSL_CTX_new`, appeler
+  `SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nullptr)` +
+  `SSL_CTX_set_default_verify_paths(ctx)` ; avant `SSL_connect`,
+  `SSL_set1_host(ssl, host)` ; après le handshake, échouer si
+  `SSL_get_verify_result(ssl) != X509_V_OK`. Vérifier que l'image Docker master
+  installe `ca-certificates`.
+- **Hors périmètre** : le bypass Windows (`Verify()` renvoie `true` sans réseau)
+  est un stub de dev ; le serveur tourne sous Linux.
+- **Test** : difficile en unitaire (réseau) — au minimum vérifier que le code
+  compile et que les appels de validation sont présents (garde de non-régression).
+
+### Groupe 2 — wire-breaking + gating boot (lock-step master+shard)
+
+#### F3 — authentifier `SHARD_REGISTER` / `SHARD_HEARTBEAT`
+- **Fichiers** : `src/shared/network/ShardPayloads.{h,cpp}` (payloads register +
+  heartbeat) ; `src/masterd/handlers/shard/ShardRegisterHandler.cpp` (validation) ;
+  côté émission `shardd` (`ShardToMasterClient` / `MasterShardClientFlow`) ;
+  helper HMAC `src/masterd/handlers/shard/ShardTicketCrypto.*` (ou équivalent
+  partagé).
+- **Correction** : ajouter un champ **tag HMAC-SHA256 (32 octets)** en fin des
+  payloads `ShardRegisterPayload` et `ShardHeartbeatPayload`, calculé sur les
+  champs sérialisés (name/endpoint/shard_id/… selon le payload) avec la clé
+  `shard.ticket_hmac_secret`. `shardd` calcule et joint le tag ; le master
+  recalcule et **rejette** (drop + log) si le tag est absent ou invalide, avant
+  tout `RegisterShard`/`UpdateHeartbeat`. Comparaison à **temps constant**
+  (`CRYPTO_memcmp`) — corrige aussi F27 (P2) au passage.
+- **Wire-breaking** : taille de payload modifiée → client (shard) neuf
+  incompatible avec master ancien et inverse → **redéploiement lock-step**.
+- **Test** : `ShardPayloadsTests` — round-trip build/parse avec tag ; tag
+  falsifié rejeté ; secret différent rejeté.
+
+#### F6 — refuser le secret HMAC par défaut au boot
+- **Fichiers** : nouveau helper partagé (ex.
+  `src/shared/security/SharedSecretPolicy.{h,cpp}`, `IsWeakSharedSecret`) ;
+  `src/masterd/main_linux.cpp` et `src/shardd/main_linux.cpp` (contrôle au boot) ;
+  configs livrées `deploy/docker/config/master.config.json`,
+  `deploy/docker/config/shard.config.json`, `server-config/config.json`.
+- **Correction** : après lecture de `shard.ticket_hmac_secret`, si le secret est
+  vide **ou** appartient au jeu de valeurs de dev connues (au minimum
+  `"dev_secret_change_in_production"`) et que `LCDLLN_ALLOW_DEV_SECRET` != `"1"`,
+  logguer FATAL et `exit(non-zéro)` avant d'ouvrir le port. Retirer la valeur
+  faible des 3 configs livrées (valeur vide, à renseigner par l'opérateur).
+- **CMake** : le nouveau `.cpp` partagé doit être ajouté **aussi** à la liste
+  `server_app` dans `src/CMakeLists.txt` (server_app ne linke pas `engine_core`).
+- **Test** : `IsWeakSharedSecret` — vide/valeur dev → true ; secret fort → false.
+
+### Groupe 3 — deploy/config
+
+#### F1 (+ F10) — synchroniser les migrations Docker + garde CI
+- **Fichiers** : `deploy/docker/sql/migrations/` (resync) ; garde CI dans
+  `.github/workflows/` ; script de sync existant
+  (`scripts/sync-db-to-docker-deploy.sh` si présent).
+- **Correction** : resynchroniser `deploy/docker/sql/migrations/` depuis
+  `sql/migrations/` (ajoute 0050-0071, corrige la copie obsolète de 0043 = F10).
+  Ajouter une étape CI qui diffe les deux répertoires et **échoue** en cas de
+  divergence, pour empêcher toute nouvelle dérive.
+- **Test** : la garde CI elle-même (échoue si divergence).
+
+### F7 — différé (non implémenté)
+- Documenté ici et dans l'entête de suivi de l'audit. Fermeture ultérieure :
+  fournir le SHA-256 du cert master dans `client.server_fingerprint`, puis passer
+  `client.allow_insecure_dev` à `false` (tous les call sites +
+  `BuildUserSettingsJson` + `config.json`).
+
+---
+
+## Stratégie de test
+
+TDD là où le repo le permet (la CI Linux `build-linux.yml` lance `ctest`). Tests
+neufs/étendus : F9 (`AccountValidation`), F3 (`ShardPayloadsTests`), F6
+(`IsWeakSharedSecret`), F8 (`PasswordResetHandler`). F5/F2/F4 couverts par revue +
+compilation (dispatch/réseau, non isolables en unitaire simple). Attention au piège
+`assert`+`NDEBUG` : ne pas mettre la logique de validation dans un `assert`.
+
+## Déploiement
+
+⚠️ **REDÉPLOIEMENT SERVEUR REQUIS — master ET shard, en lock-step.**
+- F3 est wire-breaking (taille de payload register/heartbeat modifiée).
+- F6 change le comportement de boot (échec si secret faible).
+- **Action opérateur obligatoire** : définir un vrai `shard.ticket_hmac_secret`
+  (identique côté master et shard) **avant** de démarrer, sinon boot en échec
+  (par design). En dev, poser `LCDLLN_ALLOW_DEV_SECRET=1`.
+- F1 est deploy-only (rejouer le build de l'image master).
+- Groupe 1 seul exigerait déjà un redéploiement master (F5/F8/F9/F2/F4).
+
+## Critères de succès
+
+- F1-F6, F8, F9 corrigés avec leurs tests verts en CI.
+- F7 documenté comme différé, sans changement de code client.
+- Aucune régression wire hors du changement F3 assumé.
+- Ligne de déploiement lock-step claire dans la PR.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/network/ShardTicketPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/ServerListPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/network/TermsPayloads.cpp
+    # Audit F3 : tag HMAC-SHA256 préfixe authentifiant SHARD_REGISTER/HEARTBEAT
+    # (utilisé par ShardRegisterHandler, compilé dans ce binaire master).
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ShardWireAuth.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/social/FriendSystem.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/ShardPresenceService.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/social/PartySystem.cpp
@@ -1140,6 +1143,16 @@ elseif(UNIX)
   target_link_libraries(shard_payloads_tests PRIVATE engine_core)
   target_compile_options(shard_payloads_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME shard_payloads_tests COMMAND shard_payloads_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # Audit F3 : tag HMAC-SHA256 préfixe authentifiant SHARD_REGISTER/HEARTBEAT.
+  add_executable(shard_wire_auth_tests
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ShardWireAuthTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ShardWireAuth.cpp
+  )
+  target_include_directories(shard_wire_auth_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(shard_wire_auth_tests PRIVATE OpenSSL::SSL)
+  target_compile_options(shard_wire_auth_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME shard_wire_auth_tests COMMAND shard_wire_auth_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # Présence unifiée (Niveau 1) : ShardPresenceService — présence shard-locale.
   add_executable(shard_presence_service_tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1200,15 +1200,8 @@ elseif(UNIX)
   target_compile_options(server_list_policy_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME server_list_policy_tests COMMAND server_list_policy_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-  # Sécurité (audit F9) : AccountValidation — normalisation/validation e-mail, login, mot de passe.
-  # Pure (pas de réseau, pas de DB) : dépend uniquement de NetErrorCode.h (header-only).
-  add_executable(account_validation_tests
-    ${CMAKE_SOURCE_DIR}/src/shared/account/AccountValidationTests.cpp
-    ${CMAKE_SOURCE_DIR}/src/shared/account/AccountValidation.cpp
-  )
-  target_include_directories(account_validation_tests PRIVATE ${CMAKE_SOURCE_DIR})
-  target_compile_options(account_validation_tests PRIVATE -Wall -Wextra -Wpedantic)
-  add_test(NAME account_validation_tests COMMAND account_validation_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+  # Sécurité (audit F9) : la cible account_validation_tests est déjà déclarée dans le
+  # CMakeLists.txt racine (liée à engine_core) — ne pas la redéclarer ici (CMP0002 : doublon).
 
   # Wave 12: PacketLog ring buffer (debug RX/TX trace, opt-in) — pure unit tests.
   # Aucun lien sur engine_core ni OpenSSL : PacketLog est autonome (std + threads).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,8 @@ elseif(UNIX)
     # Audit F3 : tag HMAC-SHA256 préfixe authentifiant SHARD_REGISTER/HEARTBEAT
     # (utilisé par ShardRegisterHandler, compilé dans ce binaire master).
     ${CMAKE_SOURCE_DIR}/src/shared/network/ShardWireAuth.cpp
+    # Audit F6 : refus au boot d'un secret HMAC partagé faible/par défaut.
+    ${CMAKE_SOURCE_DIR}/src/shared/security/SharedSecretPolicy.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/social/FriendSystem.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/ShardPresenceService.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/social/PartySystem.cpp
@@ -1153,6 +1155,15 @@ elseif(UNIX)
   target_link_libraries(shard_wire_auth_tests PRIVATE OpenSSL::SSL)
   target_compile_options(shard_wire_auth_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME shard_wire_auth_tests COMMAND shard_wire_auth_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
+  # Audit F6 : refus au boot d'un secret HMAC partagé faible/par défaut (masterd + shardd).
+  add_executable(shared_secret_policy_tests
+    ${CMAKE_SOURCE_DIR}/src/shared/security/SharedSecretPolicyTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/security/SharedSecretPolicy.cpp
+  )
+  target_include_directories(shared_secret_policy_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_compile_options(shared_secret_policy_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME shared_secret_policy_tests COMMAND shared_secret_policy_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
   # Présence unifiée (Niveau 1) : ShardPresenceService — présence shard-locale.
   add_executable(shard_presence_service_tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1106,6 +1106,27 @@ elseif(UNIX)
   target_compile_options(shard_ticket_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME shard_ticket_tests COMMAND shard_ticket_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # Audit F8 : verrou anti-brute-force sur PasswordResetHandler::HandleVerifyEmail
+  # (code de vérification e-mail à 6 chiffres). Passe par HandlePacket() (point
+  # d'entrée public) avec un NetServer jamais Init() — Send() y est un no-op sûr.
+  add_executable(password_reset_handler_tests
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/password/PasswordResetHandlerTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/password/PasswordResetHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/password/PasswordResetStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/account/InMemoryAccountStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/email/SmtpMailer.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/email/LocalizedEmail.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/security/RateLimitAndBan.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/security/SecurityAuditLog.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/NetServer.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/PacketLog.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/AuthRegisterPayloads.cpp
+  )
+  target_include_directories(password_reset_handler_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_link_libraries(password_reset_handler_tests PRIVATE engine_core engine_auth OpenSSL::SSL pthread)
+  target_compile_options(password_reset_handler_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME password_reset_handler_tests COMMAND password_reset_handler_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # Présence enrichie (v9) : round-trip du payload SHARD_HEARTBEAT avec tableau joueurs.
   add_executable(shard_payloads_tests
     ${CMAKE_SOURCE_DIR}/src/shared/network/ShardPayloadsTests.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1155,6 +1155,16 @@ elseif(UNIX)
   target_compile_options(server_list_policy_tests PRIVATE -Wall -Wextra -Wpedantic)
   add_test(NAME server_list_policy_tests COMMAND server_list_policy_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
+  # Sécurité (audit F9) : AccountValidation — normalisation/validation e-mail, login, mot de passe.
+  # Pure (pas de réseau, pas de DB) : dépend uniquement de NetErrorCode.h (header-only).
+  add_executable(account_validation_tests
+    ${CMAKE_SOURCE_DIR}/src/shared/account/AccountValidationTests.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/account/AccountValidation.cpp
+  )
+  target_include_directories(account_validation_tests PRIVATE ${CMAKE_SOURCE_DIR})
+  target_compile_options(account_validation_tests PRIVATE -Wall -Wextra -Wpedantic)
+  add_test(NAME account_validation_tests COMMAND account_validation_tests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
   # Wave 12: PacketLog ring buffer (debug RX/TX trace, opt-in) — pure unit tests.
   # Aucun lien sur engine_core ni OpenSSL : PacketLog est autonome (std + threads).
   # Module dans engine::server::netdebug (src/shared/network/PacketLog).

--- a/src/masterd/email/SmtpMailer.cpp
+++ b/src/masterd/email/SmtpMailer.cpp
@@ -264,6 +264,17 @@ namespace engine::server
 			return false;
 		}
 
+		// Sécurité (audit F9) : refuser CR/LF dans les champs injectés dans les commandes/headers SMTP.
+		// Défense en profondeur : ValidateEmail() rejette déjà les octets de contrôle dans l'adresse
+		// en amont (AccountValidation.cpp), mais subject/to peuvent transiter par d'autres chemins
+		// (ex. notifications internes) — on ne fait pas confiance à l'appelant.
+		auto hasCrlf = [](std::string_view s) { return s.find('\r') != std::string_view::npos || s.find('\n') != std::string_view::npos; };
+		if (hasCrlf(to) || hasCrlf(subject) || hasCrlf(cfg.from_address))
+		{
+			LOG_WARN(Smtp, "[SmtpMailer] Send refusé : CR/LF détecté dans to/subject/from");
+			return false;
+		}
+
 		LOG_WARN(Smtp,
 			"[SMTP] session démarrée → {} host={}:{} starttls={} auth={} (détail niveau Info, sous-système Smtp)",
 			RedactEmailForLog(to),

--- a/src/masterd/handlers/password/PasswordResetHandler.cpp
+++ b/src/masterd/handlers/password/PasswordResetHandler.cpp
@@ -251,6 +251,16 @@ namespace engine::server
 
 		const uint64_t account_id = parsed->account_id;
 
+		// Sécurité (audit F8) : verrou anti-brute-force sur le code à 6 chiffres, clé par compte.
+		const std::string rlKey = "vemail:" + std::to_string(account_id);
+		if (m_rateLimit && m_rateLimit->IsBanned(rlKey))
+		{
+			LOG_WARN(Auth, "[PasswordResetHandler] VerifyEmail: verrouillé (trop d'échecs) account_id={}", account_id);
+			auto pkt = BuildVerifyEmailResponseErrorPacket(NetErrorCode::VERIFICATION_CODE_INVALID, requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
 		// Lookup account to confirm it exists.
 		auto optAccount = m_accountStore->FindByAccountId(account_id);
 		if (!optAccount)
@@ -273,6 +283,7 @@ namespace engine::server
 		// Validate code.
 		if (!m_resetStore->ValidateVerificationCode(account_id, parsed->code))
 		{
+			if (m_rateLimit) m_rateLimit->RecordAuthFailure(rlKey); // audit F8 : bannit après N échecs
 			LOG_WARN(Auth, "[PasswordResetHandler] VerifyEmail: invalid or expired code (account_id={})", account_id);
 			auto pkt = BuildVerifyEmailResponseErrorPacket(NetErrorCode::VERIFICATION_CODE_INVALID, requestId, sessionIdHeader);
 			if (!pkt.empty()) m_server->Send(connId, pkt);

--- a/src/masterd/handlers/password/PasswordResetHandlerTests.cpp
+++ b/src/masterd/handlers/password/PasswordResetHandlerTests.cpp
@@ -1,0 +1,150 @@
+/**
+ * Audit F8 : tests du verrou anti-brute-force sur PasswordResetHandler::HandleVerifyEmail.
+ * No external test framework; returns 0 if all pass, non-zero on first failure.
+ *
+ * HandleVerifyEmail() est privée : on passe par HandlePacket() (point d'entrée public),
+ * comme le ferait le NetServer réel. Le NetServer utilisé ici est construit mais jamais
+ * Init() — Send() devient alors un no-op sûr (m_impl == nullptr), ce qui permet de tester
+ * la logique métier sans socket réelle.
+ */
+
+#include "src/masterd/handlers/password/PasswordResetHandler.h"
+#include "src/masterd/handlers/password/PasswordResetStore.h"
+#include "src/masterd/account/InMemoryAccountStore.h"
+#include "src/shared/security/RateLimitAndBan.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/AuthRegisterPayloads.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/core/Log.h"
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace
+{
+	static int s_failCount = 0;
+
+	void Assert(bool cond, const char* msg)
+	{
+		if (!cond)
+		{
+			++s_failCount;
+			std::cerr << "[FAIL] " << msg << std::endl;
+		}
+	}
+}
+
+using namespace engine::server;
+using namespace engine::network;
+
+// Audit F8 : sans le verrou anti-brute-force, un attaquant peut essayer les 10^6
+// combinaisons du code à 6 chiffres sans limite. Ce test prouve qu'après
+// max_failures_before_ban (5) tentatives avec un mauvais code, le compte est
+// verrouillé et un 6e appel avec le BON code est quand même refusé.
+static void TestVerifyEmailLockedAfterFiveFailures()
+{
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Off;
+	engine::core::Log::Init(logSettings);
+
+	InMemoryAccountStore accountStore;
+	PasswordResetStore resetStore;
+	RateLimitAndBan rateLimit;
+	RateLimitAndBanConfig rlCfg; // valeurs par défaut : max_failures_before_ban=5, ban_duration_sec=3600
+	rateLimit.SetConfig(rlCfg);
+	NetServer netServer; // jamais Init() : Send() est un no-op sûr (m_impl == nullptr)
+
+	PasswordResetHandler handler;
+	handler.SetServer(&netServer);
+	handler.SetAccountStore(&accountStore);
+	handler.SetPasswordResetStore(&resetStore);
+	handler.SetRateLimitAndBan(&rateLimit);
+
+	std::string tagIdOut;
+	uint64_t account_id = accountStore.CreateAccount(
+		"testuser_f8", "testuser_f8@example.com", "clienthash",
+		"Test", "User", "1990-01-01", "FR", tagIdOut);
+	Assert(account_id != 0, "CreateAccount succeeds");
+
+	const std::string goodCode = resetStore.CreateVerificationCode(account_id);
+	Assert(!goodCode.empty(), "CreateVerificationCode returns a non-empty code");
+	Assert(goodCode != "000000", "sanity: generated code differs from the bad code used below");
+
+	const uint32_t connId = 1;
+	const uint32_t requestId = 42;
+	const uint64_t sessionIdHeader = 0;
+
+	// 5 tentatives avec un mauvais code : chacune doit enregistrer un échec.
+	for (int i = 0; i < 5; ++i)
+	{
+		std::vector<uint8_t> badPayload = BuildVerifyEmailRequestPayload(account_id, "000000");
+		handler.HandlePacket(connId, kOpcodeVerifyEmailRequest, requestId, sessionIdHeader,
+			badPayload.data(), badPayload.size());
+	}
+
+	Assert(rateLimit.IsBanned("vemail:" + std::to_string(account_id)),
+		"account rate-limit key banned after 5 failures");
+
+	// 6e tentative avec le BON code : doit être refusée par le verrou (IsBanned),
+	// donc l'e-mail ne doit PAS être marqué vérifié malgré le code correct.
+	std::vector<uint8_t> goodPayload = BuildVerifyEmailRequestPayload(account_id, goodCode);
+	handler.HandlePacket(connId, kOpcodeVerifyEmailRequest, requestId, sessionIdHeader,
+		goodPayload.data(), goodPayload.size());
+
+	auto account = accountStore.FindByAccountId(account_id);
+	Assert(account.has_value(), "account still exists");
+	Assert(account && !account->email_verified,
+		"locked after 5 failures: correct code on 6th attempt is still refused");
+
+	engine::core::Log::Shutdown();
+}
+
+// Contrôle : sans avoir épuisé les tentatives, le bon code doit être accepté normalement.
+static void TestVerifyEmailAcceptedWithoutPriorFailures()
+{
+	engine::core::LogSettings logSettings;
+	logSettings.level = engine::core::LogLevel::Off;
+	engine::core::Log::Init(logSettings);
+
+	InMemoryAccountStore accountStore;
+	PasswordResetStore resetStore;
+	RateLimitAndBan rateLimit;
+	RateLimitAndBanConfig rlCfg;
+	rateLimit.SetConfig(rlCfg);
+	NetServer netServer;
+
+	PasswordResetHandler handler;
+	handler.SetServer(&netServer);
+	handler.SetAccountStore(&accountStore);
+	handler.SetPasswordResetStore(&resetStore);
+	handler.SetRateLimitAndBan(&rateLimit);
+
+	std::string tagIdOut;
+	uint64_t account_id = accountStore.CreateAccount(
+		"testuser_f8b", "testuser_f8b@example.com", "clienthash",
+		"Test", "User", "1990-01-01", "FR", tagIdOut);
+	Assert(account_id != 0, "CreateAccount succeeds (control case)");
+
+	const std::string goodCode = resetStore.CreateVerificationCode(account_id);
+
+	std::vector<uint8_t> goodPayload = BuildVerifyEmailRequestPayload(account_id, goodCode);
+	handler.HandlePacket(1, kOpcodeVerifyEmailRequest, 42, 0, goodPayload.data(), goodPayload.size());
+
+	auto account = accountStore.FindByAccountId(account_id);
+	Assert(account && account->email_verified,
+		"control: correct code accepted immediately when no prior failures");
+
+	engine::core::Log::Shutdown();
+}
+
+int main()
+{
+	TestVerifyEmailLockedAfterFiveFailures();
+	TestVerifyEmailAcceptedWithoutPriorFailures();
+
+	if (s_failCount != 0)
+		return s_failCount;
+	return 0;
+}

--- a/src/masterd/handlers/shard/ShardRegisterHandler.cpp
+++ b/src/masterd/handlers/shard/ShardRegisterHandler.cpp
@@ -14,16 +14,19 @@
 #include "src/masterd/shards/ShardRegistry.h"
 #include "src/masterd/shards/ShardPlayerPresenceCache.h"
 #include "src/shared/network/ShardPayloads.h"
+#include "src/shared/network/ShardWireAuth.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 #include "src/shared/core/Log.h"
 
 #include <cstdio>
+#include <utility>
 
 namespace engine::server
 {
 	void ShardRegisterHandler::SetServer(NetServer* server) { m_server = server; }
 	void ShardRegisterHandler::SetShardRegistry(ShardRegistry* registry) { m_registry = registry; }
 	void ShardRegisterHandler::SetPlayerPresenceCache(ShardPlayerPresenceCache* cache) { m_presenceCache = cache; }
+	void ShardRegisterHandler::SetSecret(std::string secret) { m_secret = std::move(secret); }
 
 	void ShardRegisterHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t /*sessionIdHeader*/,
 		const uint8_t* payload, size_t payloadSize)
@@ -34,15 +37,19 @@ namespace engine::server
 			LOG_WARN(Core, "[ShardRegisterHandler] HandlePacket: server or registry not set");
 			return;
 		}
-		if (opcode == kOpcodeShardRegister)
+		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)
 		{
-			HandleRegister(connId, requestId, payload, payloadSize);
-			return;
-		}
-		if (opcode == kOpcodeShardHeartbeat)
-		{
-			HandleHeartbeat(connId, payload, payloadSize);
-			return;
+			// Sécurité (audit F3) : le canal shard↔master est authentifié par un tag HMAC préfixe.
+			auto body = UnwrapShardAuth(m_secret, payload, payloadSize);
+			if (!body)
+			{
+				LOG_WARN(Server, "[SREG] paquet shard rejeté : authentification HMAC invalide (opcode={}, connId={})", opcode, connId);
+				return;
+			}
+			if (opcode == kOpcodeShardRegister)
+				HandleRegister(connId, requestId, body->first, body->second);
+			else
+				HandleHeartbeat(connId, body->first, body->second);
 		}
 	}
 

--- a/src/masterd/handlers/shard/ShardRegisterHandler.cpp
+++ b/src/masterd/handlers/shard/ShardRegisterHandler.cpp
@@ -124,7 +124,7 @@ namespace engine::server
 		}
 	}
 
-	void ShardRegisterHandler::HandleHeartbeat(uint32_t /*connId*/, const uint8_t* payload, size_t payloadSize)
+	void ShardRegisterHandler::HandleHeartbeat(uint32_t connId, const uint8_t* payload, size_t payloadSize)
 	{
 		using namespace engine::network;
 
@@ -136,6 +136,18 @@ namespace engine::server
 		if (!parsed)
 		{
 			LOG_WARN(Server, "[SREG] HandleHeartbeat: parse failed");
+			return;
+		}
+		// Sécurité (audit F2) : le shard_id du heartbeat doit correspondre à la connId qui a
+		// réalisé le REGISTER (mémorisée par SetShardConnection). Sans cette vérification,
+		// n'importe quel pair connecté au Master peut forger un heartbeat pour un shard_id
+		// qu'il ne possède pas. GetShardConnection renvoie std::optional<uint32_t> (nullopt
+		// si le shard_id est inconnu du registre).
+		const auto registered = m_registry->GetShardConnection(parsed->shard_id);
+		if (!registered || *registered != connId)
+		{
+			LOG_WARN(Server, "[SREG] HandleHeartbeat rejeté : connId={} ne correspond pas au shard_id={} (attendu connId={})",
+				connId, parsed->shard_id, registered ? *registered : 0u);
 			return;
 		}
 		m_registry->UpdateHeartbeat(parsed->shard_id, parsed->current_load);

--- a/src/masterd/handlers/shard/ShardRegisterHandler.h
+++ b/src/masterd/handlers/shard/ShardRegisterHandler.h
@@ -77,10 +77,13 @@ namespace engine::server
 
 		/// Traite l'opcode SHARD_HEARTBEAT.
 		///
-		/// Parse le payload (shard_id, charge actuelle) et délègue à
+		/// Parse le payload (shard_id, charge actuelle), vérifie (audit F2) que \p connId
+		/// correspond bien à la connexion enregistrée pour ce shard_id via
+		/// ShardRegistry::GetShardConnection (rejette sinon, LOG_WARN), puis délègue à
 		/// ShardRegistry::UpdateHeartbeat pour maintenir l'état Online du shard.
 		/// Aucune réponse n'est envoyée (fire-and-forget).
-		/// @param connId       Identifiant de connexion (utilisé pour le logging uniquement).
+		/// @param connId       Identifiant de connexion réseau de l'appelant ; doit correspondre
+		///                     à la connId mémorisée lors du REGISTER pour ce shard_id.
 		/// @param payload      Corps du paquet SHARD_HEARTBEAT.
 		/// @param payloadSize  Taille en octets de \p payload.
 		void HandleHeartbeat(uint32_t connId, const uint8_t* payload, size_t payloadSize);

--- a/src/masterd/handlers/shard/ShardRegisterHandler.h
+++ b/src/masterd/handlers/shard/ShardRegisterHandler.h
@@ -10,6 +10,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 namespace engine::server
 {
@@ -48,16 +49,25 @@ namespace engine::server
 		/// @param cache  Instance ShardPlayerPresenceCache. Non possédé. Peut être nul.
 		void SetPlayerPresenceCache(ShardPlayerPresenceCache* cache);
 
-		/// Point d'entrée principal : dispatche vers HandleRegister ou HandleHeartbeat.
+		/// Sécurité (audit F3) : secret partagé HMAC-SHA256 utilisé pour vérifier le tag
+		/// d'authentification préfixé aux payloads SHARD_REGISTER/SHARD_HEARTBEAT (config
+		/// `shard.ticket_hmac_secret`, identique au secret câblé côté shard). Si vide,
+		/// UnwrapShardAuth rejette systématiquement (aucun shard ne peut s'enregistrer).
+		void SetSecret(std::string secret);
+
+		/// Point d'entrée principal : vérifie le tag HMAC préfixe (audit F3) puis dispatche
+		/// vers HandleRegister ou HandleHeartbeat.
 		///
 		/// Ignore silencieusement tout opcode autre que SHARD_REGISTER et SHARD_HEARTBEAT.
 		/// Si m_server ou m_registry est nul, émet un LOG_WARN et retourne immédiatement.
+		/// Si le tag d'authentification est absent ou invalide, émet un LOG_WARN et
+		/// rejette le paquet sans dispatcher (aucune réponse envoyée).
 		/// @param connId          Identifiant de connexion réseau de l'appelant (shard).
 		/// @param opcode          Code d'opération du paquet reçu.
 		/// @param requestId       Identifiant de requête à reporter dans la réponse.
 		/// @param sessionIdHeader Champ session de l'en-tête (ignoré pour ces opcodes).
-		/// @param payload         Données brutes du corps du paquet.
-		/// @param payloadSize     Taille en octets de \p payload.
+		/// @param payload         Données brutes du corps du paquet, tag HMAC(32) inclus en tête.
+		/// @param payloadSize     Taille en octets de \p payload (tag inclus).
 		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 			const uint8_t* payload, size_t payloadSize);
 
@@ -94,5 +104,7 @@ namespace engine::server
 		ShardRegistry* m_registry = nullptr;
 		/// Cache de présence enrichie (optionnel, non possédé). Nul = présence enrichie désactivée.
 		ShardPlayerPresenceCache* m_presenceCache = nullptr;
+		/// Secret HMAC partagé avec les shards (audit F3). Voir SetSecret.
+		std::string m_secret;
 	};
 }

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -1049,6 +1049,9 @@ int main(int argc, char** argv)
 	passwordResetHandler.SetSecurityAuditLog(&auditLog);
 	LOG_INFO(Auth, "[ServerMain] PasswordResetHandler configured (M33.2)");
 	shardRegisterHandler.SetServer(&server);
+	// Sécurité (audit F3) : authentifie SHARD_REGISTER/SHARD_HEARTBEAT par tag HMAC préfixe
+	// (même secret que ShardTicketHandler ci-dessous, config `shard.ticket_hmac_secret`).
+	shardRegisterHandler.SetSecret(config.GetString("shard.ticket_hmac_secret", ""));
 	engine::server::ShardTicketHandler shardTicketHandler;
 	shardTicketHandler.SetServer(&server);
 	shardTicketHandler.SetShardRegistry(&shardRegistry);

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -1096,7 +1096,8 @@ int main(int argc, char** argv)
 			serverListHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeForgotPasswordRequest
 		      || opcode == kOpcodeResetPasswordRequest
-		      || opcode == kOpcodeVerifyEmailRequest)
+		      || opcode == kOpcodeVerifyEmailRequest
+		      || opcode == kOpcodeResendVerificationRequest)
 			passwordResetHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeTermsStatusRequest || opcode == kOpcodeTermsContentRequest || opcode == kOpcodeTermsAcceptRequest)
 			termsHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -24,6 +24,7 @@
 #include "src/masterd/session/SessionManager.h"
 #include "src/shared/security/RateLimitAndBan.h"
 #include "src/shared/security/SecurityAuditLog.h"
+#include "src/shared/security/SharedSecretPolicy.h"
 #include "src/masterd/session/ConnectionSessionMap.h"
 #include "src/masterd/handlers/password/PasswordResetStore.h"
 #include "src/masterd/handlers/password/PasswordResetHandler.h"
@@ -171,6 +172,20 @@ int main(int argc, char** argv)
 	if (!engine::core::Config::LoadServerConfig(config, "config"))
 	{
 		LOG_WARN(Server, "[master] config/server.config.json absent : repli sur clés inline éventuelles");
+	}
+
+	// Audit F6 : refus au boot si le secret HMAC partagé (utilisé pour signer les
+	// tickets shard) est vide ou une valeur de dev connue committée dans le repo.
+	// Placé tôt, avant toute ouverture de port réseau (server.Init plus bas).
+	{
+		const std::string shardSecret = config.GetString("shard.ticket_hmac_secret", "");
+		if (engine::security::IsWeakSharedSecret(shardSecret) && !engine::security::DevSecretOverrideEnabled())
+		{
+			LOG_ERROR(Core, "[Boot] shard.ticket_hmac_secret vide ou par défaut : refus de démarrer. "
+				"Définir un vrai secret, ou poser LCDLLN_ALLOW_DEV_SECRET=1 en développement.");
+			engine::core::Log::Shutdown();
+			return 1;
+		}
 	}
 
 	LOG_INFO(Net, "[ServerMain] Linux TCP server starting...");

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -11,6 +11,7 @@
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 #include "src/shared/network/ShardToMasterClient.h"
+#include "src/shared/security/SharedSecretPolicy.h"
 #include "src/shared/core/Config.h"
 #include "src/shared/core/Log.h"
 #include "src/shared/core/LogConfig.h"
@@ -56,6 +57,21 @@ int main(int argc, char** argv)
 	if (!engine::core::Config::LoadServerConfig(config, "config"))
 	{
 		LOG_WARN(Net, "[shard] config/server.config.json absent : repli sur clés inline éventuelles");
+	}
+
+	// Audit F6 : refus au boot si le secret HMAC partagé (utilisé pour signer les
+	// tickets et authentifier SHARD_REGISTER/HEARTBEAT vers le master) est vide ou
+	// une valeur de dev connue committée dans le repo. Placé tôt, avant l'ouverture
+	// du port réseau (server.Init plus bas) et avant le ShardToMasterClient.
+	{
+		const std::string shardSecret = config.GetString("shard.ticket_hmac_secret", "");
+		if (engine::security::IsWeakSharedSecret(shardSecret) && !engine::security::DevSecretOverrideEnabled())
+		{
+			LOG_ERROR(Net, "[Boot] shard.ticket_hmac_secret vide ou par défaut : refus de démarrer. "
+				"Définir un vrai secret, ou poser LCDLLN_ALLOW_DEV_SECRET=1 en développement.");
+			engine::core::Log::Shutdown();
+			return 1;
+		}
 	}
 
 	LOG_INFO(Net, "[ShardMain] Shard server starting...");

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -186,6 +186,9 @@ int main(int argc, char** argv)
 	toMaster.SetAllowInsecureDev(masterInsecure);
 	toMaster.SetShardIdentity(regName, regEndpoint, regUdpEndpoint, regCap, buildVer, regDisplayName, regGameMode, regRuleset, regRegion);
 	toMaster.SetHeartbeatIntervalSec(static_cast<int>(config.GetInt("shard.heartbeat_interval_sec", 10)));
+	// Sécurité (audit F3) : authentifie SHARD_REGISTER/SHARD_HEARTBEAT par tag HMAC préfixe
+	// (même secret que le master, config `shard.ticket_hmac_secret`).
+	toMaster.SetSharedSecret(config.GetString("shard.ticket_hmac_secret", ""));
 	// TA.3 — admet (account_id, character_id) dans le registre dès que le master pousse
 	// kOpcodeMasterToShardAdmitCharacter (suite à un EnterWorld réussi côté master). Sans
 	// ce câblage, le Hello UDP du client (clientNonce=character_id) serait rejeté car le

--- a/src/shared/account/AccountValidation.cpp
+++ b/src/shared/account/AccountValidation.cpp
@@ -37,6 +37,13 @@ namespace engine::server
 	{
 		if (normalisedEmail.empty())
 			return engine::network::NetErrorCode::INVALID_EMAIL;
+		// Sécurité (audit F9) : aucun caractère de contrôle (0x00-0x1F, 0x7F) où que ce soit —
+		// empêche l'injection SMTP (CR/LF vers RCPT TO/headers) via l'adresse enregistrée.
+		for (unsigned char c : normalisedEmail)
+		{
+			if (c < 0x20u || c == 0x7Fu)
+				return engine::network::NetErrorCode::INVALID_EMAIL;
+		}
 		if (normalisedEmail.size() > kAccountEmailMaxLength)
 			return engine::network::NetErrorCode::INVALID_EMAIL;
 		std::size_t at = normalisedEmail.find('@');

--- a/src/shared/account/AccountValidationTests.cpp
+++ b/src/shared/account/AccountValidationTests.cpp
@@ -44,6 +44,22 @@ namespace
 		Assert(ValidateEmail(NormaliseEmail("a@bcom")) == NetErrorCode::INVALID_EMAIL, "domaine sans .");
 		Assert(ValidateEmail(NormaliseEmail("")) == NetErrorCode::INVALID_EMAIL, "vide");
 	}
+
+	// Sécurité (audit F9) : rejet des octets de contrôle dans l'e-mail (anti-injection SMTP).
+	void TestValidateEmailControlCharsRejected()
+	{
+		using engine::server::ValidateEmail;
+		Assert(ValidateEmail("a@b.com") == NetErrorCode::OK, "email valide accepté");
+		Assert(ValidateEmail(std::string("a@b.com\r\nRCPT TO:<x@evil>")) == NetErrorCode::INVALID_EMAIL,
+			"CRLF au milieu rejeté");
+		Assert(ValidateEmail(std::string("a\tb@c.com")) == NetErrorCode::INVALID_EMAIL, "TAB rejeté");
+		{
+			std::string withNul = "a@b.com";
+			withNul.push_back('\0');
+			withNul += "x";
+			Assert(ValidateEmail(withNul) == NetErrorCode::INVALID_EMAIL, "NUL rejeté");
+		}
+	}
 }
 
 int main()
@@ -51,6 +67,7 @@ int main()
 	TestPasswordRules();
 	TestValidatePasswordEquivalence();
 	TestValidateEmail();
+	TestValidateEmailControlCharsRejected();
 	if (s_fail != 0) return 1;
 	std::cout << "AccountValidation tests: all passed." << std::endl;
 	return 0;

--- a/src/shared/network/ShardToMasterClient.cpp
+++ b/src/shared/network/ShardToMasterClient.cpp
@@ -3,6 +3,7 @@
 #include "src/shared/network/PacketBuilder.h"
 #include "src/shared/network/PacketView.h"
 #include "src/shared/network/ShardPayloads.h"
+#include "src/shared/network/ShardWireAuth.h"
 #include "src/shared/core/Log.h"
 
 #include <chrono>
@@ -40,6 +41,11 @@ namespace engine::network
 	void ShardToMasterClient::SetAllowInsecureDev(bool allow)
 	{
 		m_allow_insecure = allow;
+	}
+
+	void ShardToMasterClient::SetSharedSecret(std::string secret)
+	{
+		m_shared_secret = std::move(secret);
 	}
 
 	void ShardToMasterClient::SetShardIdentity(std::string name, std::string endpoint, std::string udp_endpoint, uint32_t max_capacity, std::string build_version,
@@ -125,6 +131,13 @@ LOG_DEBUG(Net, "[STMC] SendRegister name='{}' display='{}' endpoint='{}' cap={} 
 			LOG_ERROR(Core, "[ShardToMasterClient] BuildShardRegisterPayload failed");
 			return;
 		}
+		// Sécurité (audit F3) : authentifier le REGISTER par tag HMAC préfixe.
+		payload = WrapShardAuth(m_shared_secret, payload);
+		if (payload.empty())
+		{
+			LOG_ERROR(Core, "[ShardToMasterClient] WrapShardAuth register échoué (secret vide ?)");
+			return;
+		}
 		PacketBuilder builder;
 		auto w = builder.PayloadWriter();
 		if (!w.WriteBytes(payload.data(), payload.size()))
@@ -153,6 +166,9 @@ LOG_DEBUG(Net, "[STMC] SendRegister name='{}' display='{}' endpoint='{}' cap={} 
 		if (m_presence_provider)
 			players = m_presence_provider();
 		auto payload = BuildShardHeartbeatPayload(m_shard_id, m_current_load, timestamp, players);
+		if (payload.empty())
+			return;
+		payload = WrapShardAuth(m_shared_secret, payload); // audit F3
 		if (payload.empty())
 			return;
 		PacketBuilder builder;

--- a/src/shared/network/ShardToMasterClient.h
+++ b/src/shared/network/ShardToMasterClient.h
@@ -54,6 +54,12 @@ namespace engine::network
 		/// Heartbeat interval in seconds. Default 10. Call before Start() to take effect.
 		void SetHeartbeatIntervalSec(int sec) { m_heartbeat_interval_sec = (sec > 0) ? sec : 10; }
 
+		/// Sécurité (audit F3) : secret partagé HMAC-SHA256 authentifiant les payloads
+		/// SHARD_REGISTER/SHARD_HEARTBEAT envoyés au master (config `shard.ticket_hmac_secret`).
+		/// Doit être appelé avant Start() ; si vide, l'émission échoue silencieusement
+		/// (WrapShardAuth renvoie {} et le paquet n'est pas envoyé).
+		void SetSharedSecret(std::string secret);
+
 		/// Présence enrichie (v9) : fournisseur optionnel appelé à chaque heartbeat pour
 		/// joindre la liste des joueurs en jeu `{accountId, characterId, level, zoneId}`.
 		/// Doit renvoyer un snapshot cohérent (typiquement construit sur le thread monde).
@@ -106,6 +112,8 @@ namespace engine::network
 		ShardRuleset m_ruleset = ShardRuleset::Cooperative;
 		std::string m_region;
 		uint32_t m_current_load = 0;
+		/// Sécurité (audit F3) : secret HMAC partagé avec le master. Voir SetSharedSecret.
+		std::string m_shared_secret;
 
 		State m_state = State::Disconnected;
 		uint32_t m_shard_id = 0;

--- a/src/shared/network/ShardWireAuth.cpp
+++ b/src/shared/network/ShardWireAuth.cpp
@@ -47,7 +47,7 @@ namespace engine::network
 		uint8_t expected[kShardAuthTagSize];
 		if (!ComputeTag(secret, body, bodySize, expected))
 			return std::nullopt;
-		// Comparaison à temps constant (corrige aussi F27 pour ce chemin).
+		// Comparaison à temps constant (CRYPTO_memcmp) pour la vérification du tag HMAC.
 		if (CRYPTO_memcmp(expected, payload, kShardAuthTagSize) != 0)
 			return std::nullopt;
 		return std::make_pair(body, bodySize);

--- a/src/shared/network/ShardWireAuth.cpp
+++ b/src/shared/network/ShardWireAuth.cpp
@@ -1,0 +1,55 @@
+/// @file ShardWireAuth.cpp
+/// @brief Implémentation de l'authentification HMAC-SHA256 shard↔master (audit F3).
+
+#include "src/shared/network/ShardWireAuth.h"
+
+#include <openssl/hmac.h>
+#include <openssl/evp.h>
+#include <openssl/crypto.h>
+
+#include <cstring>
+
+namespace engine::network
+{
+	namespace
+	{
+		// Calcule HMAC-SHA256(secret, body) dans outTag (doit pointer vers au moins
+		// kShardAuthTagSize octets). Renvoie false si OpenSSL échoue ou si la taille
+		// produite ne correspond pas à kShardAuthTagSize (SHA-256 = 32 octets, ne
+		// devrait jamais arriver, mais on ne fait pas confiance implicitement à l'ABI).
+		bool ComputeTag(std::string_view secret, const uint8_t* body, size_t bodySize, uint8_t* outTag)
+		{
+			unsigned int len = 0;
+			unsigned char* r = HMAC(EVP_sha256(), secret.data(), static_cast<int>(secret.size()),
+				body, bodySize, outTag, &len);
+			return r != nullptr && len == kShardAuthTagSize;
+		}
+	}
+
+	std::vector<uint8_t> WrapShardAuth(std::string_view secret, const std::vector<uint8_t>& body)
+	{
+		if (secret.empty())
+			return {};
+		std::vector<uint8_t> out(kShardAuthTagSize + body.size(), 0u);
+		if (!ComputeTag(secret, body.data(), body.size(), out.data()))
+			return {};
+		std::memcpy(out.data() + kShardAuthTagSize, body.data(), body.size());
+		return out;
+	}
+
+	std::optional<std::pair<const uint8_t*, size_t>> UnwrapShardAuth(
+		std::string_view secret, const uint8_t* payload, size_t size)
+	{
+		if (secret.empty() || payload == nullptr || size < kShardAuthTagSize)
+			return std::nullopt;
+		const uint8_t* body = payload + kShardAuthTagSize;
+		const size_t bodySize = size - kShardAuthTagSize;
+		uint8_t expected[kShardAuthTagSize];
+		if (!ComputeTag(secret, body, bodySize, expected))
+			return std::nullopt;
+		// Comparaison à temps constant (corrige aussi F27 pour ce chemin).
+		if (CRYPTO_memcmp(expected, payload, kShardAuthTagSize) != 0)
+			return std::nullopt;
+		return std::make_pair(body, bodySize);
+	}
+}

--- a/src/shared/network/ShardWireAuth.h
+++ b/src/shared/network/ShardWireAuth.h
@@ -1,0 +1,35 @@
+#pragma once
+
+/// @file ShardWireAuth.h
+/// @brief Authentification HMAC-SHA256 du canal shard↔master (audit F3).
+///
+/// SHARD_REGISTER et SHARD_HEARTBEAT (opcodes 10/13) transitent sur le même
+/// port TCP public que les connexions joueur, sans authentification propre
+/// avant cet ajout : n'importe quel pair pouvait forger un enregistrement de
+/// shard ou un heartbeat. On préfixe désormais chaque payload d'un tag
+/// HMAC-SHA256(secret, body) de 32 octets, calculé côté shard à l'émission
+/// et vérifié côté master avant tout parsing. WIRE-BREAKING : nécessite un
+/// déploiement lock-step master + shard partageant `shard.ticket_hmac_secret`.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace engine::network
+{
+	/// Taille du tag d'authentification HMAC-SHA256 préfixé aux payloads shard↔master.
+	constexpr size_t kShardAuthTagSize = 32u;
+
+	/// Préfixe un tag HMAC-SHA256(secret, body) de 32 octets à \a body.
+	/// Renvoie tag||body, ou {} si \a secret est vide ou en cas d'erreur OpenSSL.
+	std::vector<uint8_t> WrapShardAuth(std::string_view secret, const std::vector<uint8_t>& body);
+
+	/// Vérifie le tag préfixe (comparaison à temps constant) sur les octets restants.
+	/// Renvoie {pointeur_body, taille_body} après le tag, ou nullopt si trop court,
+	/// tag invalide, ou secret vide.
+	std::optional<std::pair<const uint8_t*, size_t>> UnwrapShardAuth(
+		std::string_view secret, const uint8_t* payload, size_t size);
+}

--- a/src/shared/network/ShardWireAuthTests.cpp
+++ b/src/shared/network/ShardWireAuthTests.cpp
@@ -1,0 +1,52 @@
+/**
+ * Tests unitaires — WrapShardAuth / UnwrapShardAuth (audit F3).
+ * Pur (pas de réseau, pas de DB). Retourne 0 si OK, non-zéro sinon.
+ *
+ * Couvre :
+ *  - round-trip nominal : wrap avec un secret non vide produit tag(32)||body,
+ *    unwrap avec le même secret retrouve le body identique.
+ *  - rejet mauvais secret : unwrap avec un secret différent échoue.
+ *  - rejet altération : un octet du payload wrappé modifié fait échouer unwrap.
+ *  - secret vide : wrap renvoie {} (pas de tag calculable).
+ *  - payload trop court : unwrap rejette (< kShardAuthTagSize octets).
+ */
+
+#include "src/shared/network/ShardWireAuth.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using engine::network::WrapShardAuth;
+using engine::network::UnwrapShardAuth;
+using engine::network::kShardAuthTagSize;
+
+int main()
+{
+	int fails = 0;
+	auto A = [&](bool c, const char* m){ if(!c){ ++fails; std::cerr << "[FAIL] " << m << "\n"; } };
+	const std::string secret = "un-secret-fort-de-test";
+	std::vector<uint8_t> body = {1,2,3,4,5};
+
+	auto wrapped = WrapShardAuth(secret, body);
+	A(wrapped.size() == kShardAuthTagSize + body.size(), "wrap = tag(32) + body");
+
+	auto ok = UnwrapShardAuth(secret, wrapped.data(), wrapped.size());
+	A(ok.has_value(), "unwrap avec bon secret réussit");
+	A(ok && ok->second == body.size(), "body de bonne taille");
+	A(ok && std::equal(body.begin(), body.end(), ok->first), "body identique");
+
+	auto bad = UnwrapShardAuth("mauvais-secret", wrapped.data(), wrapped.size());
+	A(!bad.has_value(), "unwrap avec mauvais secret rejeté");
+
+	std::vector<uint8_t> tampered = wrapped; tampered.back() ^= 0xFF;
+	A(!UnwrapShardAuth(secret, tampered.data(), tampered.size()).has_value(), "body falsifié rejeté");
+
+	A(WrapShardAuth("", body).empty(), "wrap avec secret vide -> vide");
+	A(!UnwrapShardAuth(secret, wrapped.data(), kShardAuthTagSize - 1).has_value(), "trop court rejeté");
+
+	if (fails) { std::cerr << fails << " FAIL\n"; return 1; }
+	std::cout << "OK\n"; return 0;
+}

--- a/src/shared/security/CaptchaVerifier.cpp
+++ b/src/shared/security/CaptchaVerifier.cpp
@@ -17,6 +17,7 @@
 #  include <unistd.h>
 #  include <openssl/ssl.h>
 #  include <openssl/err.h>
+#  include <openssl/x509.h>
 #  include <cstring>
 #  include <sstream>
 #else
@@ -219,15 +220,35 @@ namespace engine::server
 			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: SSL_CTX_new failed");
 			return false;
 		}
+		// Sécurité (audit F4) : vérifier le certificat serveur (défaut OpenSSL = SSL_VERIFY_NONE).
+		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nullptr);
+		if (SSL_CTX_set_default_verify_paths(ctx) != 1)
+		{
+			LOG_WARN(Net, "[CaptchaVerifier] trust store système indisponible");
+			// poursuivre : SSL_get_verify_result rejettera si le cert n'est pas validable.
+		}
 		SSL* ssl = SSL_new(ctx);
 		SSL_set_fd(ssl, fd);
 		SSL_set_tlsext_host_name(ssl, host.c_str());
+		// Sécurité (audit F4) : épingler le hostname attendu pour la validation du certificat.
+		SSL_set1_host(ssl, host.c_str());
 		if (SSL_connect(ssl) != 1)
 		{
 			SSL_free(ssl);
 			SSL_CTX_free(ctx);
 			::close(fd);
 			LOG_ERROR(Net, "[CaptchaVerifier] VerifyHttp: TLS handshake failed to host={}", host);
+			return false;
+		}
+
+		// Sécurité (audit F4) : refuser si la chaîne/hostname n'est pas validée.
+		const long verifyResult = SSL_get_verify_result(ssl);
+		if (verifyResult != X509_V_OK)
+		{
+			SSL_free(ssl);
+			SSL_CTX_free(ctx);
+			::close(fd);
+			LOG_WARN(Net, "[CaptchaVerifier] validation certificat échouée (code={}, host={})", verifyResult, host);
 			return false;
 		}
 

--- a/src/shared/security/SharedSecretPolicy.cpp
+++ b/src/shared/security/SharedSecretPolicy.cpp
@@ -1,0 +1,28 @@
+#include "src/shared/security/SharedSecretPolicy.h"
+
+#include <array>
+#include <cstdlib>
+#include <string_view>
+
+namespace engine::security
+{
+	bool IsWeakSharedSecret(std::string_view secret)
+	{
+		if (secret.empty())
+			return true;
+		static constexpr std::array<std::string_view, 2> kKnownDevSecrets = {
+			"dev_secret_change_in_production",
+			"changeme",
+		};
+		for (std::string_view weak : kKnownDevSecrets)
+			if (secret == weak)
+				return true;
+		return false;
+	}
+
+	bool DevSecretOverrideEnabled()
+	{
+		const char* v = std::getenv("LCDLLN_ALLOW_DEV_SECRET");
+		return v != nullptr && std::string_view(v) == "1";
+	}
+}

--- a/src/shared/security/SharedSecretPolicy.h
+++ b/src/shared/security/SharedSecretPolicy.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <string_view>
+
+namespace engine::security
+{
+	/// Vrai si le secret partagé est vide ou égal à une valeur de développement connue
+	/// (committée dans le repo) — donc impropre à la production.
+	bool IsWeakSharedSecret(std::string_view secret);
+
+	/// Vrai si l'opérateur a explicitement autorisé un secret de dev via
+	/// la variable d'environnement LCDLLN_ALLOW_DEV_SECRET=1.
+	bool DevSecretOverrideEnabled();
+}

--- a/src/shared/security/SharedSecretPolicyTests.cpp
+++ b/src/shared/security/SharedSecretPolicyTests.cpp
@@ -1,0 +1,13 @@
+#include "src/shared/security/SharedSecretPolicy.h"
+#include <iostream>
+using engine::security::IsWeakSharedSecret;
+int main()
+{
+	int fails = 0;
+	auto A = [&](bool c, const char* m){ if(!c){ ++fails; std::cerr << "[FAIL] " << m << "\n"; } };
+	A(IsWeakSharedSecret("") == true, "vide = faible");
+	A(IsWeakSharedSecret("dev_secret_change_in_production") == true, "valeur dev connue = faible");
+	A(IsWeakSharedSecret("un-vrai-secret-aleatoire-long-9f3a") == false, "secret fort = OK");
+	if (fails) return 1;
+	std::cout << "OK\n"; return 0;
+}


### PR DESCRIPTION
Corrige les **8 findings P0/P1** de l'audit du 2026-07-03 (`docs/audit/2026-07-03-audit-complet-frais.md`). F7 est **différé** (nécessite le fingerprint opérationnel du certificat master).

## Corrections (un commit par finding)

| # | Finding | Fichier principal | Test |
|---|---------|-------------------|------|
| **F3** (P0) | Auth HMAC du canal shard↔master (`SHARD_REGISTER`/`HEARTBEAT`) — tag HMAC-SHA256 préfixe, `CRYPTO_memcmp` | `src/shared/network/ShardWireAuth.*` (nouveau) | `shard_wire_auth_tests` (8 cas) |
| **F2** (P0) | Heartbeat shard lié à la `connId` enregistrée | `ShardRegisterHandler.cpp` | revue |
| **F4** (P0) | Vérification du certificat TLS CAPTCHA (`SSL_VERIFY_PEER` + hostname + `verify_result`) | `CaptchaVerifier.cpp` | revue (réseau) |
| **F1/F10** (P0/P2) | Resync des migrations Docker (0050–0071) + garde CI anti-divergence | `deploy/docker/sql/migrations/` | garde CI |
| **F9** (P1) | Rejet des caractères de contrôle dans l'e-mail (anti-injection SMTP) | `AccountValidation.cpp` | `account_validation_tests` |
| **F6** (P1) | Refus au boot d'un secret HMAC faible/vide sauf `LCDLLN_ALLOW_DEV_SECRET=1` + configs vidées | `SharedSecretPolicy.*` (nouveau) | `shared_secret_policy_tests` |
| **F8** (P1) | Rate-limit anti-brute-force sur la vérification d'e-mail | `PasswordResetHandler.cpp` | `password_reset_handler_tests` |
| **F5** (P1) | Route l'opcode `kOpcodeResendVerificationRequest` (=37) | `masterd/main_linux.cpp` | revue |
| **F7** (P1) | Marqué **différé** dans le rapport (pinning TLS client) | doc | — |

## Méthode

Corrections dérivées d'un audit multi-agents, implémentées par sous-agents (un par finding), avec revue par tâche sur F3 (wire-breaking) et **revue globale de branche** (Opus) : verdict **prêt à merger**, 0 finding Critical/Important, 3 Minor cosmétiques/arbitrages assumés.

## ⚠️ Déploiement — REDÉPLOIEMENT SERVEUR REQUIS (master ET shard, lock-step)

- **F3 wire-breaking** : tag HMAC préfixe sur opcodes 10/13 → un master neuf rejette un shard ancien et inversement. Master et shard doivent être déployés ensemble.
- **F6 gating boot** : les 3 configs livrées n'ont plus de secret par défaut. **Action opérateur obligatoire** : renseigner un vrai `shard.ticket_hmac_secret` (non vide, ≠ `dev_secret_change_in_production`), **identique côté master et shard**, avant de démarrer — sinon les deux refusent de booter (en dev : `LCDLLN_ALLOW_DEV_SECRET=1`).
- **F1/F10** : rejouer le build de l'image master (migrations 0050–0071 désormais packagées).
- Pas de changement du binaire client de jeu (F7 différé).

## Notes de la revue (Minor, non bloquants)
- **F8** : la clé de verrou par `account_id` permet un DoS ciblé temporaire (`ban_duration_sec`, défaut 1h) sur la vérif e-mail d'un compte — arbitrage anti-brute-force assumé, vérif e-mail hors chemin de login critique.
- **F4** : pas de test unitaire (socket TLS réelle) — repose sur la revue de code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
