### PR TITLE
feat(minimap): contrôle de zoom du radar (5 crans 200-1000 m, molette + clic)

### DIFF
--- a/docs/superpowers/specs/2026-07-08-minimap-zoom-design.md
+++ b/docs/superpowers/specs/2026-07-08-minimap-zoom-design.md
@@ -1,0 +1,73 @@
+# Contrôle de zoom du radar minimap — design (2026-07-08)
+
+## Objectif
+Permettre au joueur de zoomer/dézoomer la mini-carte via un contrôle circulaire
+sur la moitié haute de l'arc du radar. Retour joueur : pouvoir régler la portée
+affichée.
+
+## Comportement
+- **5 crans de rayon affiché** : 200, 400, 600, 800, 1000 m (index 0→4).
+- **Défaut** : 600 m (index 2).
+- **Persistance** : cran mémorisé dans `user_settings.json`, clé
+  `client.quest.minimap.zoom_level` (int 0-4). Rechargé au boot.
+- Remplace le rayon fixe historique (`m_minimapRadiusM`, défaut 60 m) : le rayon
+  courant devient `kZoomLevelsM[zoom_level]`.
+
+## Interaction
+- **Molette au-dessus du disque du radar** → zoom in/out d'un cran (clamp 0..4).
+  La molette pilote déjà le zoom caméra (`OrbitalCameraController`,
+  `Camera.cpp` `MouseScrollDelta`). Quand le curseur est sur le disque du radar,
+  on **coupe le zoom caméra** (nouveau paramètre `applyZoom` passé à
+  `OrbitalCameraController::Update`) et la molette pilote le radar.
+- **Clic sur un des 5 repères** de l'arc → saut direct à ce cran (hit-test dans
+  un petit rayon autour du repère).
+
+## Visuel
+- Arc sur la **moitié haute** du cercle du radar, tracé juste à l'extérieur de la
+  bordure (n'empiète pas sur les POI intérieurs).
+- **5 repères** répartis sur l'arc : gauche = 200 m … droite = 1000 m.
+- Cran courant **surligné** (pastille/poignée plus grosse + teinte accent).
+- **Valeur numérique** (« 600 m ») affichée au-dessus du radar (lève l'ambiguïté
+  du sens de l'arc).
+
+## Architecture (isolée + testable)
+1. **`MinimapZoom` (pur, testé)** — helper : `kZoomLevelsM[5] = {200,400,600,800,
+   1000}`, `ClampZoomIndex(int)`, `StepZoomIndex(int idx, int wheelDelta)`,
+   `RadiusForZoomIndex(int)`. Aucune dépendance ImGui. Même esprit que
+   `WorldToRadarUv`.
+2. **`ComputeRadarScreenRect(cfg, displayW, displayH)` (pur, testé)** — extrait la
+   géométrie du radar (coin haut-gauche `x0/y0` + taille `size` px) aujourd'hui
+   calculée inline dans `QuestImGuiRenderer::RenderMinimap`. Partagée entre le
+   **rendu** (arc/repères/POI) et le **hit-test** (Engine : molette + clic) →
+   zéro dérive de géométrie.
+3. **Engine** — possède le cran courant (chargé de la config au boot). Chaque
+   frame in-world : hit-test souris vs disque radar (via `ComputeRadarScreenRect`) ;
+   si dessus, lit la molette (`MouseScrollDelta`) → `StepZoomIndex`, et teste le
+   clic sur les repères → cran direct. Au changement : `m_questUi.SetMinimapRadius(
+   RadiusForZoomIndex(idx))` + persiste `client.quest.minimap.zoom_level`. Passe
+   `applyZoom = !mouseOverRadar` à la caméra.
+4. **`QuestImGuiRenderer::RenderMinimap`** — dessine l'arc + 5 repères + poignée +
+   valeur numérique à partir du cran courant (fourni par Engine via un setter,
+   ex. `SetZoomIndex(int)`), en réutilisant `ComputeRadarScreenRect`.
+5. **`OrbitalCameraController::Update`** — nouveau paramètre `bool applyZoom`
+   (défaut true) : ignore la molette si false.
+
+## Config
+- `client.quest.minimap.zoom_level` : int 0-4, défaut 2 (600 m). Lu au boot,
+  persisté dans `user_settings.json` (persistance ciblée, comme `client.locale`).
+
+## Tests
+- `MinimapZoom` : clamp bornes (idx < 0, idx > 4), step molette (in/out + clamp),
+  mapping index→rayon (0→200 … 4→1000).
+- `ComputeRadarScreenRect` : coin + taille pour un viewport donné + `size_px`
+  config ; radar désactivé (`minimap.enabled=false`) → rect vide/no-op.
+
+## Périmètre / déploiement
+100% **client**. Aucun serveur, aucun wire, pas de redéploiement. Fichiers touchés :
+`QuestImGuiRenderer.{h,cpp}`, `Engine.cpp`, `Camera.{h,cpp}`, nouveau
+`MinimapZoom` + tests, `user_settings` persistance.
+
+## Hors périmètre (YAGNI)
+- Pas de zoom continu (5 crans discrets seulement).
+- Pas de panoramique (le radar reste centré joueur).
+- Pas de zoom par cran configurable au-delà des 5 valeurs fixées.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -859,6 +859,13 @@ namespace engine
 			if (cfg.LoadFromFile("character_appearance.json"))
 				LOG_INFO(Core, "[Boot] character_appearance.json applique (genre avatar persistant)");
 
+			// Zoom radar minimap (client.quest.minimap.zoom_level) : fichier dedie
+			// minimap_settings.json, ecrit au changement de zoom (molette/clic sur le
+			// radar). Meme logique que keybinds.json (un echec ne corrompt jamais
+			// user_settings.json).
+			if (cfg.LoadFromFile("minimap_settings.json"))
+				LOG_INFO(Core, "[Boot] minimap_settings.json applique (zoom radar persistant)");
+
 			engine::core::Config persisted;
 			if (!persisted.LoadFromFile("user_settings.json"))
 			{
@@ -1532,11 +1539,12 @@ namespace engine
 				LOG_WARN(Core, "[Boot] QuestPoiTable load FAILED — pas de marqueurs de POI sur la minimap");
 			}
 			m_questUi.SetPoiTable(&m_questPoiTable);
-			const float minimapRadiusM = static_cast<float>(m_cfg.GetDouble("client.quest.minimap.radius_m", 60.0));
-			if (minimapRadiusM > 0.0f)
-			{
-				m_questUi.SetMinimapRadius(minimapRadiusM);
-			}
+			// Zoom radar : cran persistant (0..4 -> 200..1000 m) ; défaut 600 m.
+			// Remplace l'ancien rayon fixe client.quest.minimap.radius_m.
+			m_minimapZoomIndex = engine::client::ClampZoomIndex(
+				static_cast<int>(m_cfg.GetInt("client.quest.minimap.zoom_level",
+					engine::client::kMinimapZoomDefaultIndex)));
+			m_questUi.SetMinimapRadius(engine::client::RadiusForZoomIndex(m_minimapZoomIndex));
 		}
 
 		// CMANGOS.18 (Phase 3.18 step 4) — Init du presenter Mail. Doit etre
@@ -9932,8 +9940,68 @@ namespace engine
 					}
 				}
 
+				// --- Zoom radar minimap (molette + clic sur l'arc). Si le curseur
+				// survole le radar (disque + anneau des repères), la molette pilote le
+				// zoom du radar (5 crans 200..1000 m) au lieu du zoom caméra, et le clic
+				// sur un repère saute à ce cran. Géométrie via ComputeRadarScreenRect
+				// (m_width/m_height = taille framebuffer = io.DisplaySize du radar, donc
+				// même géométrie qu'au rendu). Cran persisté dans minimap_settings.json.
+				bool mouseOverRadar = false;
+				{
+					const engine::client::RadarScreenRect radarRect =
+						engine::client::ComputeRadarScreenRect(m_cfg,
+							static_cast<float>(m_width), static_cast<float>(m_height));
+					if (radarRect.enabled)
+					{
+						const float rcx = radarRect.x0 + radarRect.size * 0.5f;
+						const float rcy = radarRect.y0 + radarRect.size * 0.5f;
+						// Zone d'interaction = disque + marge couvrant l'anneau des repères
+						// (tracés à R+6). Sans cette marge, un clic sur un repère (hors du
+						// disque) ne serait jamais détecté.
+						const float interactR = radarRect.size * 0.5f + 16.0f;
+						const float mdx = static_cast<float>(m_input.MouseX()) - rcx;
+						const float mdy = static_cast<float>(m_input.MouseY()) - rcy;
+						mouseOverRadar = (mdx * mdx + mdy * mdy) <= (interactR * interactR);
+						if (mouseOverRadar)
+						{
+							int newZoom = m_minimapZoomIndex;
+							const int wheel = m_input.MouseScrollDelta();
+							if (wheel != 0)
+								newZoom = engine::client::StepZoomIndex(newZoom, wheel);
+							if (m_input.WasMousePressed(engine::platform::MouseButton::Left))
+							{
+								constexpr float kTickHitRadiusPx = 12.0f;
+								for (int t = 0; t < engine::client::kMinimapZoomLevelCount; ++t)
+								{
+									const engine::client::ScreenPoint tp =
+										engine::client::RadarZoomTickPos(radarRect, t);
+									const float tdx = static_cast<float>(m_input.MouseX()) - tp.x;
+									const float tdy = static_cast<float>(m_input.MouseY()) - tp.y;
+									if ((tdx * tdx + tdy * tdy) <= (kTickHitRadiusPx * kTickHitRadiusPx))
+									{
+										newZoom = t;
+										break;
+									}
+								}
+							}
+							if (newZoom != m_minimapZoomIndex)
+							{
+								m_minimapZoomIndex = newZoom;
+								m_questUi.SetMinimapRadius(engine::client::RadiusForZoomIndex(newZoom));
+								engine::core::Config zoomCfg;
+								zoomCfg.SetValue("client.quest.minimap.zoom_level", static_cast<int64_t>(newZoom));
+								if (!zoomCfg.SaveToFile("minimap_settings.json"))
+									LOG_WARN(Core, "[Minimap] echec persistance zoom (minimap_settings.json)");
+								else
+									LOG_INFO(Core, "[Minimap] zoom radar -> cran {} ({} m)",
+										newZoom, engine::client::RadiusForZoomIndex(newZoom));
+							}
+						}
+					}
+				}
+
 				const bool rmbLook = m_input.IsMouseDown(engine::platform::MouseButton::Right);
-				m_orbitalCameraController.Update(m_input, dt, mouseSensitivity, invertY, rmbLook, out.camera);
+				m_orbitalCameraController.Update(m_input, dt, mouseSensitivity, invertY, rmbLook, !mouseOverRadar, out.camera);
 
 				// --- Clamp anti-sous-sol : la caméra ne descend pas sous le terrain. ---
 				const bool occEnabled = m_cfg.GetBool("client.camera.occlusion_fade.enabled", true);
@@ -10594,6 +10662,7 @@ namespace engine
 			if (m_questImGui)
 			{
 				m_questImGui->SetGiverPanelSuppressed(m_dialogue.IsActive());
+				m_questImGui->SetMinimapZoomIndex(m_minimapZoomIndex);
 				m_questImGui->Render(dw, dh, m_authUi.IsInWorldShard(), !m_hudMapClusterHidden);
 			}
 			// Marqueurs ImGui des interactibles : label flottant projete (visibilite v1

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -1377,6 +1377,12 @@ namespace engine
 		/// Retour joueur : pouvoir « boucher » ces overlays. Journal + panneau
 		/// donneur non concernés (interactifs). Faux par défaut (HUD visible).
 		bool                                  m_hudMapClusterHidden = false;
+		/// Cran de zoom du radar minimap (0..4 -> 200/400/600/800/1000 m, cf.
+		/// engine::client::kMinimapZoomLevelsM). Chargé de client.quest.minimap.zoom_level
+		/// au boot (défaut 600 m), modifié par la molette/clic sur le radar, persisté
+		/// dans minimap_settings.json. Le rayon effectif est poussé au presenter via
+		/// SetMinimapRadius.
+		int                                   m_minimapZoomIndex = 2;
 		/// SP-D — Renderer ImGui du panneau arbre de compétences.
 		/// Forward-déclaré dans Engine.h (ClassSkillTreeImGuiRenderer).
 		std::unique_ptr<engine::render::ClassSkillTreeImGuiRenderer> m_classSkillTreeImGui;

--- a/src/client/quest/QuestUi.cpp
+++ b/src/client/quest/QuestUi.cpp
@@ -42,6 +42,67 @@ namespace engine::client
 		return status == 2u || status == 3u;
 	}
 
+	int ClampZoomIndex(int index)
+	{
+		if (index < 0)
+			return 0;
+		if (index >= kMinimapZoomLevelCount)
+			return kMinimapZoomLevelCount - 1;
+		return index;
+	}
+
+	int StepZoomIndex(int index, int wheelDelta)
+	{
+		// Molette vers le haut (wheelDelta > 0) = zoom IN = rayon plus petit =
+		// index décroît (même convention que le zoom caméra).
+		return ClampZoomIndex(index - wheelDelta);
+	}
+
+	float RadiusForZoomIndex(int index)
+	{
+		return kMinimapZoomLevelsM[ClampZoomIndex(index)];
+	}
+
+	RadarScreenRect ComputeRadarScreenRect(const engine::core::Config& cfg,
+		float displayW, float displayH)
+	{
+		(void)displayH;
+		RadarScreenRect rect{};
+		rect.enabled = cfg.GetBool("client.quest.minimap.enabled", true);
+		const float sizePx = static_cast<float>(cfg.GetInt("client.quest.minimap.size_px", 200));
+		if (!rect.enabled || sizePx <= 0.0f)
+		{
+			rect.enabled = false;
+			return rect;
+		}
+		// Ancrage IDENTIQUE à QuestImGuiRenderer::RenderMinimap : coin haut-droit,
+		// sous le HUD météo + la boussole (marge 16 + dégagement haut 116 + 8 px).
+		// Ces constantes DOIVENT rester synchronisées avec RenderMinimap (qui utilise
+		// désormais ce même helper) sous peine de dérive géométrie rendu/hit-test.
+		constexpr float kMargin = 16.0f;
+		constexpr float kTopHudClearancePx = 116.0f;
+		rect.size = sizePx;
+		rect.x0 = displayW - sizePx - kMargin;
+		rect.y0 = kMargin + kTopHudClearancePx + 8.0f;
+		return rect;
+	}
+
+	ScreenPoint RadarZoomTickPos(const RadarScreenRect& rect, int tickIndex)
+	{
+		const int k = ClampZoomIndex(tickIndex);
+		const float cx = rect.x0 + rect.size * 0.5f;
+		const float cy = rect.y0 + rect.size * 0.5f;
+		const float rArc = rect.size * 0.5f + 6.0f; // juste à l'extérieur de la bordure
+		constexpr float kDegToRad = 3.14159265f / 180.0f;
+		// 150° (haut-gauche) -> 30° (haut-droite), 30° entre chaque repère. Repère
+		// écran : y vers le bas, donc +sin(theta) monte (d'où le -sin sur y).
+		const float theta = (150.0f - 30.0f * static_cast<float>(k)) * kDegToRad;
+		ScreenPoint p;
+		p.x = cx + rArc * std::cos(theta);
+		p.y = cy - rArc * std::sin(theta);
+		return p;
+	}
+
 	namespace
 	{
 		/// Trim spaces and tabs from both ends of one text view.

--- a/src/client/quest/QuestUi.h
+++ b/src/client/quest/QuestUi.h
@@ -33,6 +33,61 @@ namespace engine::client
 	/// (cf. `QuestStatus` dans `QuestRuntime.h`). Fonction pure, testable directement.
 	bool ShouldShowQuestInJournal(uint8_t status);
 
+	// --- Contrôle de zoom du radar minimap (cf. spec 2026-07-08) ---
+
+	/// Nombre de crans de zoom du radar.
+	inline constexpr int kMinimapZoomLevelCount = 5;
+	/// Rayons affichés par cran (mètres, centre joueur -> bord). Index 0 = le plus
+	/// zoomé (200 m), index 4 = le plus large (1000 m).
+	inline constexpr float kMinimapZoomLevelsM[kMinimapZoomLevelCount] =
+		{ 200.0f, 400.0f, 600.0f, 800.0f, 1000.0f };
+	/// Cran par défaut (600 m).
+	inline constexpr int kMinimapZoomDefaultIndex = 2;
+
+	/// Borne un index de cran dans [0, kMinimapZoomLevelCount-1]. Pure/testable.
+	int ClampZoomIndex(int index);
+
+	/// Applique une rotation de molette à un index de cran. \p wheelDelta > 0
+	/// (molette vers le haut) = zoom IN (rayon plus petit, index décroît), comme
+	/// le zoom caméra. Retourne l'index borné. Pure/testable.
+	int StepZoomIndex(int index, int wheelDelta);
+
+	/// Rayon affiché (mètres) pour un index de cran (borné). Pure/testable.
+	float RadiusForZoomIndex(int index);
+
+	/// Géométrie écran du radar minimap (coin haut-gauche + taille du cadre carré,
+	/// pixels). \c enabled reflète `client.quest.minimap.enabled`. Partagée entre
+	/// le rendu (arc/repères/POI) et le hit-test souris (Engine) pour éviter toute
+	/// dérive de géométrie.
+	struct RadarScreenRect
+	{
+		bool  enabled = false;
+		float x0 = 0.0f;
+		float y0 = 0.0f;
+		float size = 0.0f;
+	};
+
+	/// Calcule la géométrie écran du radar depuis la config et le viewport.
+	/// Ancrage : coin haut-droit, sous le bandeau météo (cf. RenderMinimap). Pure
+	/// (aucune dépendance ImGui), testable. \c enabled = false (et size = 0) si le
+	/// radar est désactivé ou `size_px <= 0`.
+	RadarScreenRect ComputeRadarScreenRect(const engine::core::Config& cfg,
+		float displayW, float displayH);
+
+	/// Point écran (pixels).
+	struct ScreenPoint
+	{
+		float x = 0.0f;
+		float y = 0.0f;
+	};
+
+	/// Position écran du repère de zoom d'index \p tickIndex (0..4) sur l'arc de la
+	/// moitié haute du radar. Les 5 repères s'étalent de 150° (haut-gauche, index 0
+	/// = 200 m) à 30° (haut-droite, index 4 = 1000 m), juste à l'extérieur de la
+	/// bordure du radar. Partagée entre le rendu (dessin des repères) et le hit-test
+	/// du clic (Engine). Pure/testable. \p rect doit être `enabled`.
+	ScreenPoint RadarZoomTickPos(const RadarScreenRect& rect, int tickIndex);
+
 	/// Pixel-space rectangle used by the quest UI presenter layout.
 	struct QuestUiRect
 	{

--- a/src/client/quest/QuestUiRadarTests.cpp
+++ b/src/client/quest/QuestUiRadarTests.cpp
@@ -10,6 +10,13 @@
 
 using engine::client::ShouldShowQuestInJournal;
 using engine::client::WorldToRadarUv;
+using engine::client::ClampZoomIndex;
+using engine::client::StepZoomIndex;
+using engine::client::RadiusForZoomIndex;
+using engine::client::ComputeRadarScreenRect;
+using engine::client::RadarZoomTickPos;
+using engine::client::RadarScreenRect;
+using engine::client::ScreenPoint;
 
 namespace
 {
@@ -97,6 +104,64 @@ int main()
 		Check(ShouldShowQuestInJournal(2u), "Active(2) -> dans le journal");
 		Check(ShouldShowQuestInJournal(3u), "ReadyToTurnIn(3) -> dans le journal");
 		Check(!ShouldShowQuestInJournal(4u), "Completed(4) -> pas dans le journal (rendue)");
+	}
+
+	// --- Contrôle de zoom du radar (helpers purs) ---
+	// ClampZoomIndex borne [0, 4].
+	Check(ClampZoomIndex(-3) == 0, "ClampZoomIndex(-3)==0");
+	Check(ClampZoomIndex(0) == 0, "ClampZoomIndex(0)==0");
+	Check(ClampZoomIndex(4) == 4, "ClampZoomIndex(4)==4");
+	Check(ClampZoomIndex(9) == 4, "ClampZoomIndex(9)==4 (clamp haut)");
+
+	// RadiusForZoomIndex : 0->200 … 4->1000 (clamp hors borne).
+	Check(NearlyEqual(RadiusForZoomIndex(0), 200.0f), "zoom 0 -> 200 m");
+	Check(NearlyEqual(RadiusForZoomIndex(2), 600.0f), "zoom 2 -> 600 m (defaut)");
+	Check(NearlyEqual(RadiusForZoomIndex(4), 1000.0f), "zoom 4 -> 1000 m");
+	Check(NearlyEqual(RadiusForZoomIndex(99), 1000.0f), "zoom hors borne -> 1000 m (clamp)");
+
+	// StepZoomIndex : molette haut (>0) = zoom IN = index decroit ; clamp.
+	Check(StepZoomIndex(2, 1) == 1, "step +1 depuis 2 -> 1 (zoom in)");
+	Check(StepZoomIndex(2, -1) == 3, "step -1 depuis 2 -> 3 (zoom out)");
+	Check(StepZoomIndex(0, 1) == 0, "step +1 depuis 0 -> 0 (clamp min)");
+	Check(StepZoomIndex(4, -1) == 4, "step -1 depuis 4 -> 4 (clamp max)");
+	Check(StepZoomIndex(4, 2) == 2, "step +2 depuis 4 -> 2 (multi-cran)");
+
+	// ComputeRadarScreenRect : coin haut-droit, sous le degagement HUD.
+	{
+		engine::core::Config cfg;
+		cfg.SetDefault("client.quest.minimap.enabled", true);
+		cfg.SetDefault("client.quest.minimap.size_px", static_cast<int64_t>(200));
+		const RadarScreenRect r = ComputeRadarScreenRect(cfg, 1280.0f, 720.0f);
+		Check(r.enabled, "radar rect enabled");
+		Check(NearlyEqual(r.size, 200.0f), "radar size == size_px");
+		Check(NearlyEqual(r.x0, 1280.0f - 200.0f - 16.0f), "radar x0 = W - size - marge");
+		Check(NearlyEqual(r.y0, 16.0f + 116.0f + 8.0f), "radar y0 = marge + degagement + 8");
+	}
+	{
+		engine::core::Config cfg;
+		cfg.SetDefault("client.quest.minimap.enabled", false);
+		cfg.SetDefault("client.quest.minimap.size_px", static_cast<int64_t>(200));
+		const RadarScreenRect r = ComputeRadarScreenRect(cfg, 1280.0f, 720.0f);
+		Check(!r.enabled, "radar desactive -> rect non enabled");
+	}
+
+	// RadarZoomTickPos : repères sur la moitié haute, symétriques, au-dessus du centre.
+	{
+		RadarScreenRect r;
+		r.enabled = true;
+		r.x0 = 100.0f;
+		r.y0 = 100.0f;
+		r.size = 200.0f;
+		const float cx = r.x0 + r.size * 0.5f; // 200
+		const float cy = r.y0 + r.size * 0.5f; // 200
+		const ScreenPoint t0 = RadarZoomTickPos(r, 0); // gauche
+		const ScreenPoint t2 = RadarZoomTickPos(r, 2); // haut-centre
+		const ScreenPoint t4 = RadarZoomTickPos(r, 4); // droite
+		Check(t0.x < cx, "repere 0 a gauche du centre");
+		Check(t4.x > cx, "repere 4 a droite du centre");
+		Check(NearlyEqual(t2.x, cx, 0.01f), "repere 2 centre en x (haut)");
+		Check(t0.y < cy && t2.y < cy && t4.y < cy, "tous les reperes au-dessus du centre");
+		Check(NearlyEqual(t0.x - cx, -(t4.x - cx), 0.01f), "reperes 0 et 4 symetriques en x");
 	}
 
 	if (g_failures != 0)

--- a/src/client/render/Camera.cpp
+++ b/src/client/render/Camera.cpp
@@ -179,7 +179,7 @@ namespace engine::render
 	}
 
 	void OrbitalCameraController::Update(engine::platform::Input& input, double dt, float mouseSensitivityRadPerPixel,
-		bool invertY, bool applyMouseLook, Camera& camera)
+		bool invertY, bool applyMouseLook, bool applyZoom, Camera& camera)
 	{
 		(void)dt; // Plus de logique d'integration temporelle ici (mouvement delegue a CharacterController).
 
@@ -202,8 +202,9 @@ namespace engine::render
 			if (camera.pitch > kPitchMax) camera.pitch = kPitchMax;
 		}
 
-		// Molette -> zoom in/out (modifie distance camera-cible).
-		const int scroll = input.MouseScrollDelta();
+		// Molette -> zoom in/out (modifie distance camera-cible). Coupe si applyZoom
+		// est faux (ex. curseur sur le radar minimap, qui capte la molette).
+		const int scroll = applyZoom ? input.MouseScrollDelta() : 0;
 		if (scroll != 0)
 		{
 			m_distance -= static_cast<float>(scroll) * kZoomStep;

--- a/src/client/render/Camera.h
+++ b/src/client/render/Camera.h
@@ -136,8 +136,10 @@ namespace engine::render
 		///
 		/// \p applyMouseLook : false coupe yaw/pitch (ex. quand le clic droit
 		/// est requis et absent, ou qu'ImGui capte la souris).
+		/// \p applyZoom : false coupe le zoom molette (ex. quand le curseur survole
+		/// le radar minimap, qui capte alors la molette pour son propre zoom).
 		void Update(engine::platform::Input& input, double dt, float mouseSensitivityRadPerPixel,
-		            bool invertY, bool applyMouseLook, Camera& camera);
+		            bool invertY, bool applyMouseLook, bool applyZoom, Camera& camera);
 
 	private:
 		engine::math::Vec3 m_target{ 0.0f, 0.0f, 0.0f };

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -261,33 +261,23 @@ namespace engine::render
 		// taille pixels du cadre carre (client.quest.minimap.size_px, defaut 200).
 		// m_cfg est non-null : invariant maintenu par l'unique appelant BindQuestUi
 		// (les 4 pointeurs sont liés ensemble ; Render() vérifie les 3 autres).
-		const bool enabled = m_cfg->GetBool("client.quest.minimap.enabled", true);
-		if (!enabled)
-			return;
-
 		const engine::client::QuestUiState& state = m_presenter->GetState();
 		if (!state.layoutValid)
 			return;
 
-		const float sizePx = static_cast<float>(m_cfg->GetInt("client.quest.minimap.size_px", 200));
-		if (sizePx <= 0.0f)
+		// Géométrie du radar partagée avec le hit-test Engine (molette/clic de zoom)
+		// via ComputeRadarScreenRect -> zéro dérive rendu/interaction. `enabled` et
+		// `size_px` (config) sont résolus dans le helper. Ancrage : coin haut-droit,
+		// sous le HUD météo + la boussole (cf. helper).
+		const ImGuiIO& io = ImGui::GetIO();
+		const engine::client::RadarScreenRect rect =
+			engine::client::ComputeRadarScreenRect(*m_cfg, io.DisplaySize.x, io.DisplaySize.y);
+		if (!rect.enabled)
 			return;
 
-		// Ancrage : coin haut-droit de l'ecran, marge fixe. Le presenter expose
-		// bien `minimapBounds` (layout), mais celui-ci est dimensionne pour
-		// l'ancien rendu texture de zone (SP1/SP2) — le radar schematique SP3
-		// utilise son propre cadre carre pilote par la config, pour eviter de
-		// re-toucher RebuildLayout ici (hors perimetre Task 3).
-		const ImGuiIO& io = ImGui::GetIO();
-		const float margin = 16.0f;
-		// SP3 — la minimap s'ancre en haut-droite, MAIS ce coin est déjà occupé par
-		// le HUD météo (WeatherImGuiRenderer, ~240x70 à y=margin) ET la boussole
-		// (CompassHud, disque + arc jusqu'à ~y122). On empile donc la minimap SOUS
-		// ces deux éléments pour éviter le chevauchement de pixels (retour joueur
-		// 2026-07-04 : le radar chevauchait la boussole).
-		const float topHudClearancePx = 116.0f;
-		const float x0 = io.DisplaySize.x - sizePx - margin;
-		const float y0 = margin + topHudClearancePx + 8.0f;
+		const float sizePx = rect.size;
+		const float x0 = rect.x0;
+		const float y0 = rect.y0;
 		const float x1 = x0 + sizePx;
 		const float y1 = y0 + sizePx;
 		const ImVec2 center((x0 + x1) * 0.5f, (y0 + y1) * 0.5f);
@@ -350,6 +340,47 @@ namespace engine::render
 				ImVec2(p.x - 5.0f, p.y + 5.0f),
 				ImVec2(p.x + 5.0f, p.y + 5.0f),
 				playerColor);
+		}
+
+		// --- Contrôle de zoom : arc sur la moitié haute du radar, 5 repères (gauche
+		// = 200 m … droite = 1000 m), cran courant surligné, valeur numérique en haut.
+		// Piloté par Engine (molette + clic, cf. SetMinimapZoomIndex) ; ici on dessine
+		// seulement. Géométrie via RadarZoomTickPos (partagée avec le hit-test Engine).
+		{
+			const int zoomIdx = engine::client::ClampZoomIndex(m_minimapZoomIndex);
+			const ImU32 arcCol = IM_COL32(120, 130, 150, 180);
+			const ImU32 tickCol = IM_COL32(150, 160, 180, 220);
+			const ImU32 activeCol = LnTheme::ToU32(LnTheme::kAccent);
+			// Arc reliant les repères (polyligne), tracé d'abord.
+			ImVec2 prevTick{};
+			for (int t = 0; t < engine::client::kMinimapZoomLevelCount; ++t)
+			{
+				const engine::client::ScreenPoint sp = engine::client::RadarZoomTickPos(rect, t);
+				const ImVec2 cur(sp.x, sp.y);
+				if (t > 0)
+					dl->AddLine(prevTick, cur, arcCol, 2.0f);
+				prevTick = cur;
+			}
+			// Repères par-dessus l'arc ; cran courant plus gros + teinte accent.
+			for (int t = 0; t < engine::client::kMinimapZoomLevelCount; ++t)
+			{
+				const engine::client::ScreenPoint sp = engine::client::RadarZoomTickPos(rect, t);
+				const ImVec2 cur(sp.x, sp.y);
+				if (t == zoomIdx)
+				{
+					dl->AddCircleFilled(cur, 5.5f, activeCol);
+					dl->AddCircle(cur, 5.5f, IM_COL32(255, 255, 255, 230), 12, 1.5f);
+				}
+				else
+				{
+					dl->AddCircleFilled(cur, 3.0f, tickCol);
+				}
+			}
+			// Valeur numérique du cran courant (« 600 m »), centrée en haut du radar.
+			const std::string zoomText =
+				std::to_string(static_cast<int>(engine::client::RadiusForZoomIndex(zoomIdx))) + " m";
+			const ImVec2 zts = ImGui::CalcTextSize(zoomText.c_str());
+			dl->AddText(ImVec2(center.x - zts.x * 0.5f, y0 + 3.0f), tickCol, zoomText.c_str());
 		}
 	}
 

--- a/src/client/render/QuestImGuiRenderer.h
+++ b/src/client/render/QuestImGuiRenderer.h
@@ -55,6 +55,11 @@ namespace engine::render
 		/// pour un donneur sans arbre de dialogue. Positionné par Engine chaque frame.
 		void SetGiverPanelSuppressed(bool suppressed) { m_giverPanelSuppressed = suppressed; }
 
+		/// Renseigne le cran de zoom courant du radar (0..4). Engine le possède
+		/// (molette/clic + persistance) ; le renderer ne fait que dessiner l'arc et
+		/// le repère surligné. Borné par \ref engine::client::ClampZoomIndex au rendu.
+		void SetMinimapZoomIndex(int index) { m_minimapZoomIndex = index; }
+
 		/// Émet les commandes ImGui pour la frame courante. Suppose que
 		/// \c m_worldEditorImGui->NewFrame a déjà été appelé.
 		/// No-op si le presenter n'est pas bindé.
@@ -91,5 +96,6 @@ namespace engine::render
 		const engine::core::Config*              m_cfg = nullptr;
 		GiverActionCallback m_giverAction;
 		bool m_giverPanelSuppressed = false;
+		int m_minimapZoomIndex = 2; ///< Cran de zoom radar (défaut 600 m), poussé par Engine.
 	};
 }


### PR DESCRIPTION
Feature demandée (design validé 2026-07-08, spec dans `docs/superpowers/specs/2026-07-08-minimap-zoom-design.md`).

## Comportement
- **5 crans** de rayon affiché : 200 / 400 / 600 / 800 / 1000 m. Défaut **600 m**, **mémorisé**.
- **Molette au-dessus du radar** → zoom in/out d'un cran. La molette pilotant déjà le zoom **caméra**, on le **coupe** quand le curseur survole le radar (nouveau `OrbitalCameraController::Update(..., applyZoom, ...)`).
- **Clic sur un des 5 repères** de l'arc → saut direct au cran.
- Persistance : `minimap_settings.json` (fichier **dédié**, comme `keybinds.json` → ne corrompt jamais `user_settings.json`), rechargé au boot.

## Visuel
Arc + 5 repères sur la **moitié haute** du radar (gauche 200 m … droite 1000 m), cran courant **surligné** (teinte accent), **valeur numérique** (« 600 m ») en haut du radar.

## Architecture (isolée + testée)
- **Helpers purs** (`QuestUi.{h,cpp}`, testés dans `QuestUiRadarTests`) : `ClampZoomIndex` / `StepZoomIndex` / `RadiusForZoomIndex`, `ComputeRadarScreenRect` (géométrie écran **partagée** rendu ↔ hit-test → zéro dérive), `RadarZoomTickPos`.
- `RenderMinimap` refactoré pour utiliser `ComputeRadarScreenRect` + dessiner l'arc.
- `Engine` : possède le cran, gère molette+clic (hit-test même géométrie), pousse le rayon (`SetMinimapRadius`), persiste.
- `Camera` : gate `applyZoom`.

Remplace l'ancien rayon fixe `client.quest.minimap.radius_m` (60 m) par `client.quest.minimap.zoom_level` (défaut 2 = 600 m).

## Note
⚠️ Conséquence voulue : le radar par défaut (600 m) montre une zone **bien plus large** qu'avant (60 m) — les mobs proches sont près du centre. C'est le comportement demandé ; molette pour re-zoomer à 200 m.

## À tester en jeu
- Molette sur le radar → zoom change (la caméra ne zoome plus quand on est sur le radar).
- Clic sur un repère → saut de cran ; valeur « X m » à jour.
- Relancer le jeu → le dernier cran est conservé.

## Déploiement
> **✅ CLIENT uniquement.** Aucun serveur, aucun wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)