### PR TITLE
polish(quest): radar/tracker suivent la quête sélectionnée + radar sans texte + fin du chevauchement

### DIFF
--- a/src/client/quest/QuestUi.cpp
+++ b/src/client/quest/QuestUi.cpp
@@ -478,6 +478,10 @@ namespace engine::client
 	void QuestUiPresenter::RebuildTracker(const UIModel& model)
 	{
 		m_state.trackerSteps.clear();
+		// Retour joueur 2026-07-08 : « je ne peux pas choisir ce qu'affiche le suivi ».
+		// Le tracker (comme le radar) ne montre plus QUE la quête SÉLECTIONNÉE dans le
+		// Journal (m_selectedQuestId, tenu à jour par RebuildJournal/SelectQuest). Cela
+		// donne au joueur un contrôle direct : cliquer une autre quête re-cible le suivi.
 		for (const UIQuestEntry& quest : model.quests)
 		{
 			if (quest.status != 2)
@@ -487,21 +491,23 @@ namespace engine::client
 				// Correctif SP3 : l'ancien `!= 1` ne gardait que les Offered.
 				continue;
 			}
+			if (quest.questId != m_selectedQuestId)
+			{
+				// Seule la quête suivie alimente le tracker (choix du joueur).
+				continue;
+			}
 
 			for (const UIQuestStep& step : quest.steps)
 			{
 				QuestStepView view{};
-				view.label = quest.questId + ": " + BuildQuestStepLabel(step);
+				// Une seule quête suivie : plus besoin du préfixe « questId: » (redondant).
+				view.label = BuildQuestStepLabel(step);
 				view.currentCount = step.currentCount;
 				view.requiredCount = step.requiredCount;
 				view.completed = (step.requiredCount > 0 && step.currentCount >= step.requiredCount);
 				m_state.trackerSteps.push_back(std::move(view));
 			}
-
-			if (m_state.trackerSteps.size() >= 4)
-			{
-				break;
-			}
+			break; // quête suivie trouvée et traitée.
 		}
 	}
 
@@ -559,6 +565,12 @@ namespace engine::client
 				// (Locked=0, Offered=1, Active=2, ReadyToTurnIn=3, Completed=4 ;
 				// cf. QuestRuntime.h). Seules les quêtes ACCEPTÉES et EN COURS
 				// affichent des marqueurs de POI (pas Offered/Locked/Completed).
+				continue;
+			}
+			if (quest.questId != m_selectedQuestId)
+			{
+				// Radar aligné sur le tracker : seuls les POI de la quête SUIVIE
+				// (sélectionnée dans le Journal) apparaissent. Choix du joueur.
 				continue;
 			}
 

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -202,20 +202,22 @@ namespace engine::render
 			return;
 
 		// Position : empilé SOUS le radar minimap, coin haut-droit, aligné à droite.
-		// Corrige le chevauchement historique (tracker et radar étaient tous deux
-		// ancrés en haut-droit à y≈marge). On reprend l'ancrage exact de
-		// RenderMinimap (marge 16 + bandeau météo ~78 px + taille radar config)
-		// pour empiler proprement la colonne météo -> radar -> tracker. Si le radar
-		// est désactivé, le tracker remonte juste sous le bandeau météo.
+		// Corrige le chevauchement (retour joueur 2026-07-08 : « collision entre le
+		// suivi de quêtes et le mini radar »). CAUSE : l'ancien calcul recomposait à
+		// la main le bas du radar (16 + 70 + 8 + 200 = 294) alors que le radar réel
+		// descend jusqu'à y0(140) + taille(200) = 340 → le tracker montait ~34 px
+		// trop haut. FIX : on lit le VRAI rectangle du radar via ComputeRadarScreenRect
+		// (même source que RenderMinimap et le hit-test de zoom) → zéro dérive. Si le
+		// radar est désactivé, on retombe sous le dégagement HUD haut (marge + météo).
 		// Cond_Always : le HUD doit suivre résolution/config sans se figer sur une
 		// position imgui.ini périmée (fenêtre NoMove + NoSavedSettings de toute façon).
 		const ImGuiIO& io = ImGui::GetIO();
 		const float trackerMargin = 16.0f;
 		const float weatherHudHeightPx = 70.0f;
-		const bool minimapEnabled = m_cfg->GetBool("client.quest.minimap.enabled", true);
-		const float radarSizePx = static_cast<float>(m_cfg->GetInt("client.quest.minimap.size_px", 200));
-		const float radarBottom = (minimapEnabled && radarSizePx > 0.0f)
-			? (trackerMargin + weatherHudHeightPx + 8.0f + radarSizePx)
+		const engine::client::RadarScreenRect radarRect =
+			engine::client::ComputeRadarScreenRect(*m_cfg, io.DisplaySize.x, io.DisplaySize.y);
+		const float radarBottom = radarRect.enabled
+			? (radarRect.y0 + radarRect.size)
 			: (trackerMargin + weatherHudHeightPx);
 		const float trackerW = state.trackerBounds.width;
 		const float trackerH = state.trackerBounds.height;
@@ -324,10 +326,11 @@ namespace engine::render
 				break; // gris (repli ci-dessus)
 			}
 
+			// Retour joueur 2026-07-08 : « je ne veux que des points colorés dans le
+			// radar, pas de texte ». On ne dessine QUE la pastille teintée par type
+			// d'étape ; le libellé reste disponible dans le tracker/journal.
 			const ImVec2 p(x0 + poi.u * sizePx, y0 + poi.v * sizePx);
 			dl->AddCircleFilled(p, 4.5f, color);
-			if (!poi.label.empty())
-				dl->AddText(ImVec2(p.x + 6.0f, p.y - 6.0f), color, poi.label.c_str());
 		}
 
 		// Marqueur joueur : petit triangle plein au centre du radar (toujours


### PR DESCRIPTION
Lot d'ajustements UI depuis retour joueur 2026-07-08 (capture #1). **100% client.**

## Contenu (items 1-3 du retour)
- **Chevauchement tracker ↔ radar** : `RenderTracker` recomposait à la main le bas du radar (`16+70+8+200=294`) alors que le radar réel descend à `y0(140)+size(200)=340` → le tracker montait ~34 px trop haut → collision visuelle. **Fix** : lit le vrai rectangle via `ComputeRadarScreenRect` (même source que `RenderMinimap` + le hit-test de zoom) → zéro dérive.
- **Radar sans texte** : les POI n'affichent plus leur libellé, seulement la pastille colorée par type d'étape (rouge=tuer, jaune=parler, bleu=entrer, gris=collecter).
- **Choix du suivi** : le tracker ET les points du radar ne montrent plus QUE la quête **sélectionnée dans le Journal** (`m_selectedQuestId`). Cliquer une autre quête re-cible instantanément suivi + radar.

## Déploiement
✅ **client uniquement, pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)