### PR TITLE
feat(xp): barre de progression d'XP (serveur pousse niveau/XP + barre client)

### DIFF
--- a/game/data/dialogues/villageois.json
+++ b/game/data/dialogues/villageois.json
@@ -1,5 +1,5 @@
 {
-    "_comment": "Dialogue PNJ. Un fichier par PNJ/zone sous game/data/dialogues/. Reference depuis config.json via world.interactables.<i>.dialogue_id = \"villageois\". Format : start (id du noeud initial) + nodes (count + index). Chaque noeud : id, lines (count+index : text, cue optionnel), choices (1..5 : text, next OU action end/accept_quest/complete_quest, questId optionnel, questKey optionnel (SP2, id texte wire QuestAccept/TurnInRequest), icon optionnel). questId illustratif (a mapper vers un vrai quest numerique cote serveur). Textes sans accents (convention du projet). NB (2026-07-04) : l'acceptation de quete ne se fait plus via une action 'accept_quest' dans le dialogue (retour joueur : trop implicite) ; le choix 'As-tu une tache ?' renvoie vers un noeud d'info, et l'acceptation explicite se fait via le bouton 'Accepter' du panneau 'Quetes du PNJ' (giver-list, ouvert au Talk).",
+    "_comment": "Dialogue PNJ. Un fichier par PNJ/zone sous game/data/dialogues/. Reference depuis config.json via world.interactables.<i>.dialogue_id = \"villageois\". Format : start (id du noeud initial) + nodes (count + index). Chaque noeud : id, lines (count+index : text, cue optionnel), choices (1..5 : text, next OU action end/accept_quest/complete_quest, questId optionnel, questKey optionnel (SP2, id texte wire QuestAccept/TurnInRequest), icon optionnel). questId illustratif (a mapper vers un vrai quest numerique cote serveur). Textes sans accents (convention du projet). NB (2026-07-07, PR-B) : l'acceptation de quete se fait DANS la conversation via un bouton 'Accepter'/'Rendre' injecte au bas de la fenetre de dialogue par DialogueImGuiRenderer, pilote par UIModel.giverList (status-aware, cote serveur). Ces boutons ne sont PAS dans ce JSON (injectes a l'execution) ; le choix 'As-tu une tache ?' renvoie toujours vers un noeud d'info. L'ancien panneau 'Quetes du PNJ' separe ne sert plus que de fallback hors dialogue.",
     "start": "intro",
     "nodes": {
         "count": 3,
@@ -34,7 +34,7 @@
             "lines": {
                 "count": 2,
                 "0": { "text": "Oui : les sangliers du nord ravagent nos champs. Reduis leur nombre pour proteger les recoltes." },
-                "1": { "text": "(Pour t'en charger, ouvre le panneau 'Quetes du PNJ' et choisis 'Accepter'.)", "cue": true }
+                "1": { "text": "(Pour t'en charger, choisis 'Accepter' ci-dessous, sans quitter la conversation.)", "cue": true }
             },
             "choices": {
                 "count": 2,

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -12193,6 +12193,40 @@ namespace engine
 								fg->AddRectFilled(ImVec2(gaugeX, resY),
 									ImVec2(gaugeX + gaugeW * resFrac, resY + 8.0f), IM_COL32(70, 130, 220, 235), 3.0f);
 							}
+							// --- Barre d'XP (PR-C) : fine barre dorée sous la vie/ressource,
+							// alimentée par PlayerXpUpdate (serveur, enter-world + chaque gain).
+							// Niveau à gauche, progression xp/prochain niveau centrée dessous.
+							// hasXp faux tant qu'aucun PlayerXpUpdate reçu -> pas de barre.
+							if (uiModel.playerStats.hasXp)
+							{
+								const bool atCap = (uiModel.playerStats.xpForNextLevel == 0u);
+								const float xpFrac = atCap ? 1.0f : std::clamp(
+									static_cast<float>(uiModel.playerStats.xpIntoLevel)
+										/ static_cast<float>(uiModel.playerStats.xpForNextLevel),
+									0.0f, 1.0f);
+								const float xpY = gaugeY + gaugeH + 16.0f;
+								const float xpH = 6.0f;
+								fg->AddRectFilled(ImVec2(gaugeX, xpY),
+									ImVec2(gaugeX + gaugeW, xpY + xpH), IM_COL32(30, 26, 12, 230), 2.0f);
+								fg->AddRectFilled(ImVec2(gaugeX, xpY),
+									ImVec2(gaugeX + gaugeW * xpFrac, xpY + xpH), IM_COL32(220, 180, 60, 235), 2.0f);
+								// Niveau, à gauche de la barre.
+								char lvlBuf[32];
+								std::snprintf(lvlBuf, sizeof(lvlBuf), "Nv. %u", uiModel.playerStats.level);
+								const ImVec2 lvlTs = ImGui::CalcTextSize(lvlBuf);
+								fg->AddText(ImVec2(gaugeX - lvlTs.x - 8.0f, xpY - 4.0f),
+									IM_COL32(230, 210, 150, 255), lvlBuf);
+								// Progression xp/prochain niveau (ou « Niveau max ») centrée dessous.
+								char xpBuf[48];
+								if (atCap)
+									std::snprintf(xpBuf, sizeof(xpBuf), "Niveau max");
+								else
+									std::snprintf(xpBuf, sizeof(xpBuf), "%u / %u XP",
+										uiModel.playerStats.xpIntoLevel, uiModel.playerStats.xpForNextLevel);
+								const ImVec2 xpTs = ImGui::CalcTextSize(xpBuf);
+								fg->AddText(ImVec2(gaugeX + (gaugeW - xpTs.x) * 0.5f, xpY + xpH + 1.0f),
+									IM_COL32(200, 190, 160, 220), xpBuf);
+							}
 						}
 					}
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8191,6 +8191,11 @@ namespace engine
 				// Partage le contexte ImGui avec auth/chat ; rendu Windows uniquement
 				// (le .cpp est gardé par #if _WIN32). Constructeur par défaut.
 				m_dialogueImGui = std::make_unique<engine::render::DialogueImGuiRenderer>();
+				// PR-B — Acceptation/rendu de quête DANS la conversation : le renderer
+				// de dialogue injecte les boutons Accepter/Rendre depuis UIModel.giverList
+				// (titres via le catalogue). Le callback d'action est câblé plus bas
+				// (même bloc GameplayNet que le panneau donneur, m_gameplayUdp requis).
+				m_dialogueImGui->BindQuestGiver(&m_uiModelBinding, &m_questTextCatalog);
 				// SP2 Task 5 — Renderer ImGui journal/tracker/panneau donneur.
 				// Partage le contexte ImGui avec auth/chat/dialogue. Le callback
 				// d'action panneau donneur est cable plus bas (apres m_gameplayUdp
@@ -10583,8 +10588,14 @@ namespace engine
 			// SP2 Task 5 — Journal + tracker + panneau donneur. No-op si non bindé
 			// (BindQuestUi est appelé au boot, cf. plus haut) ou si giverList/
 			// journalEntries sont vides (rien à afficher).
+			// PR-B — quand un dialogue PNJ est actif, on supprime le panneau donneur
+			// séparé : l'acceptation/rendu se fait DANS la conversation (boutons injectés
+			// par DialogueImGuiRenderer). Le panneau reste le fallback hors dialogue.
 			if (m_questImGui)
+			{
+				m_questImGui->SetGiverPanelSuppressed(m_dialogue.IsActive());
 				m_questImGui->Render(dw, dh, m_authUi.IsInWorldShard(), !m_hudMapClusterHidden);
+			}
 			// Marqueurs ImGui des interactibles : label flottant projete (visibilite v1
 			// sans mesh). Surligne + " [E]" si a portee. Cf. m_interactables (#39/#40).
 			{
@@ -15193,18 +15204,25 @@ namespace engine
 		// QuestGiverList (donc npcTargetId est forcément à jour dans ce contexte).
 		if (m_questImGui)
 		{
-			m_questImGui->SetGiverActionCallback(
-				[this](const std::string& questId, uint8_t role)
-				{
-					if (!m_gameplayNetInitialized)
-						return;
-					const uint32_t gameplayClientId = m_gameplayUdp.ServerClientId();
-					const std::string& npcTargetId = m_uiModelBinding.GetModel().giverList.npcTargetId;
-					if (role == 0)
-						(void)m_gameplayUdp.SendQuestAcceptRequest(gameplayClientId, questId, npcTargetId);
-					else
-						(void)m_gameplayUdp.SendQuestTurnInRequest(gameplayClientId, questId, npcTargetId);
-				});
+			// Callback partagé Accepter/Rendre (panneau donneur ET boutons injectés
+			// dans le dialogue, PR-B) : même logique, npcTargetId = celui du dernier
+			// QuestGiverList (à jour dans ce contexte).
+			auto giverActionCb = [this](const std::string& questId, uint8_t role)
+			{
+				if (!m_gameplayNetInitialized)
+					return;
+				const uint32_t gameplayClientId = m_gameplayUdp.ServerClientId();
+				const std::string& npcTargetId = m_uiModelBinding.GetModel().giverList.npcTargetId;
+				if (role == 0)
+					(void)m_gameplayUdp.SendQuestAcceptRequest(gameplayClientId, questId, npcTargetId);
+				else
+					(void)m_gameplayUdp.SendQuestTurnInRequest(gameplayClientId, questId, npcTargetId);
+			};
+			m_questImGui->SetGiverActionCallback(giverActionCb);
+			// PR-B — même callback pour les boutons Accepter/Rendre injectés dans la
+			// fenêtre de dialogue (acceptation « dans la conversation »).
+			if (m_dialogueImGui)
+				m_dialogueImGui->SetGiverActionCallback(giverActionCb);
 		}
 	}
 

--- a/src/client/render/DialogueImGuiRenderer.cpp
+++ b/src/client/render/DialogueImGuiRenderer.cpp
@@ -1,8 +1,11 @@
 #include "src/client/render/DialogueImGuiRenderer.h"
 
 #include "src/client/dialogue/DialoguePresenter.h"
+#include "src/client/quest/QuestTextCatalog.h"
+#include "src/client/ui_common/UIModel.h"
 
 #include <cstdio>
+#include <string>
 
 #if defined(_WIN32)
 #	include "imgui.h"
@@ -205,6 +208,61 @@ namespace engine::render
 					// On sort de la boucle immédiatement : l'état du node a changé.
 					presenter.SelectChoice(i);
 					break;
+				}
+			}
+
+			// PR-B — Acceptation/rendu de quête DANS la conversation. On injecte
+			// sous les réponses scriptées un bouton par entrée du panneau donneur
+			// (UIModel.giverList, instantané status-aware du dernier Talk : le serveur
+			// n'y met role 0 « Accepter » que si la quête est proposée, role 1
+			// « Rendre » que si les étapes sont remplies). Remplace l'ancien panneau
+			// donneur séparé (QuestImGuiRenderer, désormais masqué tant qu'un dialogue
+			// est actif). Le clic déclenche le callback quête d'Engine
+			// (SendQuestAccept/TurnInRequest) ; l'entrée disparaît au frame suivant
+			// (ApplyQuestDelta purge le giverList au changement de statut). No-op si
+			// non bindé (BindQuestGiver) ou si le giverList est vide.
+			if (m_uiModelBinding != nullptr && m_textCatalog != nullptr && m_giverAction)
+			{
+				const engine::client::UIQuestGiverList& giverList =
+					m_uiModelBinding->GetModel().giverList;
+				if (!giverList.entries.empty())
+				{
+					ImGui::Spacing();
+					ImGui::Separator();
+					for (const engine::client::UIQuestGiverEntry& entry : giverList.entries)
+					{
+						const bool isTurnIn = (entry.role == 1u);
+						const std::string title = m_textCatalog->Title(entry.questId);
+						char qlabel[512];
+						std::snprintf(qlabel, sizeof(qlabel), "%s : %s##giver_%s_%u",
+						              isTurnIn ? "Rendre" : "Accepter",
+						              title.c_str(),
+						              entry.questId.c_str(),
+						              static_cast<unsigned>(entry.role));
+
+						// Même code couleur que les choix scriptés de quête : doré =
+						// accepter, vert = rendre.
+						if (isTurnIn)
+						{
+							ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.16f, 0.36f, 0.18f, 0.92f));
+							ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.24f, 0.52f, 0.26f, 1.0f));
+						}
+						else
+						{
+							ImGui::PushStyleColor(ImGuiCol_Button,        ImVec4(0.46f, 0.35f, 0.11f, 0.92f));
+							ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.64f, 0.49f, 0.17f, 1.0f));
+						}
+						ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + wrapW);
+						const bool qClicked = ImGui::Button(qlabel, ImVec2(wrapW, 0.0f));
+						ImGui::PopTextWrapPos();
+						ImGui::PopStyleColor(2);
+
+						if (qClicked)
+						{
+							m_giverAction(entry.questId, entry.role);
+							break; // le giverList peut être purgé ce frame -> on sort.
+						}
+					}
 				}
 			}
 

--- a/src/client/render/DialogueImGuiRenderer.h
+++ b/src/client/render/DialogueImGuiRenderer.h
@@ -1,8 +1,15 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
+#include <string>
 
-namespace engine::client { class DialoguePresenter; }
+namespace engine::client
+{
+	class DialoguePresenter;
+	class UIModelBinding;
+	class QuestTextCatalog;
+}
 
 namespace engine::render
 {
@@ -16,6 +23,28 @@ namespace engine::render
 	class DialogueImGuiRenderer final
 	{
 	public:
+		/// PR-B — Callback émis quand le joueur clique un bouton Accepter/Rendre
+		/// injecté DANS la conversation (depuis UIModel.giverList). Même contrat
+		/// que \ref QuestImGuiRenderer::GiverActionCallback : \p questId = id texte
+		/// (clé catalogue), \p role = 0 (accepter) / 1 (rendre). Câblé par Engine
+		/// vers SendQuestAcceptRequest / SendQuestTurnInRequest.
+		using GiverActionCallback = std::function<void(const std::string& questId, uint8_t role)>;
+
+		/// PR-B — Bind les sources de l'acceptation/rendu de quête intégrés au
+		/// dialogue (non possédés) : \p uiModelBinding fournit UIModel.giverList
+		/// (instantané status-aware du dernier Talk), \p textCatalog résout les
+		/// titres. Si non bindé, aucun bouton de quête n'est injecté (comportement
+		/// legacy : dialogue de bavardage seul).
+		void BindQuestGiver(const engine::client::UIModelBinding* uiModelBinding,
+			const engine::client::QuestTextCatalog* textCatalog)
+		{
+			m_uiModelBinding = uiModelBinding;
+			m_textCatalog = textCatalog;
+		}
+
+		/// PR-B — Câble le callback Accepter/Rendre (cf. \ref GiverActionCallback).
+		void SetGiverActionCallback(GiverActionCallback callback) { m_giverAction = std::move(callback); }
+
 		/// Dessine la fenêtre de dialogue si le presenter est actif.
 		/// \param presenter source de vérité (lecture) + cible des actions joueur
 		///        (SelectChoice, Close). Doit rester valide pour toute la durée de l'appel.
@@ -27,6 +56,11 @@ namespace engine::render
 		/// Button, TextUnformatted, SetScrollY…). No-op si le presenter n'est pas actif.
 		void Render(engine::client::DialoguePresenter& presenter,
 		            float viewportWidth, float viewportHeight);
+
+	private:
+		const engine::client::UIModelBinding*   m_uiModelBinding = nullptr;
+		const engine::client::QuestTextCatalog* m_textCatalog = nullptr;
+		GiverActionCallback                     m_giverAction;
 	};
 
 } // namespace engine::render

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -355,6 +355,12 @@ namespace engine::render
 
 	void QuestImGuiRenderer::RenderGiverPanel()
 	{
+		// PR-B — Masqué tant qu'un dialogue PNJ est actif : dans ce cas
+		// l'acceptation/rendu se fait DANS la conversation (DialogueImGuiRenderer).
+		// Ce panneau ne subsiste que comme fallback (donneur sans arbre de dialogue).
+		if (m_giverPanelSuppressed)
+			return;
+
 		const engine::client::UIModel& model = m_uiModelBinding->GetModel();
 		const engine::client::UIQuestGiverList& giverList = model.giverList;
 		if (giverList.entries.empty())

--- a/src/client/render/QuestImGuiRenderer.h
+++ b/src/client/render/QuestImGuiRenderer.h
@@ -49,6 +49,12 @@ namespace engine::render
 		/// Câble le callback d'action du panneau donneur (Accepter/Terminer).
 		void SetGiverActionCallback(GiverActionCallback callback) { m_giverAction = std::move(callback); }
 
+		/// PR-B — Supprime le panneau donneur séparé quand un dialogue PNJ est actif :
+		/// dans ce cas l'acceptation/rendu se fait DANS la conversation
+		/// (DialogueImGuiRenderer injecte les boutons). Le panneau reste le fallback
+		/// pour un donneur sans arbre de dialogue. Positionné par Engine chaque frame.
+		void SetGiverPanelSuppressed(bool suppressed) { m_giverPanelSuppressed = suppressed; }
+
 		/// Émet les commandes ImGui pour la frame courante. Suppose que
 		/// \c m_worldEditorImGui->NewFrame a déjà été appelé.
 		/// No-op si le presenter n'est pas bindé.
@@ -84,5 +90,6 @@ namespace engine::render
 		const engine::client::UIModelBinding*    m_uiModelBinding = nullptr;
 		const engine::core::Config*              m_cfg = nullptr;
 		GiverActionCallback m_giverAction;
+		bool m_giverPanelSuppressed = false;
 	};
 }

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -612,6 +612,8 @@ namespace engine::client
 		// R1-B — feuille de personnage (stats dérivées poussées à l'enter-world)
 		case engine::server::MessageKind::PlayerStats:
 			return ApplyPlayerStats(packet);
+		case engine::server::MessageKind::PlayerXpUpdate:
+			return ApplyPlayerXpUpdate(packet);
 		// Combat SP3 — sorts et auras (wire v11)
 		case engine::server::MessageKind::ResourceUpdate:
 			return ApplyResourceUpdate(packet);
@@ -1598,6 +1600,30 @@ namespace engine::client
 			m_playerStatsScratch.stamina,
 			m_playerStatsScratch.damage,
 			m_playerStatsScratch.profileId.empty() ? "<none>" : m_playerStatsScratch.profileId.c_str());
+
+		NotifyObservers(UIModelChangeStats);
+		return true;
+	}
+
+	bool UIModelBinding::ApplyPlayerXpUpdate(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodePlayerXpUpdate(packet, m_playerXpScratch))
+		{
+			LOG_WARN(Net, "[UIModelBinding] PlayerXpUpdate FAILED: decode error");
+			return false;
+		}
+
+		m_model.playerStats.hasXp = true;
+		m_model.playerStats.level = m_playerXpScratch.level;
+		m_model.playerStats.xpIntoLevel = m_playerXpScratch.xpIntoLevel;
+		m_model.playerStats.xpForNextLevel = m_playerXpScratch.xpForNextLevel;
+
+		LOG_INFO(Net,
+			"[UIModelBinding] PlayerXpUpdate applied (client_id={}, level={}, xp={}/{})",
+			m_playerXpScratch.clientId,
+			m_playerXpScratch.level,
+			m_playerXpScratch.xpIntoLevel,
+			m_playerXpScratch.xpForNextLevel);
 
 		NotifyObservers(UIModelChangeStats);
 		return true;

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -228,6 +228,13 @@ namespace engine::client
 		/// Grimoire — layout autoritaire des 10 slots (slot i → spellId, "" = vide),
 		/// reçu via ActionBarLayoutUpdate (enter-world / ACK serveur).
 		std::array<std::string, 10> actionBarLayout{};
+		/// PR-C — progression de niveau (barre d'XP), reçue via PlayerXpUpdate
+		/// (enter-world + chaque gain d'XP). \c xpForNextLevel = 0 signale le cap
+		/// de niveau. \c hasXp reste faux tant qu'aucun PlayerXpUpdate n'est reçu.
+		bool     hasXp = false;
+		uint32_t level = 0;
+		uint32_t xpIntoLevel = 0;
+		uint32_t xpForNextLevel = 0;
 	};
 
 	/// Combat SP3 — état de la barre de cast du joueur local (CastBarUpdate).
@@ -707,6 +714,9 @@ namespace engine::client
 		/// Applique un message PlayerStats (feuille de perso dérivée) à la section stats (R1-B).
 		bool ApplyPlayerStats(std::span<const std::byte> packet);
 
+		/// PR-C — applique un message PlayerXpUpdate (niveau + XP) à la section stats.
+		bool ApplyPlayerXpUpdate(std::span<const std::byte> packet);
+
 		/// Advance world presenter ages (wall clock clamped).
 		void PumpWorldPresenterAge();
 
@@ -766,6 +776,7 @@ namespace engine::client
 		engine::server::CraftCompleteMessage       m_craftCompleteScratch{};
 		engine::server::CraftCancelledMessage      m_craftCancelledScratch{};
 		engine::server::PlayerStatsMessage         m_playerStatsScratch{};
+		engine::server::PlayerXpUpdateMessage      m_playerXpScratch{};
 		ChatWorldVisualPresenter m_chatWorld{};
 		size_t m_nextObserverHandle = 1;
 		bool m_initialized = false;

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -2064,6 +2064,30 @@ namespace engine::server
 		return true;
 	}
 
+	std::vector<std::byte> EncodePlayerXpUpdate(const PlayerXpUpdateMessage& message)
+	{
+		std::vector<std::byte> packet = BeginPacket(MessageKind::PlayerXpUpdate, 16);
+		WriteU32(packet, message.clientId);
+		WriteU32(packet, message.level);
+		WriteU32(packet, message.xpIntoLevel);
+		WriteU32(packet, message.xpForNextLevel);
+		return packet;
+	}
+
+	bool DecodePlayerXpUpdate(std::span<const std::byte> packet, PlayerXpUpdateMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::PlayerXpUpdate, payload) || payload.size() != 16)
+		{
+			return false;
+		}
+		outMessage.clientId = ReadU32(payload, 0);
+		outMessage.level = ReadU32(payload, 4);
+		outMessage.xpIntoLevel = ReadU32(payload, 8);
+		outMessage.xpForNextLevel = ReadU32(payload, 12);
+		return true;
+	}
+
 	std::vector<std::byte> EncodeShopOpen(const ShopOpenMessage& message)
 	{
 		const uint16_t offerCount = static_cast<uint16_t>(

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -287,7 +287,13 @@ namespace engine::server
 		/// SP1 quêtes — le joueur accepte une quête au PNJ giver (client→serveur).
 		QuestAcceptRequest = 93,
 		/// SP1 quêtes — le joueur rend une quête au PNJ turn-in (client→serveur).
-		QuestTurnInRequest = 94
+		QuestTurnInRequest = 94,
+
+		/// PR-C — progression de niveau du joueur local (serveur→client) : niveau,
+		/// XP dans le niveau courant, XP requise pour le suivant. Poussé à l'enter-world
+		/// ET à chaque gain d'XP (level-up ou non). Rétro-additif (vieux clients
+		/// l'ignorent) : PAS de bump de kProtocolVersion.
+		PlayerXpUpdate = 95
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -1179,6 +1185,26 @@ namespace engine::server
 
 	/// Decode a wallet update packet.
 	bool DecodeWalletUpdate(std::span<const std::byte> packet, WalletUpdateMessage& outMessage);
+
+	// -------------------------------------------------------------------------
+	// PR-C — Réplication de la progression de niveau (barre d'XP)
+	// -------------------------------------------------------------------------
+
+	/// Server → client : progression de niveau du joueur local.
+	/// \c xpForNextLevel = 0 signale le cap de niveau (barre pleine, pas de suivant).
+	struct PlayerXpUpdateMessage
+	{
+		uint32_t clientId = 0;
+		uint32_t level = 0;
+		uint32_t xpIntoLevel = 0;    ///< XP accumulée DANS le niveau courant.
+		uint32_t xpForNextLevel = 0; ///< XP requise pour passer au niveau suivant (0 = cap).
+	};
+
+	/// Encode a player XP update packet (server authoritative).
+	std::vector<std::byte> EncodePlayerXpUpdate(const PlayerXpUpdateMessage& message);
+
+	/// Decode a player XP update packet.
+	bool DecodePlayerXpUpdate(std::span<const std::byte> packet, PlayerXpUpdateMessage& outMessage);
 
 	// -------------------------------------------------------------------------
 	// M35.2 — Vendor shop

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -16,6 +16,7 @@
 
 // Level-up runtime — courbe XP -> niveau (séparée de la boucle réseau, pure et testable).
 #include "src/shardd/gameplay/character/LevelProgression.h"
+#include "src/shared/formulas/Formulas.h"
 
 // Combat SP2 — résolveur d'attaque pur (précision / critique, RNG injecté).
 #include "src/shardd/gameplay/combat/AttackResolver.h"
@@ -1572,6 +1573,7 @@ namespace engine::server
 			m_clients.size());
 		(void)SendWelcome(acceptedClient);
 		(void)SendPlayerStats(acceptedClient);
+		(void)SendPlayerXpUpdate(acceptedClient); // PR-C — sync initial barre d'XP
 		(void)SendActionBarLayout(acceptedClient); // Grimoire — layout persisté (ou vide)
 		(void)SendClassProgression(acceptedClient); // SP-B — progression par-classe persistée (ou vide)
 		SendDynamicEventBootstrap(acceptedClient);
@@ -6391,6 +6393,32 @@ namespace engine::server
 		return true;
 	}
 
+	// PR-C — pousse la progression de niveau (barre d'XP client). xpForNextLevel
+	// via la MÊME courbe que ApplyXpGain (formulas::XpToNextLevel) pour cohérence :
+	// 0 signale le cap de niveau. Appelé à l'enter-world et à chaque gain d'XP.
+	bool ServerApp::SendPlayerXpUpdate(const ConnectedClient& client)
+	{
+		if (!m_statsTables) return false;
+		PlayerXpUpdateMessage msg{};
+		msg.clientId    = client.clientId;
+		msg.level       = client.level;
+		msg.xpIntoLevel = client.experiencePoints;
+		const uint8_t levelU8 = static_cast<uint8_t>(std::min<uint32_t>(client.level, 255u));
+		const uint8_t levelMaxU8 = static_cast<uint8_t>(std::min<uint32_t>(m_statsTables->levelMax, 255u));
+		msg.xpForNextLevel = engine::server::formulas::XpToNextLevel(
+			levelU8, m_statsTables->xpBase, m_statsTables->xpFactor, levelMaxU8);
+
+		const std::vector<std::byte> packet = EncodePlayerXpUpdate(msg);
+		if (!m_transport.Send(client.endpoint, packet))
+		{
+			LOG_WARN(Net, "[ServerApp] SendPlayerXpUpdate failed (client_id={})", client.clientId);
+			return false;
+		}
+		LOG_INFO(Net, "[ServerApp] PlayerXpUpdate sent (client_id={}, level={}, xp={}/{})",
+			client.clientId, msg.level, msg.xpIntoLevel, msg.xpForNextLevel);
+		return true;
+	}
+
 	bool ServerApp::SendSnapshot(const ConnectedClient& client)
 	{
 		m_snapshotEntitiesScratch.clear();
@@ -7641,6 +7669,9 @@ namespace engine::server
 			m_statsTables->xpBase, m_statsTables->xpFactor, m_statsTables->levelMax);
 		client.level = r.newLevel;
 		client.experiencePoints = r.newXpIntoLevel;
+		// PR-C — pousse la barre d'XP à CHAQUE gain (même sans level-up : sinon la
+		// progression intra-niveau n'atteindrait jamais le client).
+		(void)SendPlayerXpUpdate(client);
 		if (r.levelsGained == 0u)
 			return;
 		// Recalcul des stats au nouveau niveau + soin complet.

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -842,6 +842,9 @@ namespace engine::server
 		/// Retourne false si tables absentes, char legacy (faction/classe vides) ou
 		/// calcul/envoi échoué — non fatal pour le handshake (log seulement).
 		bool SendPlayerStats(const ConnectedClient& client);
+		/// PR-C — pousse la progression de niveau (niveau + XP courante + XP pour le
+		/// niveau suivant) au client local pour la barre d'XP. Enter-world + gain d'XP.
+		bool SendPlayerXpUpdate(const ConnectedClient& client);
 
 		/// Send one empty snapshot packet to the given connected client.
 		bool SendSnapshot(const ConnectedClient& client);


### PR DESCRIPTION
> ⚠️ **Stackée sur #947** (base = `claude/quest-accept-in-dialogue`, elle-même sur #946). Ordre de merge : **#946 → #947 → celle-ci**.

## Retour joueur
« Le personnage reçoit de l'XP mais la **barre de progression d'XP n'existe pas**, il faut la créer et assurer le suivi. »

## Constat
Le client ne recevait **aucune** donnée de niveau/XP. `PlayerStats` ne les porte pas, et `ApplyLevelUpsAfterXp` n'envoyait `SendPlayerStats` **que sur level-up** → la progression **intra-niveau** n'atteignait jamais le client. Il fallait donc du travail serveur.

## Serveur
- **Nouvel opcode `PlayerXpUpdate = 95`** (serveur→client) : `clientId, level, xpIntoLevel, xpForNextLevel`. **Rétro-additif** (vieux clients l'ignorent) → **pas de bump** de `kProtocolVersion`.
- `SendPlayerXpUpdate` : `xpForNextLevel` via la **même courbe** que `ApplyXpGain` (`formulas::XpToNextLevel`) ; `0` = cap de niveau.
- Poussé à l'**enter-world** (sync initial) **ET** dans `ApplyLevelUpsAfterXp` à **chaque gain d'XP** (avant le retour anticipé sans level-up).

## Client
- `UIPlayerStats` gagne `level/xpIntoLevel/xpForNextLevel/hasXp` ; `ApplyPlayerXpUpdate` (décode + `NotifyObservers`).
- **Barre d'XP dorée** fine sous la vie/ressource (bas-centre) : « Nv. N » à gauche, « xp / next XP » (ou « Niveau max ») centré dessous. Masquée tant qu'aucun `PlayerXpUpdate` reçu.

## À tester en jeu
- La barre d'XP apparaît dès l'entrée en jeu (niveau + XP courante).
- Tuer un sanglier / rendre la quête fait **avancer la barre** ; à seuil franchi, « Nv. » incrémente.

## Déploiement
> ⚠️ **REDÉPLOIEMENT SERVEUR (shard) REQUIS** — nouvel opcode 47… (95) émis par le shard. Wire **additif** (pas de bump), donc pas de rejet des vieux clients ; mais **la barre ne se remplit que si le binaire shard est à jour**. Côté client, la PR est nécessaire pour décoder l'opcode et dessiner la barre → **déployer client + shard en lock-step** pour la feature complète.

🤖 Generated with [Claude Code](https://claude.com/claude-code)