### PR TITLE
fix(quests): le journal ne liste que les quêtes acceptées (démarrer sans quête)

### DIFF
--- a/game/data/quests/quest_definitions.json
+++ b/game/data/quests/quest_definitions.json
@@ -5,8 +5,6 @@
       "giver": "npc:elder_marn",
       "turnIn": "npc:elder_marn",
       "prereqs": [],
-      "repeat": "daily",
-      "autoComplete": false,
       "steps": [
         { "type": "kill", "target": "mob:100", "requiredCount": 10 }
       ],

--- a/src/client/quest/QuestUi.cpp
+++ b/src/client/quest/QuestUi.cpp
@@ -35,6 +35,13 @@ namespace engine::client
 		}
 	}
 
+	bool ShouldShowQuestInJournal(uint8_t status)
+	{
+		// Journal = uniquement les quêtes acceptées et en cours : Active (2) et
+		// ReadyToTurnIn (3). Offered (1)/Locked (0)/Completed (4) exclus (cf. doc h).
+		return status == 2u || status == 3u;
+	}
+
 	namespace
 	{
 		/// Trim spaces and tabs from both ends of one text view.
@@ -306,14 +313,40 @@ namespace engine::client
 		m_state.selectedQuestId.clear();
 		m_state.selectedQuestStatus = 0;
 
-		if (m_selectedQuestId.empty() && !model.quests.empty())
+		// Si la sélection courante n'est plus une quête acceptée (rendue, abandonnée,
+		// ou jamais acceptée), on la réassigne à la première quête acceptée dispo.
+		bool selectionStillShown = false;
+		for (const UIQuestEntry& quest : model.quests)
 		{
-			m_selectedQuestId = model.quests.front().questId;
+			if (ShouldShowQuestInJournal(quest.status) && quest.questId == m_selectedQuestId)
+			{
+				selectionStillShown = true;
+				break;
+			}
+		}
+		if (!selectionStillShown)
+		{
+			m_selectedQuestId.clear();
+			for (const UIQuestEntry& quest : model.quests)
+			{
+				if (ShouldShowQuestInJournal(quest.status))
+				{
+					m_selectedQuestId = quest.questId;
+					break;
+				}
+			}
 		}
 
 		bool selectedQuestFound = false;
 		for (const UIQuestEntry& quest : model.quests)
 		{
+			// Le journal ne liste QUE les quêtes acceptées (Active/ReadyToTurnIn) ;
+			// les quêtes seulement proposées par un PNJ (Offered) ou verrouillées
+			// n'y apparaissent pas — elles ne sont visibles que chez le PNJ.
+			if (!ShouldShowQuestInJournal(quest.status))
+			{
+				continue;
+			}
 			QuestJournalEntryView entry{};
 			entry.questId = quest.questId;
 			entry.status = quest.status;

--- a/src/client/quest/QuestUi.h
+++ b/src/client/quest/QuestUi.h
@@ -23,6 +23,16 @@ namespace engine::client
 	void WorldToRadarUv(float px, float pz, float playerX, float playerZ, float radiusM,
 		float& outU, float& outV, bool& outOffRadar);
 
+	/// Vrai si une quête de statut \p status doit apparaître dans le JOURNAL du
+	/// joueur : uniquement les quêtes acceptées et en cours — `Active` (2) et
+	/// `ReadyToTurnIn` (3). Les quêtes seulement proposées par un PNJ (`Offered` = 1)
+	/// ou verrouillées (`Locked` = 0), et les quêtes déjà rendues (`Completed` = 4),
+	/// n'y figurent PAS : le joueur doit d'abord accepter la quête chez le PNJ (le
+	/// journal reflète ce qu'on a accepté, pas ce qui est simplement disponible).
+	/// \p status = statut wire système B copié par `UIModelBinding::ApplyQuestDelta`
+	/// (cf. `QuestStatus` dans `QuestRuntime.h`). Fonction pure, testable directement.
+	bool ShouldShowQuestInJournal(uint8_t status);
+
 	/// Pixel-space rectangle used by the quest UI presenter layout.
 	struct QuestUiRect
 	{

--- a/src/client/quest/QuestUiRadarTests.cpp
+++ b/src/client/quest/QuestUiRadarTests.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <iostream>
 
+using engine::client::ShouldShowQuestInJournal;
 using engine::client::WorldToRadarUv;
 
 namespace
@@ -84,6 +85,18 @@ int main()
 		Check(NearlyEqual(u, 0.5f), "radiusM<=0 -> u==0.5 (garde)");
 		Check(NearlyEqual(v, 0.5f), "radiusM<=0 -> v==0.5 (garde)");
 		Check(offRadar, "radiusM<=0 -> off-radar force a true");
+	}
+
+	// Filtre du journal : seules les quêtes ACCEPTÉES (Active=2, ReadyToTurnIn=3)
+	// y apparaissent. Une quête juste proposée (Offered=1) ou verrouillée (Locked=0)
+	// n'y figure PAS — le joueur doit l'accepter chez le PNJ d'abord. Completed (4)
+	// (rendue) en sort aussi.
+	{
+		Check(!ShouldShowQuestInJournal(0u), "Locked(0) -> pas dans le journal");
+		Check(!ShouldShowQuestInJournal(1u), "Offered(1) -> pas dans le journal (dispo PNJ seulement)");
+		Check(ShouldShowQuestInJournal(2u), "Active(2) -> dans le journal");
+		Check(ShouldShowQuestInJournal(3u), "ReadyToTurnIn(3) -> dans le journal");
+		Check(!ShouldShowQuestInJournal(4u), "Completed(4) -> pas dans le journal (rendue)");
 	}
 
 	if (g_failures != 0)


### PR DESCRIPTION
## Problème

Un personnage voyait la quête `kill_10_boars` **« d'office »** dans son journal, alors qu'il ne l'avait jamais acceptée. Elle devait s'obtenir chez un PNJ (`npc:elder_marn`).

**Cause** (confirmée par le log client `QuestDelta applied (quest_id=kill_10_boars, status=1)` → status **1 = Offered**) : `RebuildJournal` listait **toutes** les quêtes du modèle, y compris les quêtes seulement **proposées** (`Offered`). Le journal affichait donc une quête disponible comme si elle était acceptée.

## Correctif (client, sans wire)

- **`ShouldShowQuestInJournal(status)`** : nouveau prédicat pur (dans `QuestUi.h`, exposé comme `WorldToRadarUv`) — le journal ne garde que **`Active` (2)** et **`ReadyToTurnIn` (3)**. `Locked` (0) / `Offered` (1) / `Completed` (4) sont exclus.
- **`RebuildJournal`** filtre via ce prédicat, et la **sélection par défaut** se réassigne à la première quête *acceptée* (plus de sélection d'une quête `Offered`).
- Les quêtes `Offered` restent visibles **uniquement chez le PNJ** (marqueur monde + panneau donneur), comme prévu par le design.

→ Le flux redevient : **démarrer sans quête au journal → l'obtenir au PNJ (Accepter) → la faire → la valider (turn-in)**.

## Contenu

- `kill_10_boars` : retrait du flag `repeat:daily` (que j'avais ajouté comme démo EXT-2). La quête tutoriel redevient **one-shot**, fidèle au design SP5. La feature répétable EXT-2 reste disponible pour d'autres quêtes.

## Tests

- `quest_ui_radar_tests` étendu : `ShouldShowQuestInJournal` — Locked/Offered/Completed → exclus, Active/ReadyToTurnIn → inclus.

## Déploiement

> **⚠️ CLIENT à reconstruire** (correctif de rendu du journal) **+ restart SHARD** (rechargement de `quest_definitions.json` sans le flag daily). **Aucun changement de wire** — pas de bump `kProtocolVersion`, pas de lock-step protocole.

## Note

Les autres anomalies signalées (avatar qui clignote au mouvement, `damage=0` en combat) sont **hors de ce correctif** : le log montre que le combat/rendu ne sont pas touchés par le merge quêtes, et le binaire client testé venait d'un commit absent du dépôt (`c8a7ec1…`) → probable mismatch client/shard. À revérifier une fois client + shard reconstruits depuis le même commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)