### PR TITLE
feat(quests): acceptation/rendu de quête DANS la conversation PNJ (retire le panneau)

### DIFF
--- a/game/data/dialogues/villageois.json
+++ b/game/data/dialogues/villageois.json
@@ -1,5 +1,5 @@
 {
-    "_comment": "Dialogue PNJ. Un fichier par PNJ/zone sous game/data/dialogues/. Reference depuis config.json via world.interactables.<i>.dialogue_id = \"villageois\". Format : start (id du noeud initial) + nodes (count + index). Chaque noeud : id, lines (count+index : text, cue optionnel), choices (1..5 : text, next OU action end/accept_quest/complete_quest, questId optionnel, questKey optionnel (SP2, id texte wire QuestAccept/TurnInRequest), icon optionnel). questId illustratif (a mapper vers un vrai quest numerique cote serveur). Textes sans accents (convention du projet). NB (2026-07-04) : l'acceptation de quete ne se fait plus via une action 'accept_quest' dans le dialogue (retour joueur : trop implicite) ; le choix 'As-tu une tache ?' renvoie vers un noeud d'info, et l'acceptation explicite se fait via le bouton 'Accepter' du panneau 'Quetes du PNJ' (giver-list, ouvert au Talk).",
+    "_comment": "Dialogue PNJ. Un fichier par PNJ/zone sous game/data/dialogues/. Reference depuis config.json via world.interactables.<i>.dialogue_id = \"villageois\". Format : start (id du noeud initial) + nodes (count + index). Chaque noeud : id, lines (count+index : text, cue optionnel), choices (1..5 : text, next OU action end/accept_quest/complete_quest, questId optionnel, questKey optionnel (SP2, id texte wire QuestAccept/TurnInRequest), icon optionnel). questId illustratif (a mapper vers un vrai quest numerique cote serveur). Textes sans accents (convention du projet). NB (2026-07-07, PR-B) : l'acceptation de quete se fait DANS la conversation via un bouton 'Accepter'/'Rendre' injecte au bas de la fenetre de dialogue par DialogueImGuiRenderer, pilote par UIModel.giverList (status-aware, cote serveur). Ces boutons ne sont PAS dans ce JSON (injectes a l'execution) ; le choix 'As-tu une tache ?' renvoie toujours vers un noeud d'info. L'ancien panneau 'Quetes du PNJ' separe ne sert plus que de fallback hors dialogue.",
     "start": "intro",
     "nodes": {
         "count": 3,
@@ -34,7 +34,7 @@
             "lines": {
                 "count": 2,
                 "0": { "text": "Oui : les sangliers du nord ravagent nos champs. Reduis leur nombre pour proteger les recoltes." },
-                "1": { "text": "(Pour t'en charger, ouvre le panneau 'Quetes du PNJ' et choisis 'Accepter'.)", "cue": true }
+                "1": { "text": "(Pour t'en charger, choisis 'Accepter' ci-dessous, sans quitter la conversation.)", "cue": true }
             },
             "choices": {
                 "count": 2,

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8191,6 +8191,11 @@ namespace engine
 				// Partage le contexte ImGui avec auth/chat ; rendu Windows uniquement
 				// (le .cpp est gardé par #if _WIN32). Constructeur par défaut.
 				m_dialogueImGui = std::make_unique<engine::render::DialogueImGuiRenderer>();
+				// PR-B — Acceptation/rendu de quête DANS la conversation : le renderer
+				// de dialogue injecte les boutons Accepter/Rendre depuis UIModel.giverList
+				// (titres via le catalogue). Le callback d'action est câblé plus bas
+				// (même bloc GameplayNet que le panneau donneur, m_gameplayUdp requis).
+				m_dialogueImGui->BindQuestGiver(&m_uiModelBinding, &m_questTextCatalog);
 				// SP2 Task 5 — Renderer ImGui journal/tracker/panneau donneur.
 				// Partage le contexte ImGui avec auth/chat/dialogue. Le callback
 				// d'action panneau donneur est cable plus bas (apres m_gameplayUdp
@@ -10583,8 +10588,14 @@ namespace engine
 			// SP2 Task 5 — Journal + tracker + panneau donneur. No-op si non bindé
 			// (BindQuestUi est appelé au boot, cf. plus haut) ou si giverList/
 			// journalEntries sont vides (rien à afficher).
+			// PR-B — quand un dialogue PNJ est actif, on supprime le panneau donneur
+			// séparé : l'acceptation/rendu se fait DANS la conversation (boutons injectés
+			// par DialogueImGuiRenderer). Le panneau reste le fallback hors dialogue.
 			if (m_questImGui)
+			{
+				m_questImGui->SetGiverPanelSuppressed(m_dialogue.IsActive());
 				m_questImGui->Render(dw, dh, m_authUi.IsInWorldShard(), !m_hudMapClusterHidden);
+			}
 			// Marqueurs ImGui des interactibles : label flottant projete (visibilite v1
 			// sans mesh). Surligne + " [E]" si a portee. Cf. m_interactables (#39/#40).
 			{
@@ -15193,18 +15204,25 @@ namespace engine
 		// QuestGiverList (donc npcTargetId est forcément à jour dans ce contexte).
 		if (m_questImGui)
 		{
-			m_questImGui->SetGiverActionCallback(
-				[this](const std::string& questId, uint8_t role)
-				{
-					if (!m_gameplayNetInitialized)
-						return;
-					const uint32_t gameplayClientId = m_gameplayUdp.ServerClientId();
-					const std::string& npcTargetId = m_uiModelBinding.GetModel().giverList.npcTargetId;
-					if (role == 0)
-						(void)m_gameplayUdp.SendQuestAcceptRequest(gameplayClientId, questId, npcTargetId);
-					else
-						(void)m_gameplayUdp.SendQuestTurnInRequest(gameplayClientId, questId, npcTargetId);
-				});
+			// Callback partagé Accepter/Rendre (panneau donneur ET boutons injectés
+			// dans le dialogue, PR-B) : même logique, npcTargetId = celui du dernier
+			// QuestGiverList (à jour dans ce contexte).
+			auto giverActionCb = [this](const std::string& questId, uint8_t role)
+			{
+				if (!m_gameplayNetInitialized)
+					return;
+				const uint32_t gameplayClientId = m_gameplayUdp.ServerClientId();
+				const std::string& npcTargetId = m_uiModelBinding.GetModel().giverList.npcTargetId;
+				if (role == 0)
+					(void)m_gameplayUdp.SendQuestAcceptRequest(gameplayClientId, questId, npcTargetId);
+				else
+					(void)m_gameplayUdp.SendQuestTurnInRequest(gameplayClientId, questId, npcTargetId);
+			};
+			m_questImGui->SetGiverActionCallback(giverActionCb);
+			// PR-B — même callback pour les boutons Accepter/Rendre injectés dans la
+			// fenêtre de dialogue (acceptation « dans la conversation »).
+			if (m_dialogueImGui)
+				m_dialogueImGui->SetGiverActionCallback(giverActionCb);
 		}
 	}
 

--- a/src/client/render/DialogueImGuiRenderer.cpp
+++ b/src/client/render/DialogueImGuiRenderer.cpp
@@ -1,8 +1,11 @@
 #include "src/client/render/DialogueImGuiRenderer.h"
 
 #include "src/client/dialogue/DialoguePresenter.h"
+#include "src/client/quest/QuestTextCatalog.h"
+#include "src/client/ui_common/UIModel.h"
 
 #include <cstdio>
+#include <string>
 
 #if defined(_WIN32)
 #	include "imgui.h"
@@ -205,6 +208,61 @@ namespace engine::render
 					// On sort de la boucle immédiatement : l'état du node a changé.
 					presenter.SelectChoice(i);
 					break;
+				}
+			}
+
+			// PR-B — Acceptation/rendu de quête DANS la conversation. On injecte
+			// sous les réponses scriptées un bouton par entrée du panneau donneur
+			// (UIModel.giverList, instantané status-aware du dernier Talk : le serveur
+			// n'y met role 0 « Accepter » que si la quête est proposée, role 1
+			// « Rendre » que si les étapes sont remplies). Remplace l'ancien panneau
+			// donneur séparé (QuestImGuiRenderer, désormais masqué tant qu'un dialogue
+			// est actif). Le clic déclenche le callback quête d'Engine
+			// (SendQuestAccept/TurnInRequest) ; l'entrée disparaît au frame suivant
+			// (ApplyQuestDelta purge le giverList au changement de statut). No-op si
+			// non bindé (BindQuestGiver) ou si le giverList est vide.
+			if (m_uiModelBinding != nullptr && m_textCatalog != nullptr && m_giverAction)
+			{
+				const engine::client::UIQuestGiverList& giverList =
+					m_uiModelBinding->GetModel().giverList;
+				if (!giverList.entries.empty())
+				{
+					ImGui::Spacing();
+					ImGui::Separator();
+					for (const engine::client::UIQuestGiverEntry& entry : giverList.entries)
+					{
+						const bool isTurnIn = (entry.role == 1u);
+						const std::string title = m_textCatalog->Title(entry.questId);
+						char qlabel[512];
+						std::snprintf(qlabel, sizeof(qlabel), "%s : %s##giver_%s_%u",
+						              isTurnIn ? "Rendre" : "Accepter",
+						              title.c_str(),
+						              entry.questId.c_str(),
+						              static_cast<unsigned>(entry.role));
+
+						// Même code couleur que les choix scriptés de quête : doré =
+						// accepter, vert = rendre.
+						if (isTurnIn)
+						{
+							ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.16f, 0.36f, 0.18f, 0.92f));
+							ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.24f, 0.52f, 0.26f, 1.0f));
+						}
+						else
+						{
+							ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.46f, 0.35f, 0.11f, 0.92f));
+							ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.64f, 0.49f, 0.17f, 1.0f));
+						}
+						ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + wrapW);
+						const bool qClicked = ImGui::Button(qlabel, ImVec2(wrapW, 0.0f));
+						ImGui::PopTextWrapPos();
+						ImGui::PopStyleColor(2);
+
+						if (qClicked)
+						{
+							m_giverAction(entry.questId, entry.role);
+							break; // le giverList peut être purgé ce frame -> on sort.
+						}
+					}
 				}
 			}
 

--- a/src/client/render/DialogueImGuiRenderer.h
+++ b/src/client/render/DialogueImGuiRenderer.h
@@ -1,8 +1,15 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
+#include <string>
 
-namespace engine::client { class DialoguePresenter; }
+namespace engine::client
+{
+	class DialoguePresenter;
+	class UIModelBinding;
+	class QuestTextCatalog;
+}
 
 namespace engine::render
 {
@@ -16,6 +23,28 @@ namespace engine::render
 	class DialogueImGuiRenderer final
 	{
 	public:
+		/// PR-B — Callback émis quand le joueur clique un bouton Accepter/Rendre
+		/// injecté DANS la conversation (depuis UIModel.giverList). Même contrat
+		/// que \ref QuestImGuiRenderer::GiverActionCallback : \p questId = id texte
+		/// (clé catalogue), \p role = 0 (accepter) / 1 (rendre). Câblé par Engine
+		/// vers SendQuestAcceptRequest / SendQuestTurnInRequest.
+		using GiverActionCallback = std::function<void(const std::string& questId, uint8_t role)>;
+
+		/// PR-B — Bind les sources de l'acceptation/rendu de quête intégrés au
+		/// dialogue (non possédés) : \p uiModelBinding fournit UIModel.giverList
+		/// (instantané status-aware du dernier Talk), \p textCatalog résout les
+		/// titres. Si non bindé, aucun bouton de quête n'est injecté (comportement
+		/// legacy : dialogue de bavardage seul).
+		void BindQuestGiver(const engine::client::UIModelBinding* uiModelBinding,
+			const engine::client::QuestTextCatalog* textCatalog)
+		{
+			m_uiModelBinding = uiModelBinding;
+			m_textCatalog = textCatalog;
+		}
+
+		/// PR-B — Câble le callback Accepter/Rendre (cf. \ref GiverActionCallback).
+		void SetGiverActionCallback(GiverActionCallback callback) { m_giverAction = std::move(callback); }
+
 		/// Dessine la fenêtre de dialogue si le presenter est actif.
 		/// \param presenter source de vérité (lecture) + cible des actions joueur
 		///        (SelectChoice, Close). Doit rester valide pour toute la durée de l'appel.
@@ -27,6 +56,11 @@ namespace engine::render
 		/// Button, TextUnformatted, SetScrollY…). No-op si le presenter n'est pas actif.
 		void Render(engine::client::DialoguePresenter& presenter,
 		            float viewportWidth, float viewportHeight);
+
+	private:
+		const engine::client::UIModelBinding*   m_uiModelBinding = nullptr;
+		const engine::client::QuestTextCatalog* m_textCatalog = nullptr;
+		GiverActionCallback                     m_giverAction;
 	};
 
 } // namespace engine::render

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -355,6 +355,12 @@ namespace engine::render
 
 	void QuestImGuiRenderer::RenderGiverPanel()
 	{
+		// PR-B — Masqué tant qu'un dialogue PNJ est actif : dans ce cas
+		// l'acceptation/rendu se fait DANS la conversation (DialogueImGuiRenderer).
+		// Ce panneau ne subsiste que comme fallback (donneur sans arbre de dialogue).
+		if (m_giverPanelSuppressed)
+			return;
+
 		const engine::client::UIModel& model = m_uiModelBinding->GetModel();
 		const engine::client::UIQuestGiverList& giverList = model.giverList;
 		if (giverList.entries.empty())

--- a/src/client/render/QuestImGuiRenderer.h
+++ b/src/client/render/QuestImGuiRenderer.h
@@ -49,6 +49,12 @@ namespace engine::render
 		/// Câble le callback d'action du panneau donneur (Accepter/Terminer).
 		void SetGiverActionCallback(GiverActionCallback callback) { m_giverAction = std::move(callback); }
 
+		/// PR-B — Supprime le panneau donneur séparé quand un dialogue PNJ est actif :
+		/// dans ce cas l'acceptation/rendu se fait DANS la conversation
+		/// (DialogueImGuiRenderer injecte les boutons). Le panneau reste le fallback
+		/// pour un donneur sans arbre de dialogue. Positionné par Engine chaque frame.
+		void SetGiverPanelSuppressed(bool suppressed) { m_giverPanelSuppressed = suppressed; }
+
 		/// Émet les commandes ImGui pour la frame courante. Suppose que
 		/// \c m_worldEditorImGui->NewFrame a déjà été appelé.
 		/// No-op si le presenter n'est pas bindé.
@@ -84,5 +90,6 @@ namespace engine::render
 		const engine::client::UIModelBinding*    m_uiModelBinding = nullptr;
 		const engine::core::Config*              m_cfg = nullptr;
 		GiverActionCallback m_giverAction;
+		bool m_giverPanelSuppressed = false;
 	};
 }


### PR DESCRIPTION
> ⚠️ **Stackée sur #946** (base = `claude/hud-overlap-toggle-wallet`). Merger **#946 d'abord**, puis celle-ci (sa base repassera sur `main` automatiquement).

## Retour joueur
« L'acceptation des quêtes n'est **toujours pas dans la conversation** avec le PNJ » — l'accept/turn-in passait par un **panneau donneur séparé** (coin d'écran), déconnecté de la fenêtre de dialogue centrale.

## Fix
`DialogueImGuiRenderer` injecte, **sous les réponses scriptées**, un bouton **« Accepter : ‹titre› »** / **« Rendre : ‹titre› »** par entrée de `UIModel.giverList`.

Le `giverList` est déjà **status-aware** côté serveur (role 0 seulement si la quête est proposée, role 1 seulement si les étapes sont remplies) → les boutons apparaissent/disparaissent au bon moment, **sans logique cliente**. Le clic réutilise le **même callback** que le panneau (`SendQuestAccept/TurnInRequest`, `npcTargetId` du dernier Talk). `ApplyQuestDelta` (PR turn-in #945) purge l'entrée après l'action → le bouton disparaît au frame suivant.

Le **panneau séparé** (`RenderGiverPanel`) est **supprimé tant qu'un dialogue est actif** (`SetGiverPanelSuppressed`, piloté chaque frame par `m_dialogue.IsActive()`) ; il subsiste comme **fallback** pour un donneur sans arbre de dialogue.

`villageois.json` : le cue renvoyait vers le panneau → corrigé. Structure inchangée (test `Test_LoadDialogueFromDedicatedFile` OK).

## Pourquoi render-time (pas d'édition JSON par quête)
Status-correct, DRY, zéro authoring par PNJ. **Réconcilie les deux demandes** : accept **explicite** (un bouton à cliquer, pas d'auto-accept) **ET** dans la conversation.

## À tester en jeu
- Parler au PNJ : le bouton **« Accepter : Réduire la horde… »** apparaît **dans la fenêtre de dialogue** (plus de panneau au coin).
- Après acceptation, le bouton disparaît ; une fois les sangliers tués, **« Rendre : … »** apparaît dans le dialogue.

## Déploiement
> **✅ CLIENT uniquement.** Aucun wire, pas de redéploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)