### PR TITLE
fix(radar): le radar minimap ne suivait jamais le joueur (position serveur figée)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10588,6 +10588,17 @@ namespace engine
 			// SP2 Task 5 — Journal + tracker + panneau donneur. No-op si non bindé
 			// (BindQuestUi est appelé au boot, cf. plus haut) ou si giverList/
 			// journalEntries sont vides (rien à afficher).
+			// Radar : alimente le presenter avec la position CLIENT-AUTORITAIRE du
+			// joueur AVANT le rendu. Le serveur exclut le joueur local de son propre
+			// snapshot (AoI self-skip) -> UIModel.playerStats.position reste figée au
+			// spawn et le radar ne suivait jamais le joueur (retour joueur 2026-07-07).
+			// In-world uniquement (contrôleur valide). UpdatePlayerWorldPosition ne
+			// reconstruit le radar que si le déplacement dépasse ~5 cm.
+			if (m_authUi.IsInWorldShard())
+			{
+				const engine::math::Vec3 radarPlayerPos = m_characterController.GetPosition();
+				m_questUi.UpdatePlayerWorldPosition(radarPlayerPos.x, radarPlayerPos.z);
+			}
 			// PR-B — quand un dialogue PNJ est actif, on supprime le panneau donneur
 			// séparé : l'acceptation/rendu se fait DANS la conversation (boutons injectés
 			// par DialogueImGuiRenderer). Le panneau reste le fallback hors dialogue.

--- a/src/client/quest/QuestUi.cpp
+++ b/src/client/quest/QuestUi.cpp
@@ -175,6 +175,34 @@ namespace engine::client
 		return true;
 	}
 
+	void QuestUiPresenter::UpdatePlayerWorldPosition(float worldX, float worldZ)
+	{
+		if (!m_initialized)
+		{
+			return;
+		}
+		// Seuil anti-rebuild (~5 cm) : joueur immobile -> pas de reconstruction du
+		// radar chaque frame. Les POI de mobs restent par ailleurs rafraîchis par
+		// ApplyModel (snapshots réseau), donc rien n'est figé à l'arrêt.
+		constexpr float kMinDeltaM = 0.05f;
+		if (m_hasLivePlayerPos)
+		{
+			const float dx = worldX - m_livePlayerX;
+			const float dz = worldZ - m_livePlayerZ;
+			if ((dx * dx + dz * dz) < (kMinDeltaM * kMinDeltaM))
+			{
+				return;
+			}
+		}
+		m_livePlayerX = worldX;
+		m_livePlayerZ = worldZ;
+		m_hasLivePlayerPos = true;
+		// Seul le radar dépend de la position ; le journal et le tracker n'en
+		// dépendent pas. On reconstruit donc uniquement la minimap depuis le
+		// dernier modèle réseau connu (mobs/quêtes courants).
+		RebuildMinimap(m_lastModel);
+	}
+
 	bool QuestUiPresenter::SelectQuest(std::string_view questId)
 	{
 		if (!m_initialized)
@@ -432,8 +460,12 @@ namespace engine::client
 			// le joueur (indépendant de la texture de zone) : on continue.
 		}
 
-		const float playerX = model.playerStats.positionX;
-		const float playerZ = model.playerStats.positionZ;
+		// Centre du radar = position CLIENT-AUTORITAIRE du joueur si disponible
+		// (poussée par Engine via UpdatePlayerWorldPosition). Le serveur exclut le
+		// joueur local de son propre snapshot (AoI self-skip) -> playerStats.position
+		// resterait figée au spawn et le radar ne suivrait jamais le joueur.
+		const float playerX = m_hasLivePlayerPos ? m_livePlayerX : model.playerStats.positionX;
+		const float playerZ = m_hasLivePlayerPos ? m_livePlayerZ : model.playerStats.positionZ;
 
 		// SP3 — radar centré joueur : le joueur est toujours au centre exact.
 		m_state.playerMarker.u = 0.5f;

--- a/src/client/quest/QuestUi.h
+++ b/src/client/quest/QuestUi.h
@@ -142,6 +142,16 @@ namespace engine::client
 		/// boot (Engine). Ignoré si \p radiusM <= 0 (garde de \ref WorldToRadarUv).
 		void SetMinimapRadius(float radiusM) { m_minimapRadiusM = radiusM; }
 
+		/// Renseigne la position monde CLIENT-AUTORITAIRE du joueur local (mètres,
+		/// XZ) et rafraîchit le radar. Le joueur local est client-autoritaire : le
+		/// serveur ne le renvoie PAS dans son propre snapshot (AoI exclut self, cf.
+		/// ServerApp::BuildRelevantEntityIds) donc \c UIModel.playerStats.position
+		/// reste figée au spawn -> le radar ne suivait jamais le joueur. Engine
+		/// appelle ceci chaque frame in-world avec \c CharacterController::GetPosition.
+		/// Ne reconstruit le radar que si le déplacement dépasse un petit seuil
+		/// (évite un rebuild par frame à l'arrêt). No-op si non initialisé.
+		void UpdatePlayerWorldPosition(float worldX, float worldZ);
+
 	private:
 		/// Load minimap zone metadata from the configured content-relative file.
 		bool LoadZoneMetadata(const engine::core::Config& config);
@@ -189,5 +199,13 @@ namespace engine::client
 		/// cadre). Valeur par défaut ; le câblage config (client.minimap.*)
 		/// est repoussé à la Task 3 du plan SP3.
 		float m_minimapRadiusM = 60.0f;
+
+		/// Position monde client-autoritaire du joueur (XZ, mètres), poussée par
+		/// \ref UpdatePlayerWorldPosition. Utilisée comme centre du radar à la place
+		/// de \c UIModel.playerStats.position (figée au spawn pour le joueur local).
+		/// \c m_hasLivePlayerPos faux tant qu'aucune position n'a été poussée.
+		float m_livePlayerX = 0.0f;
+		float m_livePlayerZ = 0.0f;
+		bool  m_hasLivePlayerPos = false;
 	};
 }


### PR DESCRIPTION
> ⚠️ **Stackée sur #948** (commits #947+#948 inclus dans le diff jusqu'à leur merge). Ordre : **#947 → #948 → celle-ci**. Diff cumulatif tant que les parents ne sont pas mergés.

## Symptôme (tes captures)
Sur 3 positions très différentes (plaine, falaises, bord d'eau), le **mini-radar affiche exactement les mêmes points** → il ne suit pas le joueur.

## Cause racine (confirmée dans le code)
Le radar (`RebuildMinimap`) se centre sur `UIModel.playerStats.positionX/Z`. Or cette position n'est mise à jour **que si l'entité du joueur figure dans le snapshot serveur** :
```cpp
// UIModel.cpp
if (entity.entityId == stats.playerEntityId) { stats.positionX = ...; }
```
Mais le joueur local est **client-autoritaire** et le serveur **l'exclut de son propre snapshot** (optimisation AoI classique) :
```cpp
// ServerApp::BuildRelevantEntityIds
for (EntityId entityId : client.interestEntityIds) {
    if (entityId == client.entityId) continue;   // <-- self-skip
```
→ `playerStats.position` **reste figée au spawn** → le radar centre tout (POI statiques **et** mobs) autour d'un point fixe → ne suit jamais le joueur.

## Fix (100% client)
Alimenter le radar avec la position **client-autoritaire** :
- `QuestUiPresenter::UpdatePlayerWorldPosition(x, z)` : stocke la position live + reconstruit le radar (seuil **~5 cm** pour éviter un rebuild par frame à l'arrêt).
- `RebuildMinimap` utilise cette position live si dispo, sinon retombe sur `playerStats.position` (comportement historique préservé).
- `Engine` appelle ça **chaque frame in-world** avec `CharacterController::GetPosition()`, juste avant le rendu quest.

Le journal et le tracker ne dépendent pas de la position → seul le radar est reconstruit.

## À tester en jeu
Le radar doit **défiler** quand tu te déplaces : les points de quête / mobs bougent en cohérence avec ton avatar (centre du radar).

## Déploiement
> **✅ CLIENT uniquement.** Aucun serveur, aucun wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)