### PR TITLE
fix(input): les touches 1-5 (barre d'action) ne basculent plus les filtres de canaux chat

### DIFF
--- a/src/client/chat/ChatUi.cpp
+++ b/src/client/chat/ChatUi.cpp
@@ -150,27 +150,37 @@ namespace engine::client
 				LOG_INFO(Core, "[ChatUiPresenter] Chat focus ON (toggle=Slash/Enter)");
 			}
 
-			for (uint32_t ch = 0; ch < 10; ++ch)
+			// Bascule des filtres de canaux par CTRL + chiffre (1..0). Le modificateur
+			// Ctrl est OBLIGATOIRE : sans lui, les touches 1..0 nues sont réservées à la
+			// BARRE D'ACTION (lancement des sorts, Engine slotKey Digit1..Digit0). Sans ce
+			// garde, presser 1-5 pour lancer un pouvoir basculait aussi les filtres de
+			// canaux (chat non focus) — retour joueur 2026-07-08. Les filtres restent aussi
+			// commutables au clic dans l'UI du chat (ToggleChannelFilter).
+			if (input.IsDown(engine::platform::Key::Control))
 			{
-				const engine::platform::Key digitKeys[10] = {
-					engine::platform::Key::Digit1,
-					engine::platform::Key::Digit2,
-					engine::platform::Key::Digit3,
-					engine::platform::Key::Digit4,
-					engine::platform::Key::Digit5,
-					engine::platform::Key::Digit6,
-					engine::platform::Key::Digit7,
-					engine::platform::Key::Digit8,
-					engine::platform::Key::Digit9,
-					engine::platform::Key::Digit0
-				};
-				if (input.WasPressed(digitKeys[ch]))
+				for (uint32_t ch = 0; ch < 10; ++ch)
 				{
-					const uint32_t bit = 1u << ch;
-					m_channelFilterMask ^= static_cast<uint16_t>(bit);
-					LOG_INFO(Core, "[ChatUiPresenter] Channel filter toggled (channel_index={}, mask=0x{:04X})",
-						ch,
-						m_channelFilterMask);
+					const engine::platform::Key digitKeys[10] = {
+						engine::platform::Key::Digit1,
+						engine::platform::Key::Digit2,
+						engine::platform::Key::Digit3,
+						engine::platform::Key::Digit4,
+						engine::platform::Key::Digit5,
+						engine::platform::Key::Digit6,
+						engine::platform::Key::Digit7,
+						engine::platform::Key::Digit8,
+						engine::platform::Key::Digit9,
+						engine::platform::Key::Digit0
+					};
+					if (input.WasPressed(digitKeys[ch]))
+					{
+						const uint32_t bit = 1u << ch;
+						m_channelFilterMask ^= static_cast<uint16_t>(bit);
+						LOG_INFO(Core, "[ChatUiPresenter] Channel filter toggled (Ctrl+{}, channel_index={}, mask=0x{:04X})",
+							ch + 1u,
+							ch,
+							m_channelFilterMask);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Symptôme (ton log)
En essayant de lancer les 5 premiers pouvoirs (touches **1-5**), le log se remplit de :
```
[ChatUiPresenter] Channel filter toggled (channel_index=0..4, mask=...)
```

## Cause (confirmée code + log)
Deux systèmes écoutent les **mêmes touches 1..0**, tous deux quand le chat n'a **pas** le focus :
- **Barre d'action** → lance les sorts (`Engine` `slotKey` = Digit1..Digit0, gate `keysAllowed`).
- **Chat** → bascule ses 5 filtres de canaux (`ChatUi`, sous `if (!m_chatFocus)`).

Les deux lisent `WasPressed` (non consommant) → chaque appui sur 1-5 **spammait les filtres de canaux** en plus de tenter le sort.

## Fix
La bascule des filtres de canaux exige désormais **Ctrl + chiffre** (Ctrl+1..0). Les touches **1..0 nues** sont laissées à la **barre d'action**. Les filtres restent commutables au clic dans l'UI du chat.

## ⚠️ Important — ceci ne suffit pas à faire « toucher » les pouvoirs
Le cast **part déjà** (les deux handlers voient l'appui). Si un pouvoir ne fait toujours **aucun dégât**, la cause est **côté shard** : `HandleCastRequest` rejette silencieusement (ressource insuffisante / hors de portée / cooldown / **sort hors du kit du profil**) et logge la raison exacte **dans le log du shard** (`SP-C CastRequest ignored: …`), pas dans le client. **J'ai besoin de ce log shard** pour corriger le #2.

## Déploiement
> **✅ CLIENT uniquement** pour ce fix d'input. (Le #2 « pouvoirs sans dégât » sera vraisemblablement shard.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)