### PR TITLE
content(quests): respawn sangliers 90s + acceptation explicite (dialogue sans auto-accept)

### DIFF
--- a/game/data/dialogues/villageois.json
+++ b/game/data/dialogues/villageois.json
@@ -1,8 +1,8 @@
 {
-    "_comment": "Dialogue PNJ. Un fichier par PNJ/zone sous game/data/dialogues/. Reference depuis config.json via world.interactables.<i>.dialogue_id = \"villageois\". Format : start (id du noeud initial) + nodes (count + index). Chaque noeud : id, lines (count+index : text, cue optionnel), choices (1..5 : text, next OU action end/accept_quest/complete_quest, questId optionnel, questKey optionnel (SP2, id texte wire QuestAccept/TurnInRequest), icon optionnel). questId illustratif (a mapper vers un vrai quest numerique cote serveur). Textes sans accents (convention du projet).",
+    "_comment": "Dialogue PNJ. Un fichier par PNJ/zone sous game/data/dialogues/. Reference depuis config.json via world.interactables.<i>.dialogue_id = \"villageois\". Format : start (id du noeud initial) + nodes (count + index). Chaque noeud : id, lines (count+index : text, cue optionnel), choices (1..5 : text, next OU action end/accept_quest/complete_quest, questId optionnel, questKey optionnel (SP2, id texte wire QuestAccept/TurnInRequest), icon optionnel). questId illustratif (a mapper vers un vrai quest numerique cote serveur). Textes sans accents (convention du projet). NB (2026-07-04) : l'acceptation de quete ne se fait plus via une action 'accept_quest' dans le dialogue (retour joueur : trop implicite) ; le choix 'As-tu une tache ?' renvoie vers un noeud d'info, et l'acceptation explicite se fait via le bouton 'Accepter' du panneau 'Quetes du PNJ' (giver-list, ouvert au Talk).",
     "start": "intro",
     "nodes": {
-        "count": 2,
+        "count": 3,
         "0": {
             "id": "intro",
             "lines": {
@@ -13,7 +13,7 @@
             "choices": {
                 "count": 3,
                 "0": { "text": "Parle-moi du coin.", "next": "infos" },
-                "1": { "text": "As-tu une tache pour moi ?", "action": "accept_quest", "questId": 1, "questKey": "kill_10_boars" },
+                "1": { "text": "As-tu une tache pour moi ?", "next": "tache" },
                 "2": { "text": "Au revoir.", "action": "end" }
             }
         },
@@ -25,8 +25,21 @@
             },
             "choices": {
                 "count": 2,
-                "0": { "text": "Finalement, j'accepte ta tache.", "action": "accept_quest", "questId": 1 },
+                "0": { "text": "As-tu une tache pour moi ?", "next": "tache" },
                 "1": { "text": "Merci, a bientot.", "action": "end" }
+            }
+        },
+        "2": {
+            "id": "tache",
+            "lines": {
+                "count": 2,
+                "0": { "text": "Oui : les sangliers du nord ravagent nos champs. Reduis leur nombre pour proteger les recoltes." },
+                "1": { "text": "(Pour t'en charger, ouvre le panneau 'Quetes du PNJ' et choisis 'Accepter'.)", "cue": true }
+            },
+            "choices": {
+                "count": 2,
+                "0": { "text": "Revenir.", "next": "intro" },
+                "1": { "text": "Au revoir.", "action": "end" }
             }
         }
     }

--- a/game/data/zones/feyhin/spawners.json
+++ b/game/data/zones/feyhin/spawners.json
@@ -7,7 +7,7 @@
       "archetypeId": 100,
       "position": [12.0, 0.0, -28.0],
       "count": 3,
-      "respawnSec": 15,
+      "respawnSec": 90,
       "leashDistanceMeters": 24.0
     },
     {
@@ -15,7 +15,7 @@
       "archetypeId": 100,
       "position": [-10.0, 0.0, -34.0],
       "count": 3,
-      "respawnSec": 15,
+      "respawnSec": 90,
       "leashDistanceMeters": 24.0
     },
     {
@@ -23,7 +23,7 @@
       "archetypeId": 100,
       "position": [22.0, 0.0, -40.0],
       "count": 3,
-      "respawnSec": 15,
+      "respawnSec": 90,
       "leashDistanceMeters": 24.0
     },
     {
@@ -31,7 +31,7 @@
       "archetypeId": 100,
       "position": [-18.0, 0.0, -22.0],
       "count": 3,
-      "respawnSec": 15,
+      "respawnSec": 90,
       "leashDistanceMeters": 24.0
     }
   ]

--- a/src/client/dialogue/tests/DialoguePresenterTests.cpp
+++ b/src/client/dialogue/tests/DialoguePresenterTests.cpp
@@ -282,15 +282,19 @@ namespace
 
 		const DialogueTree t = engine::client::LoadDialogueTree(world, "npc.", {});
 		REQUIRE(t.startNodeId == "intro");
-		REQUIRE(t.nodes.size() == 2);
+		REQUIRE(t.nodes.size() == 3);
 		REQUIRE(t.FindNode("intro") != nullptr);
 		REQUIRE(t.FindNode("infos") != nullptr);
+		REQUIRE(t.FindNode("tache") != nullptr);
 		REQUIRE(t.FindNode("intro")->choices.size() == 3);
-		// Le 2e choix du nœud d'intro accepte une quête (questId illustratif >= 0).
-		REQUIRE(t.FindNode("intro")->choices[1].action == DialogueAction::AcceptQuest);
-		REQUIRE(t.FindNode("intro")->choices[1].questId >= 0);
-		// SP2 : le choix accept_quest porte aussi la clé texte de quête (wire QuestAcceptRequest).
-		REQUIRE(t.FindNode("intro")->choices[1].questKey == "kill_10_boars");
+		// 2026-07-04 : le 2e choix du nœud d'intro « As-tu une tache ? » ne fait plus
+		// d'accept_quest direct (retour joueur : acceptation trop implicite). Il navigue
+		// vers le nœud d'info « tache » ; l'acceptation explicite passe par le bouton
+		// « Accepter » du panneau donneur. (La couverture du parsing/callback accept_quest
+		// reste assurée par les tests synthétiques ci-dessus.)
+		REQUIRE(t.FindNode("intro")->choices[1].action == DialogueAction::Continue);
+		REQUIRE(t.FindNode("intro")->choices[1].nextNodeId == "tache");
+		REQUIRE(t.FindNode("intro")->choices[1].questKey.empty());
 	}
 
 	// SP2 — un choix sans "questKey" dans la config retombe sur une chaîne vide


### PR DESCRIPTION
Deux réglages de contenu décidés en jeu (2026-07-04). **Contenu uniquement, aucun code, aucun wire.**

## 1. Respawn des sangliers : 15 s → 90 s
`game/data/zones/feyhin/spawners.json` (les 4 spawners). À 15 s les sangliers repop quasi instantanément « sous le nez » du joueur ; 90 s garde la zone peuplée (~12 sangliers) sans cet effet.
> ⚠️ **restart shard** pour recharger le contenu de zone.

## 2. Acceptation de quête EXPLICITE (plus d'auto-accept dans le dialogue)
Retour joueur : « j'ai eu la quête sans cliquer Accepter ». C'était volontaire (le choix de dialogue portait `action: accept_quest`), mais tu préfères le bouton explicite.
`game/data/dialogues/villageois.json` :
- Le choix « As-tu une tâche ? » (nœuds intro **et** infos) ne porte plus `accept_quest` → il **navigue** vers un nouveau nœud **`tache`** qui décrit la quête et invite à ouvrir le panneau « Quêtes du PNJ » et cliquer **Accepter**.
- Les 2 actions `accept_quest` du dialogue sont retirées.
- L'acceptation se fait désormais **uniquement** via le bouton « Accepter » du panneau donneur (giver-list, alimenté par le Talk à l'ouverture du dialogue → opcode 92/93 inchangés).
> Données client (dialogues) — livrées avec le client, pas de redéploiement serveur pour ce point.

## Déploiement
> ⚠️ **restart shard** (spawners.json) + **données client** (villageois.json, avec le prochain build client). Aucun wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)