### PR TITLE
fix(quests/hud): rune agrandie + radar circulaire/repositionné + panneau donneur gaté

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9897,6 +9897,10 @@ namespace engine
 								// dialogue fermé (évite qu'un futur accept/turn-in hors dialogue
 								// réutilise par erreur la dernière cible).
 								m_currentDialogueNpcTargetId.clear();
+								// Le panneau « Quêtes du PNJ » (giver-list, rempli au Talk) ne doit
+								// vivre que le temps de la conversation : on le vide à la fermeture,
+								// sinon il resterait affiché en permanence après avoir parlé une fois.
+								m_uiModelBinding.ClearGiverList();
 							}
 						}
 					}
@@ -10673,7 +10677,7 @@ namespace engine
 										const ImU32 runeRing = turnInVariant
 											? IM_COL32(230, 245, 255, 255)
 											: IM_COL32(255, 240, 190, 255);
-										const float runeR = 11.0f;
+										const float runeR = 18.0f; // agrandie (retour joueur : trop petite a 11)
 										// Losange (4 sommets) rempli.
 										const ImVec2 diamond[4] = {
 											ImVec2(rsx, rsy - runeR),
@@ -10683,7 +10687,7 @@ namespace engine
 										};
 										fg->AddConvexPolyFilled(diamond, 4, runeFill);
 										// Anneau autour du losange pour la lisibilité + signature "rune".
-										fg->AddCircle(ImVec2(rsx, rsy), runeR + 3.0f, runeRing, 16, 2.0f);
+										fg->AddCircle(ImVec2(rsx, rsy), runeR + 4.0f, runeRing, 24, 2.5f);
 									}
 								}
 							}

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -252,21 +252,26 @@ namespace engine::render
 		// re-toucher RebuildLayout ici (hors perimetre Task 3).
 		const ImGuiIO& io = ImGui::GetIO();
 		const float margin = 16.0f;
-		// SP3 — la minimap s'ancre en haut-droite, mais le HUD météo
-		// (WeatherImGuiRenderer : boîte ~240x70 à y=margin) occupe déjà ce coin.
-		// On empile donc la minimap SOUS ce bandeau pour éviter le chevauchement.
-		const float weatherHudHeightPx = 70.0f;
+		// SP3 — la minimap s'ancre en haut-droite, MAIS ce coin est déjà occupé par
+		// le HUD météo (WeatherImGuiRenderer, ~240x70 à y=margin) ET la boussole
+		// (CompassHud, disque + arc jusqu'à ~y122). On empile donc la minimap SOUS
+		// ces deux éléments pour éviter le chevauchement de pixels (retour joueur
+		// 2026-07-04 : le radar chevauchait la boussole).
+		const float topHudClearancePx = 116.0f;
 		const float x0 = io.DisplaySize.x - sizePx - margin;
-		const float y0 = margin + weatherHudHeightPx + 8.0f;
+		const float y0 = margin + topHudClearancePx + 8.0f;
 		const float x1 = x0 + sizePx;
 		const float y1 = y0 + sizePx;
 		const ImVec2 center((x0 + x1) * 0.5f, (y0 + y1) * 0.5f);
 
 		ImDrawList* dl = ImGui::GetForegroundDrawList();
 
-		// Fond + bordure + croix centrale (repere joueur).
-		dl->AddRectFilled(ImVec2(x0, y0), ImVec2(x1, y1), IM_COL32(10, 12, 16, 170), 6.0f);
-		dl->AddRect(ImVec2(x0, y0), ImVec2(x1, y1), LnTheme::ToU32(LnTheme::kBorder), 6.0f, 0, 2.0f);
+		// Fond + bordure CIRCULAIRE + croix centrale (repere joueur). Les données
+		// sont déjà radiales (WorldToRadarUv teste dist > rayon) : seul le dessin
+		// devient circulaire (retour joueur 2026-07-04 : radar carré -> rond).
+		const float radiusPx = sizePx * 0.5f;
+		dl->AddCircleFilled(center, radiusPx, IM_COL32(10, 12, 16, 170), 48);
+		dl->AddCircle(center, radiusPx, LnTheme::ToU32(LnTheme::kBorder), 48, 2.0f);
 		dl->AddLine(ImVec2(center.x - 6.0f, center.y), ImVec2(center.x + 6.0f, center.y), LnTheme::ToU32(LnTheme::kMuted), 1.0f);
 		dl->AddLine(ImVec2(center.x, center.y - 6.0f), ImVec2(center.x, center.y + 6.0f), LnTheme::ToU32(LnTheme::kMuted), 1.0f);
 
@@ -274,6 +279,13 @@ namespace engine::render
 		for (const engine::client::MinimapPoiView& poi : state.questPois)
 		{
 			if (!poi.visible)
+				continue;
+
+			// Clip circulaire : un POI hors du disque (u,v clampés au coin carré par
+			// WorldToRadarUv quand off-radar) ne doit pas s'afficher dans les coins.
+			const float pdu = poi.u - 0.5f;
+			const float pdv = poi.v - 0.5f;
+			if (pdu * pdu + pdv * pdv > 0.25f)
 				continue;
 
 			ImU32 color = IM_COL32(180, 180, 180, 255); // repli : collect/inconnu = gris

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -539,6 +539,17 @@ namespace engine::client
 		/// Return the current immutable UI model snapshot.
 		const UIModel& GetModel() const { return m_model; }
 
+		/// SP2 — vide la liste de quêtes du PNJ (giver-list). À appeler à la
+		/// fermeture du dialogue : sans ça, `giverList` (rempli au Talk, opcode 92)
+		/// n'est jamais effacé et le panneau « Quêtes du PNJ » resterait affiché en
+		/// permanence après avoir parlé une fois. Le vider ici lie le panneau à la
+		/// conversation en cours (il n'apparaît que pendant qu'on parle au PNJ).
+		void ClearGiverList()
+		{
+			m_model.giverList.entries.clear();
+			m_model.giverList.npcTargetId.clear();
+		}
+
 		/// Combat SP2 — sélection LOCALE de cible (clic / Tab). Cherche l'entité
 		/// dans les remoteEntities du dernier snapshot, remplit targetStats
 		/// (PV/flags/position) et notifie UIModelChangeCombat. Retourne false si


### PR DESCRIPTION
Quatre corrections d'UX en jeu (2026-07-04), **toutes client, sans wire**.

## 1. Panneau « Quêtes du PNJ » affiché en permanence (sans avoir parlé)
**Cause** : `UIModel.giverList` (rempli au Talk, opcode 92) n'était **jamais vidé** — grep confirmé, aucun clear. Après avoir parlé **une fois** au PNJ, le panneau survivait à la fermeture du dialogue et au fait de s'éloigner. **Fix** : `UIModelBinding::ClearGiverList()` appelé à la fermeture du dialogue → le panneau ne vit que **pendant la conversation** avec le PNJ.

## 2. Rune de quête (marqueur PNJ) trop petite
`runeR` 11 → **18**, anneau épaissi (rayon+4, épaisseur 2.5, 24 segments).

## 3. Radar / boussole se chevauchaient (haut-droite)
La minimap s'ancrait sous le HUD météo (70 px) mais **pas** sous la boussole (disque jusqu'à ~y122). **Fix** : clearance 70 → **116 px** → radar sous la boussole.

## 4. Radar carré → circulaire
Les données étaient déjà radiales (`WorldToRadarUv` teste `dist > rayon`) ; seul le **dessin** était carré. **Fix** : cadre `AddCircleFilled`/`AddCircle` + **clip** des POI hors du disque (évite les points dans les coins).

## Non inclus (prochaine étape)
- **Points de sangliers VIVANTS sur le radar** (au lieu des points de spawn statiques) — les points statiques `mob:100` existants redeviennent visibles avec ce radar agrandi, mais le suivi des mobs vivants est un +.
- **POI `item:2001` / `zone:2`** de la 2ᵉ quête (manquants dans `quest_poi.json`).
- **Texte de quête au dialogue + texte de clôture au turn-in** (choix de présentation à décider).

## Déploiement
> **✅ CLIENT uniquement.** Aucun wire, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)