### PR TITLE
feat(quests/ui): panneau donneur enrichi (description à l'offre + texte de clôture au turn-in)

### DIFF
--- a/game/data/quests/quest_texts.fr.json
+++ b/game/data/quests/quest_texts.fr.json
@@ -2,6 +2,7 @@
   "kill_10_boars": {
     "title": "Sangliers en surnombre",
     "description": "Les sangliers ravagent les champs autour du village. Réduisez leur nombre pour protéger les récoltes.",
+    "completion": "Merci, aventurier ! Grâce à toi, nos champs seront plus sûrs cette saison. Voici ta récompense.",
     "steps": [
       "Sangliers tués : {current}/{required}"
     ]
@@ -9,6 +10,7 @@
   "hunt_collect_enter": {
     "title": "Sur les traces de l'ancien",
     "description": "L'ancien Marn a besoin d'aide : traquer une bête, récupérer un objet perdu et explorer une zone voisine.",
+    "completion": "Tu as accompli tout ce que je t'avais demandé. L'ancien Marn t'en est reconnaissant — prends ceci.",
     "steps": [
       "Bête traquée : {current}/{required}",
       "Objet récupéré : {current}/{required}",
@@ -18,6 +20,7 @@
   "report_to_guard": {
     "title": "Rapport au capitaine",
     "description": "Faites votre rapport au capitaine de la garde.",
+    "completion": "Bien reçu. Le capitaine te remercie pour ce rapport.",
     "steps": [
       "Rapport donné : {current}/{required}"
     ]

--- a/src/client/quest/QuestTextCatalog.cpp
+++ b/src/client/quest/QuestTextCatalog.cpp
@@ -445,6 +445,12 @@ namespace engine::client
 				entry.description = descriptionValue->stringValue;
 			}
 
+			if (const JsonValue* completionValue = FindObjectMember(questValue, "completion");
+				completionValue != nullptr && completionValue->type == JsonType::String)
+			{
+				entry.completion = completionValue->stringValue;
+			}
+
 			if (const JsonValue* stepsValue = FindObjectMember(questValue, "steps");
 				stepsValue != nullptr && stepsValue->type == JsonType::Array)
 			{
@@ -481,6 +487,17 @@ namespace engine::client
 		}
 
 		return it->second.description;
+	}
+
+	std::string QuestTextCatalog::Completion(std::string_view questId) const
+	{
+		const auto it = m_entries.find(std::string(questId));
+		if (it == m_entries.end())
+		{
+			return {};
+		}
+
+		return it->second.completion;
 	}
 
 	std::string QuestTextCatalog::StepLabel(std::string_view questId, size_t stepIndex, uint32_t current, uint32_t required) const

--- a/src/client/quest/QuestTextCatalog.h
+++ b/src/client/quest/QuestTextCatalog.h
@@ -17,6 +17,7 @@ namespace engine::client
 	{
 		std::string title;
 		std::string description;
+		std::string completion; ///< texte de clôture affiché au turn-in (optionnel)
 		std::vector<std::string> stepTemplates; ///< un template par étape, peut contenir {current}/{required}
 	};
 
@@ -42,6 +43,10 @@ namespace engine::client
 
 		/// Description lisible de la quête \p questId. Fallback : chaîne vide.
 		std::string Description(std::string_view questId) const;
+
+		/// Texte de clôture (turn-in) de la quête \p questId — affiché dans le
+		/// panneau donneur quand la quête est prête à rendre. Fallback : chaîne vide.
+		std::string Completion(std::string_view questId) const;
 
 		/// Libellé lisible de l'étape \p stepIndex de la quête \p questId, avec
 		/// substitution de `{current}`/`{required}` dans le template d'étape.

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -331,9 +331,45 @@ namespace engine::render
 		{
 			for (const engine::client::UIQuestGiverEntry& entry : giverList.entries)
 			{
+				const bool turnIn = (entry.role == 1);
 				const std::string title = m_textCatalog->Title(entry.questId);
+
+				// Titre coloré : doré = à proposer, vert = à rendre.
+				ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(turnIn ? LnTheme::kSuccess : LnTheme::kAccent));
 				ImGui::TextUnformatted(title.c_str());
-				ImGui::SameLine();
+				ImGui::PopStyleColor();
+
+				// Texte spécifique : description à l'offre, texte de clôture au turn-in.
+				const std::string body = turnIn
+					? m_textCatalog->Completion(entry.questId)
+					: m_textCatalog->Description(entry.questId);
+				if (!body.empty())
+				{
+					ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
+					ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + 320.0f);
+					ImGui::TextUnformatted(body.c_str());
+					ImGui::PopTextWrapPos();
+					ImGui::PopStyleColor();
+				}
+
+				// Récompense (surtout parlante au turn-in) : lue sur le modèle.
+				for (const engine::client::UIQuestEntry& q : model.quests)
+				{
+					if (q.questId != entry.questId)
+						continue;
+					if (q.rewardExperience > 0 || q.rewardGold > 0)
+					{
+						std::string reward = "Recompense :";
+						if (q.rewardExperience > 0)
+							reward += "  " + std::to_string(q.rewardExperience) + " XP";
+						if (q.rewardGold > 0)
+							reward += "  " + std::to_string(q.rewardGold) + " or";
+						ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
+						ImGui::TextUnformatted(reward.c_str());
+						ImGui::PopStyleColor();
+					}
+					break;
+				}
 
 				// role 0 = offer (pas encore acceptée) -> bouton Accepter.
 				// role 1 = turnin (étapes remplies, à rendre) -> bouton Terminer.


### PR DESCRIPTION
Retour joueur (2026-07-04) : parler au PNJ ne montrait **pas de texte spécifique** de quête, et le **turn-in n'avait pas de texte de clôture**. Choix validé : **présentation centrée sur le panneau donneur** (scalable, sans authoring de dialogue par quête — marche pour toutes les quêtes du PNJ).

## Changements (client + contenu, sans wire)

- **`QuestTextCatalog`** : nouveau champ `completion` + méthode `Completion()` (miroir de `Description`), parsé depuis `quest_texts.<locale>.json`.
- **`quest_texts.fr.json`** : texte de clôture ajouté aux 3 quêtes.
- **`RenderGiverPanel`** — par quête :
  - **titre coloré** (doré = à proposer, vert = à rendre),
  - **texte spécifique** : la **description** à l'offre, le **texte de clôture** au turn-in,
  - **ligne de récompense** (XP / or).

Le panneau « Quêtes du PNJ » devient la présentation unique des offres/turn-in. Il est déjà **gaté au dialogue** (PR #942 : `giverList` vidé à la fermeture) → il n'apparaît que pendant la conversation, montre le texte de la quête, et l'acceptation/turn-in se fait par ses boutons.

## Flux résultant (conforme)
Parler au PNJ → le panneau s'ouvre avec **titre + description** de chaque quête + **Accepter** → tuer 10 sangliers → revenir → le panneau montre **titre + texte de clôture + récompense** + **Terminer**.

## Déploiement
> **✅ CLIENT + contenu (textes).** Aucun wire, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)