### PR TITLE
feat(hud): tracker sous le radar + bascule HUD (touche U) + bourse d'or

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7770,6 +7770,27 @@ namespace engine
 			}
 		}
 
+		// Bascule HUD carte — Touche U remappable post-auth masque/affiche le
+		// « cluster carte » : boussole + radar minimap + tracker de quêtes (retour
+		// joueur : « pouvoir boucher la boussole, le radar et le suivi de quête »).
+		// Le journal et le panneau donneur ne sont PAS concernés (interactifs).
+		// Mêmes guards que les autres toggles (chat focus + pause + editor + auth).
+		{
+			const bool chatBlocks = m_chatUi.IsInitialized() && m_chatUi.IsChatFocusActive();
+			const bool inGameNoMenu = !m_inGamePauseMenuVisible
+				&& !m_inGameOptionsPanelVisible
+				&& !m_editorEnabled
+				&& m_authUi.IsInitialized()
+				&& m_authUi.IsFlowComplete();
+			const engine::platform::Key hudKey =
+				KeyFromName(m_cfg.GetString("controls.keybind.hud_toggle", "U"), engine::platform::Key::U);
+			if (inGameNoMenu && !chatBlocks && m_input.WasPressed(hudKey))
+			{
+				m_hudMapClusterHidden = !m_hudMapClusterHidden;
+				LOG_INFO(Core, "[Engine] HUD map cluster toggle (hidden={})", m_hudMapClusterHidden);
+			}
+		}
+
 		// CMANGOS.21 (Phase 5.21 step 3+4) — Touche A post-auth toggle le
 		// panneau Arena (equivalent a la slash command /arena). Memes guards
 		// que la touche B (chat focus + pause + editor + auth flow).
@@ -10542,7 +10563,9 @@ namespace engine
 #if defined(_WIN32)
 			// Boussole HUD : visible en jeu. Forward caméra = row 2 du view matrix.
 			// L'aiguille rouge pointe le Nord et tourne quand le joueur pivote.
-			if (m_authUi.IsInWorldShard())
+			// Masquée avec le radar/tracker par la bascule HUD (m_hudMapClusterHidden,
+			// touche controls.keybind.hud_toggle).
+			if (m_authUi.IsInWorldShard() && !m_hudMapClusterHidden)
 			{
 				const uint32_t rIdxHud = m_renderReadIndex.load(std::memory_order_acquire);
 				const engine::RenderState& rsHud = m_renderStates[rIdxHud];
@@ -10561,7 +10584,7 @@ namespace engine
 			// (BindQuestUi est appelé au boot, cf. plus haut) ou si giverList/
 			// journalEntries sont vides (rien à afficher).
 			if (m_questImGui)
-				m_questImGui->Render(dw, dh, m_authUi.IsInWorldShard());
+				m_questImGui->Render(dw, dh, m_authUi.IsInWorldShard(), !m_hudMapClusterHidden);
 			// Marqueurs ImGui des interactibles : label flottant projete (visibilite v1
 			// sans mesh). Surligne + " [E]" si a portee. Cf. m_interactables (#39/#40).
 			{
@@ -12160,6 +12183,34 @@ namespace engine
 									ImVec2(gaugeX + gaugeW * resFrac, resY + 8.0f), IM_COL32(70, 130, 220, 235), 3.0f);
 							}
 						}
+					}
+
+					// --- Bourse : pièces d'or du joueur, coin bas-droit. Alimentée par
+					// WalletUpdate (UIModel.wallet.gold), rafraîchie à chaque récompense de
+					// quête ou vente (le serveur pousse SendWalletUpdate). Retour joueur :
+					// « il reçoit de l'or mais aucune bourse pour le suivre ». Non concernée
+					// par la bascule HUD carte (garde la bourse visible en permanence).
+					{
+						const std::string goldText = "Or : " + std::to_string(uiModel.wallet.gold);
+						const ImVec2 goldTs = ImGui::CalcTextSize(goldText.c_str());
+						const float padX = 10.0f;
+						const float padY = 6.0f;
+						const float coinR = 5.0f;
+						const float gap = 7.0f;
+						const float pillW = padX * 2.0f + coinR * 2.0f + gap + goldTs.x;
+						const float pillH = padY * 2.0f + std::max(goldTs.y, coinR * 2.0f);
+						const float bourseMargin = 16.0f;
+						const float px1 = dw - bourseMargin;
+						const float py1 = dh - bourseMargin;
+						const float px0 = px1 - pillW;
+						const float py0 = py1 - pillH;
+						fg->AddRectFilled(ImVec2(px0, py0), ImVec2(px1, py1), IM_COL32(18, 20, 26, 210), 6.0f);
+						fg->AddRect(ImVec2(px0, py0), ImVec2(px1, py1), IM_COL32(120, 100, 40, 220), 6.0f, 0, 1.5f);
+						const ImVec2 coinC(px0 + padX + coinR, (py0 + py1) * 0.5f);
+						fg->AddCircleFilled(coinC, coinR, IM_COL32(240, 200, 70, 255));
+						fg->AddCircle(coinC, coinR, IM_COL32(180, 140, 30, 255), 12, 1.0f);
+						fg->AddText(ImVec2(coinC.x + coinR + gap, (py0 + py1) * 0.5f - goldTs.y * 0.5f),
+							IM_COL32(245, 230, 190, 255), goldText.c_str());
 					}
 
 					// --- Ecran de mort : overlay sombre + bouton Reapparaitre →

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -1372,6 +1372,11 @@ namespace engine
 		/// SP-D — Visibilité du panneau arbre de compétences (toggle touche Y remappable
 		/// via controls.keybind.skilltree, ou /arbre / /competences). Faux par défaut.
 		bool                                  m_classSkillTreeVisible = false;
+		/// Bascule HUD carte : quand vrai, boussole + radar minimap + tracker de
+		/// quêtes sont masqués (touche controls.keybind.hud_toggle, défaut U).
+		/// Retour joueur : pouvoir « boucher » ces overlays. Journal + panneau
+		/// donneur non concernés (interactifs). Faux par défaut (HUD visible).
+		bool                                  m_hudMapClusterHidden = false;
 		/// SP-D — Renderer ImGui du panneau arbre de compétences.
 		/// Forward-déclaré dans Engine.h (ClassSkillTreeImGuiRenderer).
 		std::unique_ptr<engine::render::ClassSkillTreeImGuiRenderer> m_classSkillTreeImGui;

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -46,7 +46,7 @@ namespace engine::render
 		m_cfg = cfg;
 	}
 
-	void QuestImGuiRenderer::Render(float viewportW, float viewportH, bool inWorldShard)
+	void QuestImGuiRenderer::Render(float viewportW, float viewportH, bool inWorldShard, bool showMapCluster)
 	{
 		(void)viewportW;
 		(void)viewportH;
@@ -59,8 +59,14 @@ namespace engine::render
 			return;
 
 		RenderJournal();
-		RenderTracker();
-		RenderMinimap();
+		// Le tracker et le radar forment le « cluster carte » masquable par le
+		// joueur (avec la boussole, gérée côté Engine). Le journal et le panneau
+		// donneur restent toujours visibles (interactifs).
+		if (showMapCluster)
+		{
+			RenderTracker();
+			RenderMinimap();
+		}
 		RenderGiverPanel();
 	}
 
@@ -194,9 +200,27 @@ namespace engine::render
 		if (!state.layoutValid || state.trackerSteps.empty())
 			return;
 
-		const engine::client::QuestUiRect& bounds = state.trackerBounds;
-		ImGui::SetNextWindowPos(ImVec2(bounds.x, bounds.y), ImGuiCond_FirstUseEver);
-		ImGui::SetNextWindowSize(ImVec2(bounds.width, bounds.height), ImGuiCond_FirstUseEver);
+		// Position : empilé SOUS le radar minimap, coin haut-droit, aligné à droite.
+		// Corrige le chevauchement historique (tracker et radar étaient tous deux
+		// ancrés en haut-droit à y≈marge). On reprend l'ancrage exact de
+		// RenderMinimap (marge 16 + bandeau météo ~78 px + taille radar config)
+		// pour empiler proprement la colonne météo -> radar -> tracker. Si le radar
+		// est désactivé, le tracker remonte juste sous le bandeau météo.
+		// Cond_Always : le HUD doit suivre résolution/config sans se figer sur une
+		// position imgui.ini périmée (fenêtre NoMove + NoSavedSettings de toute façon).
+		const ImGuiIO& io = ImGui::GetIO();
+		const float trackerMargin = 16.0f;
+		const float weatherHudHeightPx = 70.0f;
+		const bool minimapEnabled = m_cfg->GetBool("client.quest.minimap.enabled", true);
+		const float radarSizePx = static_cast<float>(m_cfg->GetInt("client.quest.minimap.size_px", 200));
+		const float radarBottom = (minimapEnabled && radarSizePx > 0.0f)
+			? (trackerMargin + weatherHudHeightPx + 8.0f + radarSizePx)
+			: (trackerMargin + weatherHudHeightPx);
+		const float trackerW = state.trackerBounds.width;
+		const float trackerH = state.trackerBounds.height;
+		ImGui::SetNextWindowPos(
+			ImVec2(io.DisplaySize.x - trackerMargin - trackerW, radarBottom + 12.0f), ImGuiCond_Always);
+		ImGui::SetNextWindowSize(ImVec2(trackerW, trackerH), ImGuiCond_Always);
 		ImGui::SetNextWindowBgAlpha(0.78f);
 
 		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.78f)));
@@ -204,6 +228,7 @@ namespace engine::render
 
 		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration
 			| ImGuiWindowFlags_NoMove
+			| ImGuiWindowFlags_NoSavedSettings
 			| ImGuiWindowFlags_NoFocusOnAppearing
 			| ImGuiWindowFlags_NoBringToFrontOnFocus
 			| ImGuiWindowFlags_NoNav
@@ -422,7 +447,7 @@ namespace engine::render
 		const engine::client::QuestTextCatalog*,
 		const engine::client::UIModelBinding*,
 		const engine::core::Config*) {}
-	void QuestImGuiRenderer::Render(float, float, bool) {}
+	void QuestImGuiRenderer::Render(float, float, bool, bool) {}
 }
 
 #endif

--- a/src/client/render/QuestImGuiRenderer.h
+++ b/src/client/render/QuestImGuiRenderer.h
@@ -55,7 +55,11 @@ namespace engine::render
 		///
 		/// \p inWorldShard : si false (post-auth mais pas encore in-world), les
 		/// panneaux ne sont pas dessinés (pas de quêtes hors monde).
-		void Render(float viewportW, float viewportH, bool inWorldShard = true);
+		/// \p showMapCluster : si false, le tracker HUD et le radar minimap sont
+		/// masqués (bascule joueur « boussole/radar/suivi », cf. Engine touche
+		/// controls.keybind.hud_toggle). Le journal et le panneau donneur restent
+		/// toujours affichés (interactifs, pas concernés par la bascule HUD).
+		void Render(float viewportW, float viewportH, bool inWorldShard = true, bool showMapCluster = true);
 
 	private:
 		/// Dessine le panneau journal (liste Active/ReadyToTurnIn + détail).


### PR DESCRIPTION
Trois retours joueur sur le HUD in-game (2026-07-04).

## 1. Chevauchement tracker ↔ radar
Le **tracker « Suivi de quêtes »** et le **radar minimap** étaient tous deux ancrés en haut-droite → superposition. `RenderTracker` empile désormais le tracker **sous le radar** (même ancrage que `RenderMinimap` : marge 16 + bandeau météo 78 + taille radar config), aligné à droite, `Cond_Always`. Radar désactivé → le tracker remonte sous la météo.

## 2. Masquer boussole / radar / tracker
Nouvelle **bascule HUD** — touche **U** (remappable `controls.keybind.hud_toggle`) — qui masque **boussole + radar + tracker** d'un coup (`m_hudMapClusterHidden`). Le **journal** et le **panneau donneur** restent visibles (interactifs). `QuestImGuiRenderer::Render` reçoit un `showMapCluster` qui gate `RenderTracker`/`RenderMinimap` ; la boussole est gatée côté Engine.

## 3. Bourse (or)
Pastille **bourse** en bas-droite (pièce dorée + « Or : N »), alimentée par `UIModel.wallet.gold` — déjà répliquée par `WalletUpdate` (`GrantQuestReward` → `SendWalletUpdate` à chaque récompense). Non masquée par la bascule HUD.

## À tester en jeu
- Tracker n'empiète plus sur le radar.
- Touche **U** masque/affiche boussole+radar+tracker (journal/donneur inchangés).
- La bourse reflète l'or après un turn-in de quête.

## Déploiement
> **✅ CLIENT uniquement.** Aucun wire, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)