### PR TITLE
fix(quests): bouton Terminer/Accepter du panneau donneur inopérant au 2e clic

### DIFF
--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -1296,6 +1296,29 @@ namespace engine::client
 		}
 		quest->rewardItems = m_questMessage.rewardItems;
 
+		// Resynchronise le panneau donneur (giverList = instantané du dernier Talk)
+		// avec le nouveau statut : une entrée « Accepter » (role 0) n'est valide que
+		// si la quête est Offered, une entrée « Terminer » (role 1) que si elle est
+		// ReadyToTurnIn. Sans ça, après un accept/turn-in réussi, le bouton restait
+		// affiché et un 2e clic était rejeté par le serveur -> illusion d'un bouton
+		// « qui ne marche pas » (retour joueur 2026-07-04 : Terminer inopérant).
+		{
+			constexpr uint8_t kStatusOffered = 1;        // QuestStatus::Offered
+			constexpr uint8_t kStatusReadyToTurnIn = 3;  // QuestStatus::ReadyToTurnIn
+			std::vector<UIQuestGiverEntry>& entries = m_model.giverList.entries;
+			for (size_t i = 0; i < entries.size();)
+			{
+				const UIQuestGiverEntry& e = entries[i];
+				const bool stale = (e.questId == quest->questId)
+					&& ((e.role == 0 && quest->status != kStatusOffered)
+						|| (e.role == 1 && quest->status != kStatusReadyToTurnIn));
+				if (stale)
+					entries.erase(entries.begin() + static_cast<std::ptrdiff_t>(i));
+				else
+					++i;
+			}
+		}
+
 		NotifyObservers(UIModelChangeQuests);
 		LOG_INFO(Net, "[UIModelBinding] QuestDelta applied (quest_id={}, status={}, steps={})",
 			quest->questId,


### PR DESCRIPTION
## Symptôme
Retour joueur : « le bouton **Terminer** ne fonctionne pas » — alors que le personnage **recevait bien l'XP**.

## Cause (confirmée)
Le turn-in **fonctionnait** (récompense versée côté serveur → l'XP reçue), mais le panneau donneur (`UIModel.giverList`, un **instantané** du dernier Talk) n'était **jamais resynchronisé** après. Donc :
1. clic **Terminer** → serveur rend la quête + verse la récompense,
2. mais l'entrée « Terminer » **reste affichée** (panneau périmé),
3. 2ᵉ clic → serveur rejette (quête déjà `Completed`) → rien ne se passe → **illusion d'un bouton mort**.

Même souci pour **Accepter** après acceptation.

## Fix
`ApplyQuestDelta` retire du `giverList` l'entrée devenue périmée quand le statut change : « Accepter » (role 0) n'est valide que si `Offered`, « Terminer » (role 1) que si `ReadyToTurnIn`. Le bouton disparaît donc dès l'action réussie, en cohérence avec le journal.

## Déploiement
> **✅ CLIENT uniquement.** Aucun wire, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)