### PR TITLE
fix(skilltree): l'arbre de compétences restait bloqué au niveau d'entrée

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -12472,6 +12472,16 @@ namespace engine
 			// les paliers > niveau et affiche le bon « Niveau joueur ». Le serveur revalide.
 			{
 				const engine::client::UIModel& treeModel = m_uiModelBinding.GetModel();
+				// Le level-up EN JEU doit débloquer les paliers de l'arbre. Le niveau
+				// live vient de PlayerXpUpdate (barre d'XP, playerStats.level), qui suit
+				// les montées de niveau ; m_activeCharacterLevel n'était capturé qu'à
+				// l'EnterWorld et jamais remis à jour -> l'arbre restait bloqué au niveau
+				// d'entrée (retour joueur 2026-07-07 : perso niv. 5 mais arbre « Niveau
+				// joueur : 1 », compétences verrouillées). On synchronise donc le niveau
+				// actif sur le niveau serveur (monotone ; fallback = EnterWorld si aucun
+				// PlayerXpUpdate reçu, ex. serveur ancien).
+				if (treeModel.playerStats.hasXp && treeModel.playerStats.level > m_activeCharacterLevel)
+					m_activeCharacterLevel = treeModel.playerStats.level;
 				m_classSkillTreeUi.Sync(treeModel.classId, treeModel.knownSkillIds, m_activeCharacterLevel);
 				if (m_classSkillTreeVisible && m_classSkillTreeImGui && m_classSkillTreeUi.IsInitialized())
 				{


### PR DESCRIPTION
## Symptôme (ta capture)
Le perso monte **niveau 5** (barre d'XP OK) mais l'arbre de compétences affiche **« Niveau joueur : 1 »** et les compétences restent **verrouillées**.

## Cause racine (confirmée dans le code)
L'arbre est synchronisé avec `m_activeCharacterLevel`, **capturé une seule fois à l'EnterWorld** (depuis CHARACTER_LIST) et **jamais remis à jour** au level-up en jeu (2 seuls usages : set à l'enter-world + Sync de l'arbre). Le déblocage d'un skill est `tier <= playerLevel` → à niveau figé 1, seuls les paliers 1 sont disponibles.

Le serveur, lui, monte bien le niveau **et l'envoie désormais** au client via `PlayerXpUpdate` (opcode 95, la barre d'XP de #948) → `UIModel.playerStats.level`.

## Fix (100% client)
Au moment du Sync de l'arbre, on synchronise `m_activeCharacterLevel` sur le niveau **live** du serveur (`playerStats.level`, monotone). Fallback sur le niveau d'EnterWorld si aucun `PlayerXpUpdate` reçu (serveur ancien).

## À tester en jeu
Monter de niveau → l'arbre affiche le bon « Niveau joueur » et les paliers ≤ niveau deviennent **disponibles** (choisissables ; le serveur revalide).

## Déploiement
> **✅ CLIENT uniquement.** Le serveur envoie déjà le niveau (la barre d'XP le prouve) et revalide les choix. Aucun wire, pas de redéploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)