### PR TITLE
fix(quests/ui): marqueur PNJ + double compteur + choix dialogue quête + cadre cible mort

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10630,10 +10630,14 @@ namespace engine
 							// configurée (defaut 35 m), indépendamment du rayon d'interaction
 							// (e.radius, ~2.5 m) qui régit le badge "E".
 							const engine::math::Vec3 markerPlayerPos = m_characterController.GetPosition();
+							// Distance XZ uniquement (comme le rayon d'interaction / badge "E",
+							// cf. calcul dx²+dz² du "[E]") : la position des interactables est
+							// chargée avec y=0 (jamais collée au sol) alors que le joueur est
+							// ~100 m plus haut (plateau terrain). Inclure le Y ferait toujours
+							// dépasser markerMaxDist → le rune ne s'afficherait jamais.
 							const float mdx = e.position.x - markerPlayerPos.x;
-							const float mdy = e.position.y - markerPlayerPos.y;
 							const float mdz = e.position.z - markerPlayerPos.z;
-							const float markerDist = std::sqrt(mdx * mdx + mdy * mdy + mdz * mdz);
+							const float markerDist = std::sqrt(mdx * mdx + mdz * mdz);
 							const float markerMaxDist = static_cast<float>(
 								m_cfg.GetDouble("client.quest.giver_marker_distance_m", 35.0));
 							if (markerDist <= markerMaxDist)
@@ -11195,7 +11199,11 @@ namespace engine
 
 					// --- Cadre cible (haut-centre) : nom + barre de PV. Les PV de la
 					// cible suivent les snapshots (cf. UIModelBinding::ApplySnapshot).
-					if (uiModel.targetStats.hasTarget)
+					// On masque le cadre dès que la cible est morte (bit 1 de stateFlags) :
+					// inutile de laisser traîner « (MORT) » tant qu'aucune autre cible n'est
+					// sélectionnée — ça encombrait le HUD (retour joueur 2026-07-04).
+					if (uiModel.targetStats.hasTarget
+						&& (uiModel.targetStats.stateFlags & 1u) == 0u)
 					{
 						const float frameW = 260.0f;
 						const float frameH = 54.0f;

--- a/src/client/render/DialogueImGuiRenderer.cpp
+++ b/src/client/render/DialogueImGuiRenderer.cpp
@@ -134,29 +134,61 @@ namespace engine::render
 			const size_t choiceCount = node.choices.size();
 			for (size_t i = 0; i < choiceCount; ++i)
 			{
-				// Libellé : numéro + icône optionnelle + texte du choix.
+				const DialogueChoice& choice = node.choices[i];
+				// SP2 — distinction visuelle des choix liés à une QUÊTE : couleur de
+				// bouton dédiée (doré = accepter, vert = rendre) + tag texte, pour les
+				// séparer nettement des réponses de bavardage ordinaires.
+				const bool isAcceptChoice = (choice.action == DialogueAction::AcceptQuest);
+				const bool isTurnInChoice = (choice.action == DialogueAction::CompleteQuest);
+				const bool isQuestChoice  = isAcceptChoice || isTurnInChoice || choice.questId >= 0;
+				const char* questTag = isAcceptChoice ? "  [Nouvelle quête]"
+				                     : isTurnInChoice ? "  [Rendre la quête]"
+				                     : isQuestChoice  ? "  [Quête]" : "";
+
+				// Libellé : numéro + icône optionnelle + texte du choix + tag quête.
 				// Le suffix ##choice<i> garantit l'unicité de l'ID ImGui.
 				char label[512];
-				if (!node.choices[i].icon.empty())
+				if (!choice.icon.empty())
 				{
-					std::snprintf(label, sizeof(label), "%zu. %s %s##choice%zu",
+					std::snprintf(label, sizeof(label), "%zu. %s %s%s##choice%zu",
 					              i + 1u,
-					              node.choices[i].icon.c_str(),
-					              node.choices[i].text.c_str(),
+					              choice.icon.c_str(),
+					              choice.text.c_str(),
+					              questTag,
 					              i);
 				}
 				else
 				{
-					std::snprintf(label, sizeof(label), "%zu. %s##choice%zu",
+					std::snprintf(label, sizeof(label), "%zu. %s%s##choice%zu",
 					              i + 1u,
-					              node.choices[i].text.c_str(),
+					              choice.text.c_str(),
+					              questTag,
 					              i);
+				}
+
+				// Surbrillance dédiée aux choix de quête (avant le bouton).
+				int questColorsPushed = 0;
+				if (isAcceptChoice)
+				{
+					ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.46f, 0.35f, 0.11f, 0.92f));
+					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.64f, 0.49f, 0.17f, 1.0f));
+					questColorsPushed = 2;
+				}
+				else if (isTurnInChoice)
+				{
+					ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.16f, 0.36f, 0.18f, 0.92f));
+					ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.24f, 0.52f, 0.26f, 1.0f));
+					questColorsPushed = 2;
 				}
 
 				// Bouton pleine largeur avec word-wrap (PushTextWrapPos avant le bouton).
 				ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + wrapW);
 				const bool clicked = ImGui::Button(label, ImVec2(wrapW, 0.0f));
 				ImGui::PopTextWrapPos();
+
+				// Toujours dépiler les couleurs de quête avant tout break de boucle.
+				if (questColorsPushed > 0)
+					ImGui::PopStyleColor(questColorsPushed);
 
 				// Raccourcis clavier 1..5 (API ImGui moderne : ImGuiKey_1 + offset).
 				// Limité à i < 5 pour ne pas dépasser ImGuiKey_5.

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -137,11 +137,14 @@ namespace engine::render
 				for (size_t i = 0; i < state.selectedQuestSteps.size(); ++i)
 				{
 					const engine::client::QuestStepView& step = state.selectedQuestSteps[i];
+					// StepLabel inclut DÉJÀ le compteur (template quest_texts.fr.json
+					// « … {current}/{required} », ou fallback « current/required »).
+					// Ne pas ré-ajouter « (x/y) » ici sinon double affichage « 9/10 (9/10) ».
 					const std::string stepLabel = m_textCatalog->StepLabel(
 						state.selectedQuestId, i, step.currentCount, step.requiredCount);
 					if (step.completed)
 						ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kSuccess));
-					ImGui::BulletText("%s (%u/%u)", stepLabel.c_str(), step.currentCount, step.requiredCount);
+					ImGui::BulletText("%s", stepLabel.c_str());
 					if (step.completed)
 						ImGui::PopStyleColor();
 				}


### PR DESCRIPTION
Quatre corrections d'UX signalées en jeu (2026-07-04), **toutes client, sans wire**.

## 1. Marqueur PNJ (rune de quête) — ne s'affichait JAMAIS
La rune au-dessus du donneur (`npc:elder_marn`) n'apparaissait ni pour proposer ni pour rendre. **Cause** : la distance donneur→joueur était calculée en **3D** (`Engine.cpp:10633`), or les interactables sont chargés avec **`y=0`** (jamais collés au sol, `Engine.cpp:5238`) et le joueur est à **`y≈100`** (plateau terrain) → distance toujours ≥100 m > `client.quest.giver_marker_distance_m` (35) → rune culée en permanence. Le badge « [E] » et le Talk marchaient car ils utilisent une distance **XZ**. **Fix** : distance XZ pour le marqueur aussi. Corrige la rune dorée (`Offered`) ET bleue (`ReadyToTurnIn`), pour elder_marn et tout futur donneur (`guard_captain`…).

## 2. Double compteur « 9/10 (9/10) » dans le journal
`StepLabel` (template `quest_texts.fr.json` « … {current}/{required} ») inclut déjà le compteur, et `RenderJournal` ré-ajoutait « (x/y) ». **Fix** : le journal n'ajoute plus le compteur. Le tracker (qui utilise `BuildQuestStepLabel` sans compteur) était déjà correct.

## 3. Choix de dialogue de quête indistincts
Le choix « As-tu une tâche pour moi ? » ne se distinguait pas du bavardage. **Fix** : couleur de bouton dédiée (**doré = accepter**, **vert = rendre**) + tag texte **[Nouvelle quête]** / **[Rendre la quête]**, keyé sur `DialogueChoice.action` (AcceptQuest/CompleteQuest).

## 4. Cadre de cible « (MORT) » qui traînait
Le cadre de cible restait affiché « (MORT) » indéfiniment tant qu'aucune autre cible n'était sélectionnée. **Fix** : on masque le cadre dès que la cible est morte (bit 1 de `stateFlags`).

## Déploiement
> **✅ CLIENT uniquement.** Aucun opcode/wire/migration, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)