### PR TITLE
fix(combat): la mêlée ne touche jamais (accuracy dérivée 0 = 100% de ratés)

### DIFF
--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -58,6 +58,15 @@ namespace engine::server
 		inline constexpr uint32_t kDefaultMobDamage = 6;
 		inline constexpr uint32_t kDefaultLootBagArchetypeId = 200;
 		inline constexpr float kDefaultAttackRangeMeters = 4.0f;
+		/// Accuracy de repli pour les profils de mêlée. Le moteur de stats
+		/// (`CharacterStatsEngine`) met délibérément `accuracy = 0` pour les classes
+		/// de mêlée (range 0) — dans SON domaine, 0 signifie « accuracy non
+		/// applicable à la mêlée ». Mais `ResolveAttackRoll` interprète `accuracy = 0`
+		/// comme 0 % de chance de toucher → 100 % de ratés. On substitue donc une
+		/// accuracy pleine (100 = touche toujours, la mêlée ne fait pas de jet de
+		/// précision) au moment de peupler le composant combat. Cf.
+		/// `ApplyDerivedCombatStats` (miroir du fallback de portée juste au-dessus).
+		inline constexpr float kDefaultMeleeAccuracy = 100.0f;
 		inline constexpr float kDefaultMobLeashDistanceMeters = 24.0f;
 		inline constexpr float kDefaultMobMoveSpeedMetersPerSecond = 3.0f;
 		inline constexpr float kDefaultMobPatrolDistanceMeters = 6.0f;
@@ -271,7 +280,10 @@ namespace engine::server
 		{
 			client.combat.damagePerHit = derived.damage;
 			client.combat.attackRangeMeters = (derived.range > 0.0f) ? derived.range : kDefaultAttackRangeMeters;
-			client.combat.accuracy = derived.accuracy;
+			// Mêlée : le moteur de stats donne accuracy 0 (« non applicable »), que
+			// ResolveAttackRoll lit comme 0 % de touche → 100 % de ratés. Fallback à
+			// une accuracy pleine (la mêlée touche toujours). Cf. kDefaultMeleeAccuracy.
+			client.combat.accuracy = (derived.accuracy > 0.0f) ? derived.accuracy : kDefaultMeleeAccuracy;
 			client.combat.critRate = derived.critRate;
 			client.combat.critMult = derived.critMult;
 		}


### PR DESCRIPTION
## Symptôme

Un joueur de mêlée (guerrier) **ne peut endommager aucune cible** : chaque auto-attaque affiche `CombatEvent damage=0`, la cible reste à pleine vie (log : sanglier 60/60 à chaque coup). Fortement impactant.

## Origine (confirmée)

Ce n'est pas « 0 dégât » — c'est **100 % de ratés**. Chaîne :

1. **`CharacterStatsEngine.cpp:69-73`** : pour un profil de **mêlée** (`range == 0` → guerrier/tank/sacré), le moteur force `accuracy = 0`. Dans le domaine du moteur, 0 = « accuracy non applicable à la mêlée » (comportement volontaire, testé dans `CharacterStatsEngineTests`).
2. **`ServerApp::ApplyDerivedCombatStats`** copiait ce `0` **tel quel** dans le composant combat — alors qu'il gère déjà spécialement `range==0` (fallback `kDefaultAttackRangeMeters`) juste au-dessus.
3. **`ResolveAttackRoll` (AttackResolver.h)** lit `accuracy = 0` comme **0 % de chance de toucher** → `roll >= 0` toujours vrai → **miss systématique**, `damage=0`, retour avant tout calcul de dégât. Comportement **testé et voulu** : `AttackResolverTests::TestGuaranteedMiss` (accuracy 0 → rate toujours) / `TestGuaranteedHit` (accuracy 100 → touche toujours).

→ Désaccord sémantique entre deux sous-systèmes : le moteur de stats dit « accuracy N/A » (0), le résolveur lit « 0 % touche ». Les classes **à distance** (accuracy ~70) touchent normalement — d'où le bug limité à la mêlée.

## Correctif (1 ligne + constante)

Dans `ApplyDerivedCombatStats`, fallback à **`kDefaultMeleeAccuracy = 100`** (la mêlée touche toujours ; elle ne fait pas de jet de précision) quand `derived.accuracy <= 0`. **Miroir exact** du fallback de portée déjà présent une ligne au-dessus.

- Ne touche PAS le moteur de stats ni son test (l'accuracy « N/A »=0 reste vraie dans le domaine des stats).
- Ne touche PAS le résolveur ni ses tests (accuracy 100 → touche, déjà couvert).

## Portée

Bug **pré-existant**, hors du chantier quêtes (le combat n'a jamais été modifié par ces PRs).

## Déploiement

> **⚠️ REDÉPLOIEMENT SHARD requis** (change le peuplement des stats de combat à l'enter-world). **Aucun changement de wire**, client inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)