### PR TITLE
feat(currency): monnaie or/argent/bronze (100:1) + bourse repensée

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -64,6 +64,7 @@
 #include "src/client/render/ClassSkillTreeImGuiRenderer.h"
 #include "src/client/render/EditorHubImGuiRenderer.h"
 #include "src/client/gameplay/ActionBarLayout.h"
+#include "src/client/ui_common/CurrencyFormat.h"
 #include "src/client/render/LnTheme.h"
 #include "src/client/render/AuthUiRenderer.h"
 #include "src/client/render/DeferredPipeline.h"
@@ -12317,32 +12318,62 @@ namespace engine
 						}
 					}
 
-					// --- Bourse : pièces d'or du joueur, coin bas-droit. Alimentée par
-					// WalletUpdate (UIModel.wallet.gold), rafraîchie à chaque récompense de
-					// quête ou vente (le serveur pousse SendWalletUpdate). Retour joueur :
-					// « il reçoit de l'or mais aucune bourse pour le suivre ». Non concernée
-					// par la bascule HUD carte (garde la bourse visible en permanence).
+					// --- Bourse : pièces or / argent / bronze du joueur, coin bas-droit.
+					// Alimentée par WalletUpdate (UIModel.wallet.gold), réinterprétée comme
+					// un total en BRONZE (unité de base : 100 bronze = 1 argent, 100 argent
+					// = 1 or ; retour joueur 2026-07-08). Chaque palier = une pastille teintée
+					// + son compte. On masque or/argent tant qu'ils sont nuls (bronze toujours
+					// visible). Non concernée par la bascule HUD carte (bourse toujours visible).
 					{
-						const std::string goldText = "Or : " + std::to_string(uiModel.wallet.gold);
-						const ImVec2 goldTs = ImGui::CalcTextSize(goldText.c_str());
-						const float padX = 10.0f;
+						const engine::client::CoinBreakdown coins =
+							engine::client::SplitCoins(uiModel.wallet.gold);
+						struct CoinTier { uint32_t value; ImU32 fill; ImU32 ring; };
+						std::vector<CoinTier> tiers;
+						if (coins.gold > 0u)
+							tiers.push_back({coins.gold, IM_COL32(240, 200, 70, 255), IM_COL32(180, 140, 30, 255)});
+						if (coins.gold > 0u || coins.silver > 0u)
+							tiers.push_back({coins.silver, IM_COL32(214, 220, 228, 255), IM_COL32(150, 160, 172, 255)});
+						tiers.push_back({coins.bronze, IM_COL32(205, 125, 60, 255), IM_COL32(150, 80, 35, 255)});
+
+						const float padX = 11.0f;
 						const float padY = 6.0f;
-						const float coinR = 5.0f;
-						const float gap = 7.0f;
-						const float pillW = padX * 2.0f + coinR * 2.0f + gap + goldTs.x;
-						const float pillH = padY * 2.0f + std::max(goldTs.y, coinR * 2.0f);
+						const float coinR = 6.0f;
+						const float coinTextGap = 5.0f;
+						const float groupGap = 12.0f;
+						const float textH = ImGui::GetTextLineHeight();
+						std::vector<std::string> labels;
+						labels.reserve(tiers.size());
+						float contentW = 0.0f;
+						for (size_t i = 0; i < tiers.size(); ++i)
+						{
+							labels.push_back(std::to_string(tiers[i].value));
+							const ImVec2 ts = ImGui::CalcTextSize(labels[i].c_str());
+							contentW += coinR * 2.0f + coinTextGap + ts.x;
+							if (i + 1 < tiers.size())
+								contentW += groupGap;
+						}
+						const float pillW = padX * 2.0f + contentW;
+						const float pillH = padY * 2.0f + std::max(textH, coinR * 2.0f);
 						const float bourseMargin = 16.0f;
 						const float px1 = dw - bourseMargin;
 						const float py1 = dh - bourseMargin;
 						const float px0 = px1 - pillW;
 						const float py0 = py1 - pillH;
-						fg->AddRectFilled(ImVec2(px0, py0), ImVec2(px1, py1), IM_COL32(18, 20, 26, 210), 6.0f);
-						fg->AddRect(ImVec2(px0, py0), ImVec2(px1, py1), IM_COL32(120, 100, 40, 220), 6.0f, 0, 1.5f);
-						const ImVec2 coinC(px0 + padX + coinR, (py0 + py1) * 0.5f);
-						fg->AddCircleFilled(coinC, coinR, IM_COL32(240, 200, 70, 255));
-						fg->AddCircle(coinC, coinR, IM_COL32(180, 140, 30, 255), 12, 1.0f);
-						fg->AddText(ImVec2(coinC.x + coinR + gap, (py0 + py1) * 0.5f - goldTs.y * 0.5f),
-							IM_COL32(245, 230, 190, 255), goldText.c_str());
+						const float midY = (py0 + py1) * 0.5f;
+						fg->AddRectFilled(ImVec2(px0, py0), ImVec2(px1, py1), IM_COL32(18, 20, 26, 215), 7.0f);
+						fg->AddRect(ImVec2(px0, py0), ImVec2(px1, py1), IM_COL32(120, 100, 40, 220), 7.0f, 0, 1.5f);
+						float cursorX = px0 + padX;
+						for (size_t i = 0; i < tiers.size(); ++i)
+						{
+							const ImVec2 cc(cursorX + coinR, midY);
+							fg->AddCircleFilled(cc, coinR, tiers[i].fill);
+							fg->AddCircle(cc, coinR, tiers[i].ring, 14, 1.2f);
+							cursorX += coinR * 2.0f + coinTextGap;
+							const ImVec2 ts = ImGui::CalcTextSize(labels[i].c_str());
+							fg->AddText(ImVec2(cursorX, midY - ts.y * 0.5f),
+								IM_COL32(245, 235, 205, 255), labels[i].c_str());
+							cursorX += ts.x + groupGap;
+						}
 					}
 
 					// --- Fenetre d'inventaire (bascule touche I). La grille 4x4 est

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -11315,6 +11315,13 @@ namespace engine
 						m_advancedCombatVisible = !m_advancedCombatVisible;
 					}
 
+					// --- I : fenetre d'inventaire (grille objets). Retour joueur
+					// 2026-07-08 : l'inventaire etait calcule mais jamais affichable.
+					if (keysAllowed && m_input.WasPressed(engine::platform::Key::I))
+					{
+						m_inventoryVisible = !m_inventoryVisible;
+					}
+
 					// --- Cadre cible (haut-centre) : nom + barre de PV. Les PV de la
 					// cible suivent les snapshots (cf. UIModelBinding::ApplySnapshot).
 					// On masque le cadre dès que la cible est morte (bit 1 de stateFlags) :
@@ -12336,6 +12343,97 @@ namespace engine
 						fg->AddCircle(coinC, coinR, IM_COL32(180, 140, 30, 255), 12, 1.0f);
 						fg->AddText(ImVec2(coinC.x + coinR + gap, (py0 + py1) * 0.5f - goldTs.y * 0.5f),
 							IM_COL32(245, 230, 190, 255), goldText.c_str());
+					}
+
+					// --- Fenetre d'inventaire (bascule touche I). La grille 4x4 est
+					// deja calculee par InventoryUiPresenter (slots, icones, quantites)
+					// mais n'etait jamais dessinee ni ouvrable. On la rend ici en fenetre
+					// ImGui deplacable + fermable. Retour joueur 2026-07-08.
+					if (m_inventoryVisible)
+					{
+						const engine::client::InventoryPanelState& inv = m_invUi.GetState();
+						const int invCols = (inv.columns > 0u) ? static_cast<int>(inv.columns) : 4;
+						const int invSlotCount = static_cast<int>(inv.slots.size());
+						const int invRows = (invSlotCount + invCols - 1) / invCols;
+						const float invCell = 54.0f;
+						const float invGap = 6.0f;
+						const float invPad = 12.0f;
+						const float invGridW = static_cast<float>(invCols) * invCell
+							+ static_cast<float>(invCols - 1) * invGap;
+						const float invGridH = static_cast<float>(invRows) * invCell
+							+ static_cast<float>(std::max(0, invRows - 1)) * invGap;
+						const float invWinW = invGridW + invPad * 2.0f;
+						ImGui::SetNextWindowPos(ImVec2((dw - invWinW) * 0.5f, dh * 0.26f), ImGuiCond_Appearing);
+						ImGui::SetNextWindowBgAlpha(0.95f);
+						ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.06f, 0.07f, 0.10f, 0.95f));
+						ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.47f, 0.39f, 0.16f, 0.86f));
+						const ImGuiWindowFlags invFlags = ImGuiWindowFlags_NoSavedSettings
+							| ImGuiWindowFlags_NoResize
+							| ImGuiWindowFlags_AlwaysAutoResize;
+						if (ImGui::Begin("Inventaire##ln_inventory", &m_inventoryVisible, invFlags))
+						{
+							ImDrawList* wdl = ImGui::GetWindowDrawList();
+							const ImVec2 invOrigin = ImGui::GetCursorScreenPos();
+							int invOccupied = 0;
+							for (int i = 0; i < invSlotCount; ++i)
+							{
+								const engine::client::InventorySlotState& slot =
+									inv.slots[static_cast<size_t>(i)];
+								const int r = i / invCols;
+								const int c = i % invCols;
+								const float cx0 = invOrigin.x + static_cast<float>(c) * (invCell + invGap);
+								const float cy0 = invOrigin.y + static_cast<float>(r) * (invCell + invGap);
+								const ImVec2 mn(cx0, cy0);
+								const ImVec2 mx(cx0 + invCell, cy0 + invCell);
+								const bool occupied = slot.occupied && slot.itemId != 0u;
+								wdl->AddRectFilled(mn, mx,
+									occupied ? IM_COL32(26, 30, 40, 235) : IM_COL32(16, 18, 24, 200), 5.0f);
+								wdl->AddRect(mn, mx,
+									occupied ? IM_COL32(150, 130, 60, 220) : IM_COL32(64, 66, 74, 180),
+									5.0f, 0, 1.5f);
+								if (!occupied)
+									continue;
+								++invOccupied;
+								bool hasIcon = false;
+								if (!slot.iconPath.empty())
+								{
+									const uint64_t texId = m_skillIconCache.GetOrLoad(slot.iconPath);
+									if (texId != 0)
+									{
+										const float ip = 3.0f;
+										wdl->AddImage(static_cast<ImTextureID>(texId),
+											ImVec2(cx0 + ip, cy0 + ip), ImVec2(mx.x - ip, mx.y - ip));
+										hasIcon = true;
+									}
+								}
+								if (!hasIcon && !slot.label.empty())
+								{
+									const std::string lbl = slot.label.substr(0, 8);
+									wdl->AddText(ImVec2(cx0 + 4.0f, cy0 + 6.0f),
+										IM_COL32(220, 220, 225, 255), lbl.c_str());
+								}
+								if (slot.quantity > 1u)
+								{
+									char qty[12];
+									std::snprintf(qty, sizeof(qty), "%u", slot.quantity);
+									const ImVec2 qs = ImGui::CalcTextSize(qty);
+									wdl->AddText(ImVec2(mx.x - qs.x - 4.0f, mx.y - qs.y - 3.0f),
+										IM_COL32(255, 240, 190, 255), qty);
+								}
+								if (ImGui::IsMouseHoveringRect(mn, mx) && !slot.label.empty())
+								{
+									ImGui::BeginTooltip();
+									ImGui::TextUnformatted(slot.label.c_str());
+									ImGui::EndTooltip();
+								}
+							}
+							// Reserve l'espace de la grille (dessinee au draw list manuel).
+							ImGui::Dummy(ImVec2(invGridW, invGridH));
+							if (invOccupied == 0)
+								ImGui::TextDisabled("Inventaire vide");
+						}
+						ImGui::End();
+						ImGui::PopStyleColor(2);
 					}
 
 					// --- Ecran de mort : overlay sombre + bouton Reapparaitre →

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -1568,6 +1568,11 @@ namespace engine
 		std::unordered_map<std::string, float> m_spellCooldownUiUntilSec;
 		/// Combat SP2 — visibilité du panneau combat avancé (touche J).
 		bool m_advancedCombatVisible = false;
+		/// Inventaire — visibilité de la fenêtre d'inventaire (touche I). Retour
+		/// joueur 2026-07-08 : « je gagne un objet mais je ne peux pas afficher
+		/// l'inventaire ». La grille était calculée (InventoryUiPresenter) mais
+		/// jamais dessinée ni ouvrable.
+		bool m_inventoryVisible = false;
 		/// Combat SP2 — throttle local d'envoi d'AttackRequest (le serveur reste
 		/// l'autorité du cooldown réel ; ceci évite juste le spam réseau).
 		float m_attackSendCooldownSec = 0.0f;

--- a/src/client/quest/QuestUi.cpp
+++ b/src/client/quest/QuestUi.cpp
@@ -478,6 +478,10 @@ namespace engine::client
 	void QuestUiPresenter::RebuildTracker(const UIModel& model)
 	{
 		m_state.trackerSteps.clear();
+		// Retour joueur 2026-07-08 : « je ne peux pas choisir ce qu'affiche le suivi ».
+		// Le tracker (comme le radar) ne montre plus QUE la quête SÉLECTIONNÉE dans le
+		// Journal (m_selectedQuestId, tenu à jour par RebuildJournal/SelectQuest). Cela
+		// donne au joueur un contrôle direct : cliquer une autre quête re-cible le suivi.
 		for (const UIQuestEntry& quest : model.quests)
 		{
 			if (quest.status != 2)
@@ -487,21 +491,23 @@ namespace engine::client
 				// Correctif SP3 : l'ancien `!= 1` ne gardait que les Offered.
 				continue;
 			}
+			if (quest.questId != m_selectedQuestId)
+			{
+				// Seule la quête suivie alimente le tracker (choix du joueur).
+				continue;
+			}
 
 			for (const UIQuestStep& step : quest.steps)
 			{
 				QuestStepView view{};
-				view.label = quest.questId + ": " + BuildQuestStepLabel(step);
+				// Une seule quête suivie : plus besoin du préfixe « questId: » (redondant).
+				view.label = BuildQuestStepLabel(step);
 				view.currentCount = step.currentCount;
 				view.requiredCount = step.requiredCount;
 				view.completed = (step.requiredCount > 0 && step.currentCount >= step.requiredCount);
 				m_state.trackerSteps.push_back(std::move(view));
 			}
-
-			if (m_state.trackerSteps.size() >= 4)
-			{
-				break;
-			}
+			break; // quête suivie trouvée et traitée.
 		}
 	}
 
@@ -559,6 +565,12 @@ namespace engine::client
 				// (Locked=0, Offered=1, Active=2, ReadyToTurnIn=3, Completed=4 ;
 				// cf. QuestRuntime.h). Seules les quêtes ACCEPTÉES et EN COURS
 				// affichent des marqueurs de POI (pas Offered/Locked/Completed).
+				continue;
+			}
+			if (quest.questId != m_selectedQuestId)
+			{
+				// Radar aligné sur le tracker : seuls les POI de la quête SUIVIE
+				// (sélectionnée dans le Journal) apparaissent. Choix du joueur.
 				continue;
 			}
 

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -3,6 +3,7 @@
 #include "src/client/quest/QuestUi.h"
 #include "src/client/quest/QuestTextCatalog.h"
 #include "src/client/ui_common/UIModel.h"
+#include "src/client/ui_common/CurrencyFormat.h"
 #include "src/shared/core/Config.h"
 #include "src/client/render/LnTheme.h"
 
@@ -173,7 +174,7 @@ namespace engine::render
 						if (quest.rewardExperience > 0)
 							ImGui::BulletText("%u XP", quest.rewardExperience);
 						if (quest.rewardGold > 0)
-							ImGui::BulletText("%u or", quest.rewardGold);
+							ImGui::BulletText("%s", engine::client::FormatCoinsText(quest.rewardGold).c_str());
 						for (const auto& item : quest.rewardItems)
 						{
 							ImGui::BulletText("Objet #%u x%u", item.itemId, item.quantity);
@@ -470,7 +471,7 @@ namespace engine::render
 						if (q.rewardExperience > 0)
 							reward += "  " + std::to_string(q.rewardExperience) + " XP";
 						if (q.rewardGold > 0)
-							reward += "  " + std::to_string(q.rewardGold) + " or";
+							reward += "  " + engine::client::FormatCoinsText(q.rewardGold);
 						ImGui::PushStyleColor(ImGuiCol_Text, ToImVec4(LnTheme::kMuted));
 						ImGui::TextUnformatted(reward.c_str());
 						ImGui::PopStyleColor();

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -202,20 +202,22 @@ namespace engine::render
 			return;
 
 		// Position : empilé SOUS le radar minimap, coin haut-droit, aligné à droite.
-		// Corrige le chevauchement historique (tracker et radar étaient tous deux
-		// ancrés en haut-droit à y≈marge). On reprend l'ancrage exact de
-		// RenderMinimap (marge 16 + bandeau météo ~78 px + taille radar config)
-		// pour empiler proprement la colonne météo -> radar -> tracker. Si le radar
-		// est désactivé, le tracker remonte juste sous le bandeau météo.
+		// Corrige le chevauchement (retour joueur 2026-07-08 : « collision entre le
+		// suivi de quêtes et le mini radar »). CAUSE : l'ancien calcul recomposait à
+		// la main le bas du radar (16 + 70 + 8 + 200 = 294) alors que le radar réel
+		// descend jusqu'à y0(140) + taille(200) = 340 → le tracker montait ~34 px
+		// trop haut. FIX : on lit le VRAI rectangle du radar via ComputeRadarScreenRect
+		// (même source que RenderMinimap et le hit-test de zoom) → zéro dérive. Si le
+		// radar est désactivé, on retombe sous le dégagement HUD haut (marge + météo).
 		// Cond_Always : le HUD doit suivre résolution/config sans se figer sur une
 		// position imgui.ini périmée (fenêtre NoMove + NoSavedSettings de toute façon).
 		const ImGuiIO& io = ImGui::GetIO();
 		const float trackerMargin = 16.0f;
 		const float weatherHudHeightPx = 70.0f;
-		const bool minimapEnabled = m_cfg->GetBool("client.quest.minimap.enabled", true);
-		const float radarSizePx = static_cast<float>(m_cfg->GetInt("client.quest.minimap.size_px", 200));
-		const float radarBottom = (minimapEnabled && radarSizePx > 0.0f)
-			? (trackerMargin + weatherHudHeightPx + 8.0f + radarSizePx)
+		const engine::client::RadarScreenRect radarRect =
+			engine::client::ComputeRadarScreenRect(*m_cfg, io.DisplaySize.x, io.DisplaySize.y);
+		const float radarBottom = radarRect.enabled
+			? (radarRect.y0 + radarRect.size)
 			: (trackerMargin + weatherHudHeightPx);
 		const float trackerW = state.trackerBounds.width;
 		const float trackerH = state.trackerBounds.height;
@@ -324,10 +326,11 @@ namespace engine::render
 				break; // gris (repli ci-dessus)
 			}
 
+			// Retour joueur 2026-07-08 : « je ne veux que des points colorés dans le
+			// radar, pas de texte ». On ne dessine QUE la pastille teintée par type
+			// d'étape ; le libellé reste disponible dans le tracker/journal.
 			const ImVec2 p(x0 + poi.u * sizePx, y0 + poi.v * sizePx);
 			dl->AddCircleFilled(p, 4.5f, color);
-			if (!poi.label.empty())
-				dl->AddText(ImVec2(p.x + 6.0f, p.y - 6.0f), color, poi.label.c_str());
 		}
 
 		// Marqueur joueur : petit triangle plein au centre du radar (toujours

--- a/src/client/ui_common/CurrencyFormat.h
+++ b/src/client/ui_common/CurrencyFormat.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace engine::client
+{
+	/// Décomposition d'un montant en pièces or / argent / bronze.
+	/// Retour joueur 2026-07-08 : intégrer l'unité « bronze » comme base, avec
+	/// 100 bronze = 1 argent et 100 argent = 1 or.
+	struct CoinBreakdown
+	{
+		uint32_t gold = 0;   ///< 1 or   = 100 argent = 10 000 bronze.
+		uint32_t silver = 0; ///< 0..99  argent.
+		uint32_t bronze = 0; ///< 0..99  bronze.
+	};
+
+	/// Décompose un total exprimé en BRONZE (unité de base) en or/argent/bronze.
+	/// La valeur stockée côté modèle (UIWalletState.gold, UIQuestEntry.rewardGold)
+	/// est réinterprétée comme un total en bronze — 100% client, aucun changement
+	/// de protocole. Ex. 10075 -> { or=1, argent=0, bronze=75 }.
+	inline CoinBreakdown SplitCoins(uint32_t totalBronze)
+	{
+		CoinBreakdown coins{};
+		coins.gold = totalBronze / 10000u;
+		coins.silver = (totalBronze / 100u) % 100u;
+		coins.bronze = totalBronze % 100u;
+		return coins;
+	}
+
+	/// Texte compact d'un montant en bronze : n'affiche un palier supérieur que
+	/// s'il est non nul (ou impliqué par un palier plus haut) ; le bronze est
+	/// toujours montré. Ex. 75 -> « 75 br » ; 10075 -> « 1 or 0 arg 75 br ».
+	inline std::string FormatCoinsText(uint32_t totalBronze)
+	{
+		const CoinBreakdown coins = SplitCoins(totalBronze);
+		std::string out;
+		if (coins.gold > 0u)
+			out += std::to_string(coins.gold) + " or ";
+		if (coins.gold > 0u || coins.silver > 0u)
+			out += std::to_string(coins.silver) + " arg ";
+		out += std::to_string(coins.bronze) + " br";
+		return out;
+	}
+}


### PR DESCRIPTION
Retour joueur 2026-07-08 (capture #1, items 5-6) : intégrer l'unité **bronze** (100 bronze = 1 argent, 100 argent = 1 or) et rendre la **bourse plus jolie**. **100% client.**

## Contenu
- **`CurrencyFormat.h`** (header-only, aucun ajout CMake) : `SplitCoins()` réinterprète le total stocké (`wallet.gold` / `rewardGold`) comme un total en **bronze** (unité de base) et le décompose en or/argent/bronze ; `FormatCoinsText()` en texte compact. **Zéro changement de protocole.**
- **Bourse** (HUD bas-droite) : au lieu d'un seul « Or : N », affiche jusqu'à 3 pastilles teintées (or jaune / argent gris / bronze cuivré) + leur compte — or & argent masqués tant que nuls, bronze toujours visible.
- **Récompenses de quête** (journal + panneau donneur PNJ) : « N or » → format or/argent/bronze cohérent avec la bourse.

## Note d'équilibrage (data, séparé)
La valeur serveur existante est désormais lue **en bronze** : un `75` affiché « 75 or » devient « 75 br ». Les montants de récompense (`rewardGold` côté data) pourront être ré-échelonnés plus tard si tu veux des gains plus gros — c'est un levier data, pas de code/wire.

## Déploiement
✅ **client uniquement, pas de redéploiement serveur.**

> ⚠️ Empilée sur #958 (elle-même sur #957) — merger dans l'ordre #957 → #958 → #959.

🤖 Generated with [Claude Code](https://claude.com/claude-code)