### PR TITLE
fix(render): avatar local qui clignote (anneau de buffers skinnés trop court)

### DIFF
--- a/src/client/render/skinned/SkinnedRenderer.h
+++ b/src/client/render/skinned/SkinnedRenderer.h
@@ -168,7 +168,17 @@ public:
     /// une marge confortable avant qu'un slot soit réutilisé par-dessus une
     /// écriture encore en flight côté GPU. Coût : 32 × (~16 KB bone SSBO + 64 B
     /// model) ≈ 512 KB host-visible GPU. Acceptable pour un client.
-    static constexpr uint32_t kFrameSlots = 32u;
+    ///
+    /// 2026-07-04 — bump 32 → 64. Les zones peuplées (ex. cluster de 16 sangliers
+    /// SP5 rendus comme avatars skinnés) dépassaient 16 draws skinnés/frame :
+    /// 1 local + 16 distants = 17 > 32/FIF(2) = 16 → l'anneau se réécrivait par-
+    /// dessus les os de l'avatar LOCAL (slot le plus ancien) encore lu par le GPU
+    /// → l'avatar local clignotait/disparaissait. 64 slots couvrent 32 draws/frame
+    /// à FIF=2 (marge sur les 17 actuels). Coût ≈ 1 MB host-visible. LIMITE : reste
+    /// un plafond fixe (au-delà de 32 draps/frame le bug réapparaît) — le fix
+    /// durable = allocation partitionnée par index de frame (ou cap de draws
+    /// skinnés/frame), à faire séparément.
+    static constexpr uint32_t kFrameSlots = 64u;
 
 private:
     VkDevice m_device = VK_NULL_HANDLE;


### PR DESCRIPTION
## Symptôme

L'avatar **local** (ton personnage, vue 3e personne) apparaît puis **disparaît au mouvement**, par intermittence. Les avatars distants s'affichent bien. Aucun crash.

## Origine (confirmée)

`SkinnedRenderer` partage **un anneau** (`kFrameSlots`) de buffers par-draw (bone SSBO + matrice modèle), avancé d'un cran à **chaque `Record()`** et **jamais remis à zéro par frame** (`SkinnedRenderer.cpp:568-569`). Les buffers sont host-coherent, écrits par un `memcpy` direct **sans fence** (568-599).

- Chaque entité skinnée = 1 `Record()` : avatar local (`Engine.cpp:5589`, écrit **en premier**) + chaque distant (`RecordRemoteAvatars`).
- Ton log : `remotes=16` → **17 draws skinnés/frame** (1 local + 16). Les 16 « distants » sont en fait les **16 sangliers** (mob:100 de SP5) rendus comme avatars skinnés.
- FIF=2, `kFrameSlots=32` → un slot revient tous les 32 draws. À 17/frame : la frame N+1 réécrit les slots de la fin sur ceux du **début de la frame N** — dont l'**avatar local** (slot le plus ancien) — **pendant que le GPU lit encore** la frame N. → le skinning local s'effondre → **clignotement**.

C'est la **limite exacte déjà documentée** : `Engine.cpp:14703` (audit 2026-06-10) « au-delà de ~16 draws skinnés par frame le ring se réécrit pendant une frame en vol ». Le cluster de sangliers a franchi le seuil.

L'avatar local est la victime visible car c'est le slot écrit en premier (le plus ancien, le plus susceptible d'être encore lu par le GPU) ; un sanglier qui glitche parmi 16 est quasi invisible.

## Hypothèses écartées (avec preuves)
- **Culling GPU / gate de rendu** : l'avatar skinné bypasse le GPU-driven culling (mesh forcé à `nullptr`, `Engine.cpp:5342`) ; flags de rendu stables.
- **CameraOcclusionFade / screen-door** : `pc.fade` est **codé en dur à 1.0** pour les skinnés (`SkinnedRenderer.cpp:637,644`) ; l'avatar local n'est jamais dans la liste d'occludeurs.
- **LOD / impostor / near-plane** : les avatars skinnés n'y passent pas ; pas de pull-in caméra qui coincerait le near-plane.

## Correctif

Bump **`kFrameSlots` 32 → 64** (`SkinnedRenderer.h`). Couvre 32 draws skinnés/frame à FIF=2 (marge sur les 17 actuels). Toutes les allocations (tableaux, descriptor pool, boucles) suivent déjà la constante → un seul point à changer. Coût ≈ **1 MB** host-visible GPU.

> **LIMITE** : reste un plafond fixe. Au-delà de 32 draws skinnés/frame le bug réapparaîtrait. **Fix durable** (allocation partitionnée par index de frame, ou cap de draws skinnés/frame) à faire séparément — voir chip de suivi.

Bug **pré-existant**, hors du chantier quêtes (le rendu skinné n'a pas été modifié) ; déclenché par le nombre de sangliers rendus en skinné.

## Déploiement

> **✅ CLIENT uniquement** (dimensionnement d'un buffer de rendu). Aucun opcode/wire/migration. Pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)