### PR TITLE
fix(net): ne plus traiter Spawn/Despawn/amis comme 'unsupported message kind'

### DIFF
--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -637,6 +637,27 @@ namespace engine::client
 		// Validation v12 — butin auto-crédité à la mort d'un mob.
 		case engine::server::MessageKind::LootNotify:
 			return ApplyLootNotify(packet);
+		// Spawn (5) / Despawn (6) : le client reconstruit l'ENSEMBLE des entités de
+		// l'AoI depuis chaque Snapshot complet (cf. ApplySnapshot) ; ces messages
+		// incrémentaux de cycle de vie sont donc redondants ici. No-op silencieux
+		// (au lieu du faux « unsupported message kind » qui polluait le log —
+		// retour joueur 2026-07-08). Une entité tuée/sortie de l'AoI disparaît
+		// naturellement au snapshot suivant.
+		case engine::server::MessageKind::Spawn:
+		case engine::server::MessageKind::Despawn:
+			return true;
+		// Amis (FriendListSync=23, FriendStatusUpdate=24) : le presenter FriendsUi
+		// existe (ApplyFriendList / ApplyStatusUpdate) mais n'est PAS encore monté
+		// dans Engine — la liste d'amis n'a donc aucun consommateur côté client. On
+		// accepte le message sans le traiter (au lieu du faux « unsupported ») et on
+		// le signale comme FONCTIONNALITÉ DIFFÉRÉE.
+		// TODO(friends) : monter FriendsUi (instancier + décoder FriendListSync/
+		// FriendStatusUpdate + ApplyFriendList/ApplyStatusUpdate + rendu + touche).
+		case engine::server::MessageKind::FriendListSync:
+		case engine::server::MessageKind::FriendStatusUpdate:
+			LOG_INFO(Net, "[UIModelBinding] Message amis kind {} recu — panneau FriendsUi non monte (differe)",
+				static_cast<uint16_t>(kind));
+			return true;
 		default:
 			LOG_WARN(Net, "[UIModelBinding] ApplyPacket ignored: unsupported message kind {}", static_cast<uint16_t>(kind));
 			return false;


### PR DESCRIPTION
## Anomalie (ton log)
Le client jetait en boucle :
```
ApplyPacket ignored: unsupported message kind 5   (×16 à l'entrée)
ApplyPacket ignored: unsupported message kind 6   (à chaque kill)
ApplyPacket ignored: unsupported message kind 23  (×1)
```

## Identification + fix
- **5 = `Spawn`, 6 = `Despawn`** : le client reconstruit **toutes** les entités de l'AoI depuis chaque **Snapshot complet** → ces messages incrémentaux sont **redondants**. Désormais **no-op explicite** (plus de faux WARN). *(16× à l'entrée = 16 entités ; « kind 6 » = despawn après chaque kill.)*
- **23 = `FriendListSync`, 24 = `FriendStatusUpdate`** : le presenter `FriendsUi` (`ApplyFriendList`/`ApplyStatusUpdate`) **et** le décodage (`DecodeFriendListSync`) existent, **mais `FriendsUi` n'est jamais monté dans Engine** → la liste d'amis est une **feature morte** côté client. Le message est désormais accepté et **loggé comme différé** (INFO) au lieu du faux « unsupported ». `TODO(friends)` posé.

## Effet
Retire le bruit de log + la fausse impression de messages non supportés. **Aucun changement de comportement de jeu** (entités déjà gérées par le Snapshot ; amis toujours non montés, mais explicitement).

## Suite possible
Monter le **panneau amis** complet (instancier `FriendsUi` + décoder + rendre + touche) — feature à part si tu veux.

## Déploiement
> **✅ CLIENT uniquement.** Aucun wire, pas de redéploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)