### PR TITLE
content(quests): de-trap hunt_collect_enter (retire l'étape impossible 'enter zone:2')

### DIFF
--- a/game/data/quests/quest_definitions.json
+++ b/game/data/quests/quest_definitions.json
@@ -21,8 +21,7 @@
       "prereqs": [],
       "steps": [
         { "type": "kill", "target": "mob:100", "requiredCount": 1 },
-        { "type": "collect", "target": "item:2001", "requiredCount": 1 },
-        { "type": "enter", "target": "zone:2", "requiredCount": 1 }
+        { "type": "collect", "target": "item:2001", "requiredCount": 1 }
       ],
       "rewards": {
         "xp": 100,

--- a/game/data/quests/quest_texts.fr.json
+++ b/game/data/quests/quest_texts.fr.json
@@ -9,12 +9,11 @@
   },
   "hunt_collect_enter": {
     "title": "Sur les traces de l'ancien",
-    "description": "L'ancien Marn a besoin d'aide : traquer une bête, récupérer un objet perdu et explorer une zone voisine.",
+    "description": "L'ancien Marn a besoin d'aide : traquer une bête et récupérer un objet perdu.",
     "completion": "Tu as accompli tout ce que je t'avais demandé. L'ancien Marn t'en est reconnaissant — prends ceci.",
     "steps": [
       "Bête traquée : {current}/{required}",
-      "Objet récupéré : {current}/{required}",
-      "Zone explorée : {current}/{required}"
+      "Objet récupéré : {current}/{required}"
     ]
   },
   "report_to_guard": {


### PR DESCRIPTION
## Contexte
En investiguant le contenu quêtes (après ton lot HUD/dialogue/XP), j'ai trouvé un **cul-de-sac** : `hunt_collect_enter` — offerte par **elder_marn** à côté de `kill_10_boars` — a une 3ᵉ étape **« enter zone:2 » infranchissable** :
- `zone_2` existe en données mais **aucune transition** feyhin→zone_2 n'existe → inatteignable.
- Avec l'acceptation **dans le dialogue** (#947), elder_marn affiche **deux** boutons « Accepter », dont celui-ci → le joueur peut se piéger.

## Fix (de-trap minimal, ta décision)
Retirer l'étape `enter zone:2`. `hunt_collect_enter` devient **jouable en 2 étapes** (tuer 1 sanglier `mob:100` + ramasser `item:2001`, tous deux dispo en feyhin) et reste rendable chez elder_marn. Label « Zone explorée » + mention « explorer une zone voisine » retirés de `quest_texts.fr.json` par cohérence.

## Non touché
`report_to_guard` reste **inerte** : son giver `npc:guard_captain` n'est placé **nulle part** dans le monde → jamais proposé en jeu, donc pas un piège. Laissé tel quel (si tu construis zone_2 + guard_captain plus tard, on recâblera).

## Déploiement
> ⚠️ **Le shard doit relire `quest_definitions.json`** (redéploiement/redémarrage shard) pour appliquer le changement. **Aucun code**, aucun wire — pur contenu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)