### PR TITLE
feat(ui): fenêtre Personnage unifiée à onglets (F1) — Chantier 1 (Tasks 1-3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,6 +650,7 @@ add_library(engine_core
   src/client/render/SkillBookImGuiRenderer.cpp
   src/client/render/GrimoireImGuiRenderer.cpp
   src/client/render/ClassSkillTreeImGuiRenderer.cpp
+  src/client/render/CharacterWindowImGuiRenderer.cpp
   src/client/render/SkillIconCache.cpp
   src/client/render/EditorHubImGuiRenderer.cpp
   src/client/render/DecalSystem.cpp

--- a/docs/superpowers/plans/2026-07-09-fenetre-personnage-unifiee.md
+++ b/docs/superpowers/plans/2026-07-09-fenetre-personnage-unifiee.md
@@ -1,0 +1,533 @@
+# Fenêtre Personnage unifiée (Chantier 1) — plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Regrouper les panneaux personnage (F1/F2/F3/F4/I) dans une seule fenêtre à onglets ouverte par F1, onglet par défaut = perso 3D + inventaire + caractéristiques + argent.
+
+**Architecture:** Un nouveau renderer conteneur `CharacterWindowImGuiRenderer` dessine une fenêtre ImGui à onglets, rendu au même point de frame que les panneaux existants (single-pass → corrige le doublon d'inventaire). Les onglets Compétences/Techniques/Arbre délèguent aux renderers existants passés en mode « embedded » (sans leur propre `Begin`). L'onglet Personnage assemble `RacePreviewViewport` (3D), `InventoryUiPresenter` (grille) et `CurrencyFormat.h` (argent).
+
+**Tech Stack:** C++17, Dear ImGui (draw list + widgets), Vulkan (via `RacePreviewViewport` offscreen), CMake.
+
+## Global Constraints
+
+- **Client uniquement** — aucun opcode, handler, migration ; pas de redéploiement serveur.
+- **Pas de toolchain locale** — compilation via CI uniquement ; le code client ImGui est sous `#if defined(_WIN32)` (non compilé/testé sur la CI Linux ctest). **Vérification = CI Windows verte + test en jeu.** Pas de cycle TDD local.
+- **PascalCase** pour tout nouveau fichier/classe/méthode ; commentaires en français.
+- **Ne pas toucher** aux `frontFace`/`cullMode` d'aucun pipeline Vulkan (garde anti-régression CLAUDE.md). Le pipeline 3D de `RacePreviewViewport` existe déjà — le réutiliser tel quel.
+- Nouveau `.cpp` client → l'ajouter à la liste des sources dans **`CMakeLists.txt` racine** (les renderers y sont, ~ligne 635-651). NE PAS l'ajouter à `server_app`.
+
+## Prérequis (avant Task 1)
+
+Ce chantier consomme #958 (bloc inventaire à retirer) et #959 (`CurrencyFormat.h`).
+
+- [ ] Merger #957 → #958 → #959 dans `main`.
+- [ ] Recréer la branche de travail sur `main` à jour et y porter le commit de spec :
+  `git fetch origin && git checkout -B claude/character-window origin/main && git cherry-pick <sha-spec>` (ou rebase de la branche spec existante sur `origin/main`).
+
+---
+
+## File Structure
+
+- **Create** `src/client/render/CharacterWindowImGuiRenderer.h` — interface du conteneur à onglets.
+- **Create** `src/client/render/CharacterWindowImGuiRenderer.cpp` — rendu fenêtre + onglets + onglet Personnage.
+- **Modify** `src/client/render/SkillBookImGuiRenderer.{h,cpp}` — ajout `SetEmbedded(bool)`.
+- **Modify** `src/client/render/GrimoireImGuiRenderer.{h,cpp}` — ajout `SetEmbedded(bool)`.
+- **Modify** `src/client/render/ClassSkillTreeImGuiRenderer.{h,cpp}` — ajout `SetEmbedded(bool)`.
+- **Modify** `src/client/app/Engine.h` — membre renderer + retrait `m_inventoryVisible`.
+- **Modify** `src/client/app/Engine.cpp` — init/bind, appel Render dans le bloc panneaux, F1 toggle, retrait des toggles F2/F3/F4/I et du bloc inventaire #958.
+- **Modify** `CMakeLists.txt` — ajout `CharacterWindowImGuiRenderer.cpp`.
+
+---
+
+## Task 1 : Mode « embedded » sur les 3 renderers de panneaux
+
+**Files:**
+- Modify: `src/client/render/GrimoireImGuiRenderer.h`, `src/client/render/GrimoireImGuiRenderer.cpp`
+- Modify: `src/client/render/SkillBookImGuiRenderer.h`, `src/client/render/SkillBookImGuiRenderer.cpp`
+- Modify: `src/client/render/ClassSkillTreeImGuiRenderer.h`, `src/client/render/ClassSkillTreeImGuiRenderer.cpp`
+
+**Interfaces:**
+- Produces (chaque renderer) : `void SetEmbedded(bool e)` — quand `true`, `Render()` dessine son contenu **sans** ouvrir sa propre fenêtre `ImGui::Begin/End` (le conteneur fournit déjà l'onglet courant).
+
+- [ ] **Step 1 : Header — ajouter le flag (Grimoire, identique pour les 2 autres)**
+
+Dans `GrimoireImGuiRenderer.h`, après `SetEnabled` :
+
+```cpp
+		void SetEnabled(bool on) { m_enabled = on; }
+		bool IsEnabled() const { return m_enabled; }
+		/// Mode embarqué : Render() dessine son contenu dans la fenêtre/onglet
+		/// courant sans ouvrir sa propre fenêtre ImGui (piloté par le conteneur
+		/// CharacterWindowImGuiRenderer). Défaut false = fenêtre autonome.
+		void SetEmbedded(bool e) { m_embedded = e; }
+```
+
+Et dans la section `private:` : `bool m_embedded = false;`
+
+- [ ] **Step 2 : Impl — court-circuiter Begin/End (Grimoire)**
+
+Dans `GrimoireImGuiRenderer.cpp::Render()`, remplacer le motif fenêtre autonome. Structure cible :
+
+```cpp
+	void GrimoireImGuiRenderer::Render()
+	{
+		if (m_presenter == nullptr) return;
+		if (!m_embedded && !m_enabled) return;
+
+		bool open = true;
+		if (!m_embedded)
+		{
+			const float vpW = static_cast<float>(m_viewportW);
+			const float vpH = static_cast<float>(m_viewportH);
+			ImGui::SetNextWindowPos(ImVec2((vpW - panelW) * 0.5f, (vpH - panelH) * 0.5f), ImGuiCond_FirstUseEver);
+			ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+			ImGui::SetNextWindowBgAlpha(0.96f);
+			open = ImGui::Begin(title, nullptr, ImGuiWindowFlags_NoCollapse);
+		}
+		if (open)
+		{
+			// ... corps existant inchangé (listes, drag&drop, slots) ...
+		}
+		if (!m_embedded)
+			ImGui::End();
+	}
+```
+
+Conserver le corps existant à l'identique entre `if (open)`. Adapter les noms de variables locales (`panelW`, `title`, etc.) à ceux déjà présents dans le fichier.
+
+- [ ] **Step 3 : Répéter Step 1-2 pour `SkillBookImGuiRenderer` et `ClassSkillTreeImGuiRenderer`**
+
+Même transformation : header `SetEmbedded` + `m_embedded`, et dans `Render()` sauter le `Begin`/`End` quand embarqué, garder le corps. Vérifier la vraie signature/`Begin` de chaque fichier avant d'éditer (certains utilisent `SetNextWindow*` + `ImGui::Begin(...)`).
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add src/client/render/GrimoireImGuiRenderer.h src/client/render/GrimoireImGuiRenderer.cpp \
+        src/client/render/SkillBookImGuiRenderer.h src/client/render/SkillBookImGuiRenderer.cpp \
+        src/client/render/ClassSkillTreeImGuiRenderer.h src/client/render/ClassSkillTreeImGuiRenderer.cpp
+git commit -m "feat(ui): mode embedded (SetEmbedded) sur Grimoire/SkillBook/ClassSkillTree"
+```
+
+**Vérification :** CI Windows verte. Comportement inchangé en jeu (embedded défaut false ; F2/F3/F4 ouvrent encore leurs fenêtres comme avant). Pas de test en jeu requis à ce stade.
+
+---
+
+## Task 2 : `CharacterWindowImGuiRenderer` (conteneur à onglets)
+
+**Files:**
+- Create: `src/client/render/CharacterWindowImGuiRenderer.h`
+- Create: `src/client/render/CharacterWindowImGuiRenderer.cpp`
+- Modify: `CMakeLists.txt` (ajout de la source, près de la ligne ~651)
+
+**Interfaces:**
+- Consumes : `engine::render::SkillBookImGuiRenderer`, `GrimoireImGuiRenderer`, `ClassSkillTreeImGuiRenderer` (avec `SetEmbedded`/`SetEnabled`/`Render`) ; `engine::client::InventoryUiPresenter::GetState()` ; `engine::client::UIModelBinding::GetModel()` ; `engine::client::SkillIconCache::GetOrLoad(const std::string&)` ; `engine::client::SplitCoins`/`FormatCoinsText` (`CurrencyFormat.h`) ; `engine::render::RacePreviewViewport::GetImguiTextureId()` (Task 4).
+- Produces :
+  - `void Bind(const engine::core::Config* cfg, const engine::client::UIModelBinding* uiBinding, const engine::client::InventoryUiPresenter* inv, engine::client::SkillIconCache* icons, engine::render::SkillBookImGuiRenderer* skillBook, engine::render::GrimoireImGuiRenderer* grimoire, engine::render::ClassSkillTreeImGuiRenderer* classTree)`
+  - `void SetVisible(bool v)` / `bool IsVisible() const` / `bool* VisiblePtr()`
+  - `void SetViewportSize(uint32_t w, uint32_t h)`
+  - `void SetRaceViewport(engine::render::RacePreviewViewport* vp)` (Task 4 ; peut rester nul en Task 2/3 → placeholder)
+  - `void Render(const engine::client::UIModel& model)` — à appeler entre NewFrame et Render, dans le bloc panneaux.
+
+- [ ] **Step 1 : Header**
+
+Créer `src/client/render/CharacterWindowImGuiRenderer.h` :
+
+```cpp
+#pragma once
+// Fenêtre Personnage unifiée à onglets (Chantier 1). Regroupe perso 3D +
+// inventaire + caractéristiques + argent (onglet défaut) et délègue aux
+// renderers Compétences/Techniques/Arbre en mode embarqué. Rendu au même point
+// de frame que les panneaux existants (single-pass) -> pas de doublon.
+
+#include <cstdint>
+
+namespace engine::core { class Config; }
+namespace engine::client { class UIModelBinding; class InventoryUiPresenter; class SkillIconCache; struct UIModel; }
+namespace engine::render { class SkillBookImGuiRenderer; class GrimoireImGuiRenderer; class ClassSkillTreeImGuiRenderer; class RacePreviewViewport; }
+
+namespace engine::render
+{
+	class CharacterWindowImGuiRenderer
+	{
+	public:
+		enum class Tab { Personnage = 0, Competences, Techniques, Arbre };
+
+		void Bind(const engine::core::Config* cfg,
+			const engine::client::UIModelBinding* uiBinding,
+			const engine::client::InventoryUiPresenter* inv,
+			engine::client::SkillIconCache* icons,
+			engine::render::SkillBookImGuiRenderer* skillBook,
+			engine::render::GrimoireImGuiRenderer* grimoire,
+			engine::render::ClassSkillTreeImGuiRenderer* classTree);
+
+		void SetRaceViewport(engine::render::RacePreviewViewport* vp) { m_raceViewport = vp; }
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+		void SetVisible(bool v) { m_visible = v; }
+		void ToggleVisible() { m_visible = !m_visible; }
+		bool IsVisible() const { return m_visible; }
+		bool* VisiblePtr() { return &m_visible; }
+		void SetActiveTab(Tab t) { m_activeTab = t; }
+
+		void Render(const engine::client::UIModel& model);
+
+	private:
+		void RenderPersonnageTab(const engine::client::UIModel& model);
+
+		const engine::core::Config* m_cfg = nullptr;
+		const engine::client::UIModelBinding* m_uiBinding = nullptr;
+		const engine::client::InventoryUiPresenter* m_inv = nullptr;
+		engine::client::SkillIconCache* m_icons = nullptr;
+		engine::render::SkillBookImGuiRenderer* m_skillBook = nullptr;
+		engine::render::GrimoireImGuiRenderer* m_grimoire = nullptr;
+		engine::render::ClassSkillTreeImGuiRenderer* m_classTree = nullptr;
+		engine::render::RacePreviewViewport* m_raceViewport = nullptr;
+		uint32_t m_viewportW = 0;
+		uint32_t m_viewportH = 0;
+		bool m_visible = false;
+		Tab m_activeTab = Tab::Personnage;
+	};
+}
+```
+
+- [ ] **Step 2 : Impl — cadre + barre d'onglets + délégation**
+
+Créer `src/client/render/CharacterWindowImGuiRenderer.cpp`. Garder tout sous `#if defined(_WIN32)` (comme les autres renderers), stub vide sinon.
+
+```cpp
+#include "src/client/render/CharacterWindowImGuiRenderer.h"
+
+#include "src/client/render/SkillBookImGuiRenderer.h"
+#include "src/client/render/GrimoireImGuiRenderer.h"
+#include "src/client/render/ClassSkillTreeImGuiRenderer.h"
+#include "src/client/render/race/RacePreviewViewport.h"
+#include "src/client/render/SkillIconCache.h"
+#include "src/client/ui_common/UIModel.h"
+#include "src/client/ui_common/CurrencyFormat.h"
+#include "src/client/inventory/InventoryUi.h"
+#include "src/shared/core/Config.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+namespace engine::render
+{
+	void CharacterWindowImGuiRenderer::Bind(const engine::core::Config* cfg,
+		const engine::client::UIModelBinding* uiBinding,
+		const engine::client::InventoryUiPresenter* inv,
+		engine::client::SkillIconCache* icons,
+		engine::render::SkillBookImGuiRenderer* skillBook,
+		engine::render::GrimoireImGuiRenderer* grimoire,
+		engine::render::ClassSkillTreeImGuiRenderer* classTree)
+	{
+		m_cfg = cfg; m_uiBinding = uiBinding; m_inv = inv; m_icons = icons;
+		m_skillBook = skillBook; m_grimoire = grimoire; m_classTree = classTree;
+	}
+
+	void CharacterWindowImGuiRenderer::Render(const engine::client::UIModel& model)
+	{
+		if (!m_visible) return;
+
+		const float vpW = static_cast<float>(m_viewportW);
+		const float vpH = static_cast<float>(m_viewportH);
+		const float winW = 640.0f, winH = 440.0f;
+		ImGui::SetNextWindowPos(ImVec2((vpW - winW) * 0.5f, (vpH - winH) * 0.5f), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(winW, winH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.96f);
+
+		if (ImGui::Begin("Personnage##ln_character_window", &m_visible, ImGuiWindowFlags_NoCollapse))
+		{
+			if (ImGui::BeginTabBar("##ln_character_tabs"))
+			{
+				if (ImGui::BeginTabItem("Personnage"))
+				{
+					m_activeTab = Tab::Personnage;
+					RenderPersonnageTab(model);
+					ImGui::EndTabItem();
+				}
+				if (ImGui::BeginTabItem("Competences"))
+				{
+					m_activeTab = Tab::Competences;
+					if (m_skillBook) { m_skillBook->SetEmbedded(true); m_skillBook->SetEnabled(true); m_skillBook->Render(); }
+					ImGui::EndTabItem();
+				}
+				if (ImGui::BeginTabItem("Techniques"))
+				{
+					m_activeTab = Tab::Techniques;
+					if (m_grimoire) { m_grimoire->SetEmbedded(true); m_grimoire->SetEnabled(true); m_grimoire->Render(); }
+					ImGui::EndTabItem();
+				}
+				if (ImGui::BeginTabItem("Arbre"))
+				{
+					m_activeTab = Tab::Arbre;
+					if (m_classTree) { m_classTree->SetEmbedded(true); m_classTree->SetEnabled(true); m_classTree->Render(); }
+					ImGui::EndTabItem();
+				}
+				ImGui::EndTabBar();
+			}
+		}
+		ImGui::End();
+	}
+
+	void CharacterWindowImGuiRenderer::RenderPersonnageTab(const engine::client::UIModel& model)
+	{
+		// Colonnes : gauche (3D + slots + stats), droite (inventaire + argent).
+		const float leftW = ImGui::GetContentRegionAvail().x * 0.46f;
+		ImGui::BeginChild("##ln_char_left", ImVec2(leftW, 0), false);
+		{
+			// Aperçu 3D (Task 4 : image du viewport ; ici placeholder si absent).
+			const ImVec2 avail = ImGui::GetContentRegionAvail();
+			const float previewH = 190.0f;
+			if (m_raceViewport && m_raceViewport->GetImguiTextureId() != 0u)
+			{
+				ImGui::Image(static_cast<ImTextureID>(m_raceViewport->GetImguiTextureId()),
+					ImVec2(avail.x, previewH));
+			}
+			else
+			{
+				ImDrawList* dl = ImGui::GetWindowDrawList();
+				const ImVec2 p0 = ImGui::GetCursorScreenPos();
+				dl->AddRectFilled(p0, ImVec2(p0.x + avail.x, p0.y + previewH), IM_COL32(14, 16, 22, 255), 6.0f);
+				dl->AddText(ImVec2(p0.x + avail.x * 0.5f - 30.0f, p0.y + previewH * 0.5f), IM_COL32(120, 130, 160, 255), "Apercu 3D");
+				ImGui::Dummy(ImVec2(avail.x, previewH));
+			}
+			ImGui::TextDisabled("Equipement — Chantier 2");
+			ImGui::Separator();
+			// Caractéristiques compactes (ex-fiche F1).
+			const engine::client::UIPlayerStats& ps = model.playerStats;
+			ImGui::Text("Niveau %u", ps.level);
+			ImGui::Text("Points de vie : %u", ps.maxHealth);
+			ImGui::Text("Ressource : %u", ps.secondaryResourceMax);
+			ImGui::Text("Degats : %u", ps.attackDamage);
+		}
+		ImGui::EndChild();
+
+		ImGui::SameLine();
+
+		ImGui::BeginChild("##ln_char_right", ImVec2(0, 0), false);
+		{
+			ImGui::TextUnformatted("Inventaire");
+			// Grille 4x4 depuis InventoryUiPresenter (repris du bloc #958, single-pass ici).
+			if (m_inv)
+			{
+				const engine::client::InventoryPanelState& gi = m_inv->GetState();
+				const int cols = (gi.columns > 0u) ? static_cast<int>(gi.columns) : 4;
+				const int count = static_cast<int>(gi.slots.size());
+				const float cell = 48.0f, gap = 6.0f;
+				ImDrawList* wdl = ImGui::GetWindowDrawList();
+				const ImVec2 origin = ImGui::GetCursorScreenPos();
+				for (int i = 0; i < count; ++i)
+				{
+					const engine::client::InventorySlotState& s = gi.slots[static_cast<size_t>(i)];
+					const int r = i / cols, c = i % cols;
+					const float x0 = origin.x + static_cast<float>(c) * (cell + gap);
+					const float y0 = origin.y + static_cast<float>(r) * (cell + gap);
+					const ImVec2 mn(x0, y0), mx(x0 + cell, y0 + cell);
+					const bool occ = s.occupied && s.itemId != 0u;
+					wdl->AddRectFilled(mn, mx, occ ? IM_COL32(26,30,40,235) : IM_COL32(16,18,24,200), 5.0f);
+					wdl->AddRect(mn, mx, occ ? IM_COL32(150,130,60,220) : IM_COL32(64,66,74,180), 5.0f, 0, 1.5f);
+					if (!occ) continue;
+					bool hasIcon = false;
+					if (m_icons && !s.iconPath.empty())
+					{
+						const uint64_t tex = m_icons->GetOrLoad(s.iconPath);
+						if (tex != 0) { wdl->AddImage(static_cast<ImTextureID>(tex), ImVec2(x0+3,y0+3), ImVec2(mx.x-3,mx.y-3)); hasIcon = true; }
+					}
+					if (!hasIcon && !s.label.empty())
+						wdl->AddText(ImVec2(x0+4,y0+5), IM_COL32(220,220,225,255), s.label.substr(0,7).c_str());
+					if (s.quantity > 1u)
+					{
+						char q[12]; std::snprintf(q, sizeof(q), "%u", s.quantity);
+						const ImVec2 qs = ImGui::CalcTextSize(q);
+						wdl->AddText(ImVec2(mx.x-qs.x-3, mx.y-qs.y-2), IM_COL32(255,240,190,255), q);
+					}
+					if (ImGui::IsMouseHoveringRect(mn, mx) && !s.label.empty())
+					{ ImGui::BeginTooltip(); ImGui::TextUnformatted(s.label.c_str()); ImGui::EndTooltip(); }
+				}
+				const int rows = (count + cols - 1) / cols;
+				ImGui::Dummy(ImVec2(0, static_cast<float>(rows) * (cell + gap)));
+			}
+			// Bourse or/argent/bronze.
+			const engine::client::CoinBreakdown coins = engine::client::SplitCoins(model.wallet.gold);
+			ImGui::Separator();
+			ImGui::Text("Or %u   Arg %u   Br %u", coins.gold, coins.silver, coins.bronze);
+		}
+		ImGui::EndChild();
+	}
+}
+
+#else
+namespace engine::render
+{
+	void CharacterWindowImGuiRenderer::Bind(const engine::core::Config*, const engine::client::UIModelBinding*,
+		const engine::client::InventoryUiPresenter*, engine::client::SkillIconCache*,
+		engine::render::SkillBookImGuiRenderer*, engine::render::GrimoireImGuiRenderer*,
+		engine::render::ClassSkillTreeImGuiRenderer*) {}
+	void CharacterWindowImGuiRenderer::Render(const engine::client::UIModel&) {}
+	void CharacterWindowImGuiRenderer::RenderPersonnageTab(const engine::client::UIModel&) {}
+}
+#endif
+```
+
+> NB : vérifier les vrais noms de champs `UIPlayerStats` (`level`, `maxHealth`, `secondaryResourceMax`, `attackDamage`) et `UIWalletState.gold` dans `src/client/ui_common/UIModel.h` avant compilation ; ajuster si différents. `<cstdio>` pour `snprintf` : ajouter l'include si absent.
+
+- [ ] **Step 3 : CMake**
+
+Dans `CMakeLists.txt` racine, à côté de `src/client/render/GrimoireImGuiRenderer.cpp` (~ligne 651), ajouter :
+
+```cmake
+  src/client/render/CharacterWindowImGuiRenderer.cpp
+```
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add src/client/render/CharacterWindowImGuiRenderer.h src/client/render/CharacterWindowImGuiRenderer.cpp CMakeLists.txt
+git commit -m "feat(ui): CharacterWindowImGuiRenderer (conteneur onglets Personnage)"
+```
+
+**Vérification :** CI Windows verte (la classe compile ; encore non instanciée → pas d'effet en jeu).
+
+---
+
+## Task 3 : Câblage Engine + consolidation des touches + retrait #958
+
+**Files:**
+- Modify: `src/client/app/Engine.h`
+- Modify: `src/client/app/Engine.cpp`
+
+**Interfaces:**
+- Consumes : `CharacterWindowImGuiRenderer::Bind/SetViewportSize/ToggleVisible/Render` (Task 2).
+
+- [ ] **Step 1 : Engine.h — membre + retrait m_inventoryVisible**
+
+Ajouter l'include `#include "src/client/render/CharacterWindowImGuiRenderer.h"` près des autres renderers (~ligne 47-64). Ajouter le membre près de `m_classSkillTreeImGui` :
+
+```cpp
+		std::unique_ptr<engine::render::CharacterWindowImGuiRenderer> m_characterWindowImGui;
+```
+
+Supprimer le membre `bool m_inventoryVisible = false;` (ajouté en #958).
+
+- [ ] **Step 2 : Engine.cpp — init + Bind**
+
+Dans le bloc d'init des renderers ImGui (~8236-8261, là où `m_grimoireImGui`, `m_classSkillTreeImGui` sont créés), ajouter :
+
+```cpp
+				m_characterWindowImGui = std::make_unique<engine::render::CharacterWindowImGuiRenderer>();
+				m_characterWindowImGui->Bind(&m_cfg, &m_uiModelBinding, &m_invUi, &m_skillIconCache,
+					m_skillBookImGui.get(), m_grimoireImGui.get(), m_classSkillTreeImGui.get());
+				m_characterWindowImGui->SetRaceViewport(&m_racePreviewViewport); // Task 4 ; nom réel du membre à confirmer
+```
+
+> Confirmer le nom du membre `RacePreviewViewport` dans Engine (grep `RacePreviewViewport` dans Engine.h). S'il n'est pas directement accessible, laisser `SetRaceViewport` pour Task 4 et ne pas l'appeler ici.
+
+- [ ] **Step 3 : Engine.cpp — appel Render dans le bloc panneaux**
+
+Dans le bloc ~12580-12740 (où `m_grimoireImGui->Render()` etc. sont appelés), **remplacer** les rendus autonomes de la fiche/skillbook/grimoire/arbre par un seul appel conteneur. Concrètement :
+
+- Retirer/neutraliser les appels `m_characterSheetImGui->Render(...)` (~12608-12610), `m_skillBookImGui->...Render()` (~12638-12640), `m_grimoireImGui->...Render()` (~12675-12677), `m_classSkillTreeImGui->...Render()` (~12697-12699) — ils sont désormais pilotés par le conteneur en mode embedded.
+- Ajouter :
+
+```cpp
+				if (m_characterWindowImGui)
+				{
+					m_characterWindowImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+					m_characterWindowImGui->Render(m_uiModelBinding.GetModel());
+				}
+```
+
+- [ ] **Step 4 : Engine.cpp — retrait du bloc inventaire #958**
+
+Supprimer le bloc `// --- Fenetre d'inventaire (bascule touche I)...` jusqu'à son `ImGui::End(); ImGui::PopStyleColor(2);` (introduit en #958, région ~12360 avant retrait). C'est la source du doublon.
+
+- [ ] **Step 5 : Engine.cpp — touches**
+
+- Remplacer le toggle F1 fiche (~7920-7923) par :
+
+```cpp
+			if (inGameNoMenu && !chatBlocks
+				&& m_input.WasPressed(KeyFromName(m_cfg.GetString("controls.keybind.charactersheet", "F1"), engine::platform::Key::F_1)))
+			{
+				if (m_characterWindowImGui) m_characterWindowImGui->ToggleVisible();
+				LOG_INFO(Core, "[Engine] F1 toggle fenetre Personnage");
+			}
+```
+
+> Confirmer que `inGameNoMenu`/`chatBlocks` sont en portée à cet endroit ; sinon réutiliser les gardes locales du bloc F1 existant.
+
+- Supprimer le bloc toggle Grimoire (~7744-7758), le bloc toggle ClassSkillTree (~7766-7780), et le toggle inventaire I (#958, ~7317-7321). Les touches F2/F3/F4/I deviennent libres.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add src/client/app/Engine.h src/client/app/Engine.cpp
+git commit -m "feat(ui): F1 ouvre la fenetre Personnage unifiee ; F2/F3/F4/I liberees ; retrait fenetre inventaire #958 (doublon)"
+```
+
+**Vérification (CI verte puis EN JEU) :**
+1. F1 ouvre/ferme la fenêtre Personnage.
+2. 4 onglets présents ; Compétences/Techniques/Arbre montrent le contenu d'avant, **une seule fois** (pas de doublon).
+3. Onglet Personnage : inventaire affiché **une seule fois** + argent or/argent/bronze corrects + caractéristiques.
+4. F2, F3, F4, I ne font plus rien.
+5. Aucune régression du reste du HUD (barre d'action, bourse HUD bas-droite, cadre cible).
+
+---
+
+## Task 4 : Perso 3D dans l'onglet Personnage (`RacePreviewViewport`)
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp` (alimenter le viewport quand l'onglet Personnage est actif)
+- Modify: `src/client/render/CharacterWindowImGuiRenderer.cpp` (déjà prêt : `ImGui::Image` si `GetImguiTextureId() != 0`)
+
+**Interfaces:**
+- Consumes : `RacePreviewViewport::SetMesh/SetGender/SetSkinTone/Tick/RenderOffscreen/GetImguiTextureId`.
+
+- [ ] **Step 1 : Repérer le mesh/gender/skin du perso local**
+
+Grep dans `Engine.cpp` comment l'avatar local est chargé à `EnterWorld` (`genre perso`, `teinte peau`, `Avatar mesh selected`). Récupérer le `SkinnedMesh*` du perso local, le genre (`"male"/"female"`) et la teinte.
+
+- [ ] **Step 2 : Alimenter le viewport quand la fenêtre est visible et l'onglet Personnage actif**
+
+Dans `Engine::Update`, juste avant l'appel `m_characterWindowImGui->Render(...)`, si visible :
+
+```cpp
+				if (m_characterWindowImGui && m_characterWindowImGui->IsVisible())
+				{
+					m_racePreviewViewport.SetGender(localGenderStr);
+					m_racePreviewViewport.SetSkinTone(localSkinTone);
+					m_racePreviewViewport.SetMesh(localAvatarMesh); // idempotent si inchangé
+					m_racePreviewViewport.Tick(static_cast<float>(dt));
+					m_racePreviewViewport.RenderOffscreen();
+				}
+```
+
+> Noms exacts (`m_racePreviewViewport`, `localAvatarMesh`, `localGenderStr`, `localSkinTone`) à confirmer par grep. `RenderOffscreen` doit être appelé au bon moment vis-à-vis de la frame Vulkan (regarder où l'écran de création l'appelle et calquer). Si l'ordonnancement Vulkan est délicat, faire tourner le viewport uniquement quand la fenêtre est ouverte pour limiter le coût.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add src/client/app/Engine.cpp
+git commit -m "feat(ui): perso 3D (RacePreviewViewport) dans l'onglet Personnage"
+```
+
+**Vérification (CI verte puis EN JEU) :** le perso 3D s'affiche dans l'onglet Personnage ; pas de crash Vulkan (device lost) ; le reste de la scène reste rendu normalement.
+
+---
+
+## Ouverture du chantier suivant
+
+- **Chantier 2** (spec séparée) : activer les emplacements d'équipement (slots fonctionnels, wire equip/unequip, persistance DB, recalcul stats, mesh 3D selon stuff). ⚠️ client + serveur.
+- **Correctif indépendant** : repositionner le texte de zoom « 200 m » du radar au-dessus de l'arc (radar-seul) — PR séparée, non liée à cette fenêtre.
+
+---
+
+## Self-Review (couverture spec)
+
+- Fenêtre F1 + 4 onglets → Task 2 (conteneur) + Task 3 (F1).
+- F2/F3/F4/I libérées → Task 3 Step 5.
+- Onglet défaut 3D + inventaire + stats + argent → Task 2 (inventaire/stats/argent) + Task 4 (3D).
+- Délégation panneaux existants → Task 1 (embedded) + Task 2 (appels).
+- Correctif doublon inventaire → Task 3 Step 3-4 (rendu single-pass + retrait bloc #958).
+- Slots équipement inactifs (placeholder) → Task 2 (`TextDisabled("Equipement — Chantier 2")` ; enrichir en dessins de cases si souhaité).
+- Client-only / pas de serveur → aucun opcode/handler/migration dans le plan. ✅
+- Réutilisation (RacePreviewViewport, InventoryUiPresenter, CurrencyFormat, renderers) → Tasks 2/4.

--- a/docs/superpowers/specs/2026-07-09-fenetre-personnage-unifiee-design.md
+++ b/docs/superpowers/specs/2026-07-09-fenetre-personnage-unifiee-design.md
@@ -1,0 +1,197 @@
+# Fenêtre « Personnage » unifiée à onglets — design (Chantier 1)
+
+Date : 2026-07-09
+Statut : validé (direction approuvée par l'utilisateur, maquette `fenetre_personnage_onglets_mockup`)
+
+## Contexte & problème
+
+Retour joueur 2026-07-08 : « il y a trop d'interface concernant le personnage, ce
+qui complexifie l'expérience ». Aujourd'hui cinq panneaux séparés, chacun sa
+touche et sa fenêtre :
+
+- F1 → fiche personnage (`CharacterSheetImGuiRenderer`, stats)
+- F2 → livre de compétences (`SkillBookImGuiRenderer`)
+- F3 → carnet de techniques / Grimoire (`GrimoireImGuiRenderer`)
+- F4 → arbre de compétences (`ClassSkillTreeImGuiRenderer`)
+- I → inventaire (grille 4×4 de #958)
+
+Cet éparpillement charge le HUD et les touches. L'utilisateur veut **une seule
+fenêtre à onglets**, ouverte par **F1**, regroupant tout, avec un onglet par
+défaut montrant le **personnage en 3D d'un côté et l'inventaire de l'autre**,
+argent inclus.
+
+## Découpage en deux chantiers
+
+Le projet mêle deux tailles de travail très différentes ; on les sépare.
+
+- **Chantier 1 (cette spec)** — la fenêtre unifiée à onglets. Surtout client :
+  conteneur à onglets, ré-hébergement des panneaux existants, onglet par défaut
+  (3D **en vue seule** + inventaire + caractéristiques + argent). Corrige au
+  passage le bug d'inventaire en double.
+- **Chantier 2 (spec ultérieure)** — équiper le loot sur le perso 3D. Sous-système
+  complet client **+ serveur** : slots d'équipement fonctionnels, protocole
+  equip/unequip, persistance DB, recalcul de stats, loot modifiant le mesh 3D.
+  ⚠️ redéploiement serveur. **Hors périmètre ici.**
+
+L'onglet par défaut du Chantier 1 **dessine déjà les emplacements d'équipement**
+mais **inactifs** (pointillés), pour réserver la place ; le Chantier 2 les
+activera sans refonte de disposition.
+
+## Objectif du Chantier 1
+
+Une fenêtre `Personnage` ouverte par **F1**, 4 onglets, les touches **F2/F3/F4/I
+libérées** (anciens toggles retirés). 100% client, aucun redéploiement serveur.
+
+## Architecture
+
+### Nouveau composant : `CharacterWindowImGuiRenderer`
+
+Un renderer conteneur (dossier `src/client/render/`) qui :
+
+1. Dessine le cadre de fenêtre ImGui (`Begin("Personnage##ln_character_window",
+   &m_characterWindowVisible, …)`), la barre d'onglets (`ImGui::BeginTabBar`),
+   et route vers le contenu de l'onglet actif.
+2. **Est invoqué au même endroit que les panneaux existants** (`Engine::Update`,
+   bloc ~`Engine.cpp:12580-12740`, à côté de `m_grimoireImGui->Render()` etc.).
+   C'est le point de la frame finalisé par un **unique** `ImGui::Render()` — d'où
+   l'absence de doublon. (cf. section « Correctif inventaire en double ».)
+3. Pour les onglets Compétences / Techniques / Arbre, **délègue aux renderers
+   existants** (`SkillBookImGuiRenderer`, `GrimoireImGuiRenderer`,
+   `ClassSkillTreeImGuiRenderer`) — pas de réécriture. Le conteneur les affiche
+   « embarqués » dans l'onglet plutôt qu'en fenêtres autonomes (voir « Intégration
+   des panneaux existants »).
+4. Pour l'onglet Personnage (défaut), rend lui-même : aperçu 3D + emplacements
+   d'équipement inactifs + caractéristiques compactes + inventaire 4×4 + bourse.
+
+### Les 4 onglets
+
+| Onglet | Contenu | Source |
+|--------|---------|--------|
+| **Personnage** (défaut) | 3D (vue seule) + slots équipement inactifs + caractéristiques + inventaire + argent | nouveau, réutilise `RacePreviewViewport`, `InventoryUiPresenter`, `CurrencyFormat.h` |
+| **Compétences** | livre de compétences | `SkillBookImGuiRenderer` (délégué) |
+| **Techniques** | carnet de techniques | `GrimoireImGuiRenderer` (délégué) |
+| **Arbre** | arbre de compétences par classe | `ClassSkillTreeImGuiRenderer` (délégué) |
+
+Les **caractéristiques** (ex-fiche F1) sont fusionnées dans l'onglet Personnage
+(bloc compact lu depuis `UIModel`), plutôt qu'un 5ᵉ onglet. La fenêtre autonome
+`CharacterSheetImGuiRenderer` est retirée (son contenu stats est repris compact).
+
+### Onglet « Personnage » — disposition
+
+Deux colonnes (cf. maquette validée) :
+
+- **Gauche (~46%)** :
+  - Aperçu 3D encadré, alimenté par `RacePreviewViewport` (déjà existant, utilisé
+    à la création de personnage : rend le perso skinné dans une texture 512×512).
+    Vue seule ; rotation à la souris si simple à câbler, sinon rotation lente
+    auto. Affiché via `ImGui::Image(<texId viewport>)`.
+  - Emplacements d'équipement **inactifs** dessinés autour du 3D (pointillés,
+    libellé « Chantier 2 »). Aucune logique d'équipement.
+  - Bloc **Caractéristiques** compact : niveau, PV, ressource, dégâts (lus sur
+    `uiModel.playerStats`).
+- **Droite (~54%)** :
+  - **Inventaire** 4×4 depuis `InventoryUiPresenter.GetState()` (icônes via
+    `m_skillIconCache`, quantités, tooltips) — même rendu que #958 mais placé
+    dans l'onglet (donc single-pass).
+  - **Bourse** or/argent/bronze via `CurrencyFormat.h` (#959), en bas.
+
+### Interaction / touches
+
+- **F1** : ouvre/ferme la fenêtre (`controls.keybind.charactersheet`, défaut F1 —
+  on réutilise cette clé de config, renommée conceptuellement « ouvrir Personnage »).
+- **F2, F3, F4, I** : anciens toggles **retirés** (les blocs correspondants dans
+  `Engine::Update` — grimoire ~7752, skilltree ~7774, inventaire I ~7318 ajouté
+  en #958, et le toggle F1 fiche ~7920). Les touches redeviennent libres.
+- **Navigation onglets** : clic sur la barre d'onglets. À l'ouverture, la fenêtre
+  montre l'onglet par défaut (Personnage) — mémorisation du dernier onglet
+  optionnelle (non requise en v1).
+- Gardes d'ouverture identiques aux panneaux actuels (pas en chat focus / menu
+  pause / éditeur ; post-auth flow complet).
+
+### Correctif « inventaire en double » (#958)
+
+**Cause racine confirmée** : le `ImGui::Begin` de l'inventaire de #958 était placé
+dans la **région HUD avant-plan** de `Engine::Update` (~`Engine.cpp:12360`), entre
+deux `ImGui::Render()` (10614 et 12904). Son contenu de fenêtre était finalisé
+dans deux passes → **deux grilles empilées**. Les panneaux existants (Grimoire…)
+ne doublent pas car ils sont rendus plus bas (~12580-12740), finalisés par un
+unique `ImGui::Render()`.
+
+**Correctif** : l'inventaire n'existe plus en fenêtre autonome ; il devient
+l'onglet Personnage de `CharacterWindowImGuiRenderer`, rendu dans le **bon bloc**
+(single-pass) → plus de doublon. Le bloc HUD `m_inventoryVisible`/`ln_inventory`
+de #958 est supprimé.
+
+### Intégration des panneaux existants
+
+Les `*ImGuiRenderer` existants font aujourd'hui leur propre `ImGui::Begin(...)`
+(fenêtre autonome) selon un flag `SetEnabled(...)`. Deux options d'intégration :
+
+- **A (recommandée)** : le conteneur ouvre le corps de l'onglet
+  (`BeginTabItem`) et appelle le `Render()` du panneau **dans** ce corps ; on
+  ajuste chaque renderer pour dessiner son contenu sans re-`Begin` une fenêtre
+  propre (mode « embarqué » via un flag, p. ex. `SetEmbedded(true)`), en gardant
+  le mode fenêtre autonome pour compatibilité/tests.
+- **B (repli)** : conserver les fenêtres autonomes mais les positionner/afficher
+  pilotées par l'onglet actif (moins propre, fenêtres qui flottent).
+
+On part sur **A** : petit flag « embedded » par renderer, le corps de contenu
+existant réutilisé tel quel.
+
+## Réutilisation (anti-duplication)
+
+- `RacePreviewViewport` — rendu 3D perso (existe, création de personnage).
+- `InventoryUiPresenter` — grille 4×4 (existe).
+- `CurrencyFormat.h` — or/argent/bronze (#959).
+- `SkillBookImGuiRenderer`, `GrimoireImGuiRenderer`, `ClassSkillTreeImGuiRenderer`
+  — contenu des 3 onglets (existent).
+- `m_skillIconCache` — icônes d'objets/sorts (existe).
+
+Aucune classe/logique n'est réécrite ; le Chantier 1 est essentiellement de
+l'assemblage + le retrait des anciens toggles + le correctif de passe.
+
+## Hors périmètre (→ Chantier 2)
+
+- Slots d'équipement fonctionnels, drag-to-equip du loot.
+- Protocole réseau equip/unequip, persistance DB, recalcul des stats depuis le
+  stuff, modification du mesh 3D selon l'équipement.
+- ⚠️ Tout redéploiement serveur.
+
+## Déploiement
+
+✅ **Client uniquement, aucun redéploiement serveur.** (Aucun opcode, aucun
+handler, aucune migration ; lit uniquement des données déjà reçues.)
+
+## Vérification
+
+Pas de toolchain locale → validation en jeu après build CI :
+
+1. **F1** ouvre la fenêtre Personnage ; re-presser F1 ferme.
+2. **F2/F3/F4/I** ne font plus rien (touches libérées).
+3. Les 4 onglets s'affichent et basculent au clic ; Compétences/Techniques/Arbre
+   montrent le même contenu qu'avant.
+4. Onglet Personnage : le perso 3D s'affiche, l'inventaire apparaît **une seule
+   fois** (bug #958 corrigé), l'argent s'affiche en or/argent/bronze.
+5. Aucune régression des autres éléments de HUD (barre d'action, bourse HUD,
+   cadre cible, etc.).
+
+Tests unitaires : pas de nouvelle logique pure justifiant un test dédié (assemblage
+UI) ; les presenters réutilisés ont déjà leurs tests.
+
+## Risques / points d'attention
+
+- **Embarquer `RacePreviewViewport` dans un onglet ImGui** : il rend dans une
+  texture ; il faut exposer son `ImTextureID` et le rendre à chaque frame où
+  l'onglet Personnage est ouvert. Coût 512×512, acceptable ; ne rendre que si
+  l'onglet est actif (économie GPU).
+- **Flag « embedded » des renderers existants** : petite modif par renderer ;
+  garder le chemin fenêtre-autonome pour ne rien casser ailleurs.
+- **Convention winding / pipelines Vulkan** : le viewport 3D perso a déjà son
+  pipeline (création de personnage) — ne pas toucher aux `frontFace`/`cullMode`
+  (cf. CLAUDE.md, garde anti-régression terrain/avatar).
+
+## Petit correctif indépendant (hors cette fenêtre)
+
+Le texte de zoom « 200 m » du radar est mal placé (chevauche la glissière en arc) ;
+il doit passer **au-dessus** de l'arc. Radar-seul, indépendant de cette fenêtre —
+traité comme correctif séparé (ne pas mêler à cette spec).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -1973,12 +1973,11 @@ namespace engine
 				    || text.starts_with("/skills ") || text.starts_with("/skills\t")
 				    || text.starts_with("/skill ") || text.starts_with("/skill\t")))
 			{
-				m_skillBookVisible = !m_skillBookVisible;
-				if (m_skillBookVisible)
-				{
-					m_skillBookUi.RequestList();
-				}
-				LOG_INFO(Core, "[Engine] /skills toggle (visible={})", m_skillBookVisible);
+				// Chantier 1 — route vers la fenêtre Personnage unifiée (onglet Compétences).
+				if (m_characterWindowImGui)
+					m_characterWindowImGui->OpenAtTab(engine::render::CharacterWindowImGuiRenderer::Tab::Competences);
+				m_skillBookUi.RequestList();
+				LOG_INFO(Core, "[Engine] /skills -> fenetre Personnage (onglet Competences)");
 				sendAdminAudit("/skills");
 				return true;
 			}
@@ -1989,8 +1988,9 @@ namespace engine
 				    || text.starts_with("/grimoire ") || text.starts_with("/grimoire\t")
 				    || text.starts_with("/sorts ") || text.starts_with("/sorts\t")))
 			{
-				m_grimoireVisible = !m_grimoireVisible;
-				LOG_INFO(Core, "[Engine] /grimoire toggle (visible={})", m_grimoireVisible);
+				if (m_characterWindowImGui)
+					m_characterWindowImGui->OpenAtTab(engine::render::CharacterWindowImGuiRenderer::Tab::Techniques);
+				LOG_INFO(Core, "[Engine] /grimoire -> fenetre Personnage (onglet Techniques)");
 				return true;
 			}
 			// SP-D — Slash commands /arbre et /competences pour l'arbre de compétences.
@@ -1999,8 +1999,9 @@ namespace engine
 				    || text.starts_with("/arbre ") || text.starts_with("/arbre	")
 				    || text.starts_with("/competences ") || text.starts_with("/competences	")))
 			{
-				m_classSkillTreeVisible = !m_classSkillTreeVisible;
-				LOG_INFO(Core, "[Engine] /arbre toggle (visible={})", m_classSkillTreeVisible);
+				if (m_characterWindowImGui)
+					m_characterWindowImGui->OpenAtTab(engine::render::CharacterWindowImGuiRenderer::Tab::Arbre);
+				LOG_INFO(Core, "[Engine] /arbre -> fenetre Personnage (onglet Arbre)");
 				return true;
 			}
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Slash command /lfg pour
@@ -7879,6 +7880,11 @@ namespace engine
 						m_racePreviewViewport.SetGender(m_avatarGender);
 						m_racePreviewViewport.SetSkinTone(m_avatarSkinTone);
 						m_racePreviewViewport.SetMesh(m_currentSkinnedMesh);
+						// Vue de face + rotation manuelle (pas d'auto-orbit) : retour
+						// joueur 2026-07-09. Le drag dans la fenêtre pilote ensuite l'angle.
+						m_racePreviewViewport.SetAutoOrbit(false);
+						m_racePreviewViewport.SetOrbitYaw(0.0f);
+						m_characterWindowImGui->ResetPreviewOrientation();
 					}
 				}
 				LOG_INFO(Core, "[Engine] F1 toggle fenetre Personnage");
@@ -10581,6 +10587,9 @@ namespace engine
 				m_racePreviewLastNowSec = previewNowSec;
 				if (previewDt < 0.0f)  previewDt = 0.0f;
 				if (previewDt > 0.1f)  previewDt = 0.1f; // clamp gros hitch
+				// L'écran de création garde la rotation auto (la fenêtre Personnage la
+				// coupe ; on la réactive ici au cas où elle a servi avant).
+				m_racePreviewViewport.SetAutoOrbit(true);
 				m_racePreviewViewport.Tick(previewDt);
 				m_racePreviewViewport.RenderOffscreen();
 			}
@@ -12437,10 +12446,13 @@ namespace engine
 			{
 				if (ImGui::BeginMenu("Panneaux"))
 				{
-					if (ImGui::MenuItem("Carnet de sorts", nullptr, m_skillBookVisible))
+					if (ImGui::MenuItem("Personnage (F1)", nullptr,
+						m_characterWindowImGui && m_characterWindowImGui->IsVisible()))
 					{
-						m_skillBookVisible = !m_skillBookVisible;
-						if (m_skillBookVisible) m_skillBookUi.RequestList();
+						// Ouvre la fenêtre Personnage unifiée (onglet Compétences).
+						if (m_characterWindowImGui)
+							m_characterWindowImGui->OpenAtTab(engine::render::CharacterWindowImGuiRenderer::Tab::Competences);
+						m_skillBookUi.RequestList();
 					}
 					if (ImGui::MenuItem("Arenes", nullptr, m_arenaVisible))
 					{

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9976,7 +9976,12 @@ namespace engine
 				// applyZoom coupé aussi quand ImGui capte la souris : sinon la molette
 				// utilisée pour défiler dans une fenêtre (ex. onglet Arbre de la fenêtre
 				// Personnage) zoomait AUSSI la caméra du jeu (retour joueur 2026-07-09).
-				const bool imguiWantsMouse = ImGui::GetIO().WantCaptureMouse;
+				// Cette section n'est PAS sous #if defined(_WIN32) et ImGui n'est inclus
+				// que sur Windows -> on garde la lecture WantCaptureMouse.
+				bool imguiWantsMouse = false;
+#if defined(_WIN32)
+				imguiWantsMouse = ImGui::GetIO().WantCaptureMouse;
+#endif
 				m_orbitalCameraController.Update(m_input, dt, mouseSensitivity, invertY, rmbLook,
 					!mouseOverRadar && !imguiWantsMouse, out.camera);
 

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -62,6 +62,7 @@
 #include "src/client/render/SkillBookImGuiRenderer.h"
 #include "src/client/render/GrimoireImGuiRenderer.h"
 #include "src/client/render/ClassSkillTreeImGuiRenderer.h"
+#include "src/client/render/CharacterWindowImGuiRenderer.h"
 #include "src/client/render/EditorHubImGuiRenderer.h"
 #include "src/client/gameplay/ActionBarLayout.h"
 #include "src/client/ui_common/CurrencyFormat.h"
@@ -7714,70 +7715,14 @@ namespace engine
 		if (m_input.WasPressed(engine::platform::Key::F_11))
     		m_window.ToggleFullscreen();
 
-		// CMANGOS.39 (Phase 4.39 step 3+4) — Touche B post-auth toggle le
-		// panneau Skill Book (equivalent a la slash command /skills). Bloquee
-		// si le chat a le focus (l'utilisateur tape) ou si le menu pause /
-		// editor est ouvert pour eviter les toggles accidentels.
-		{
-			const bool chatBlocks = m_chatUi.IsInitialized() && m_chatUi.IsChatFocusActive();
-			const bool inGameNoMenu = !m_inGamePauseMenuVisible
-				&& !m_inGameOptionsPanelVisible
-				&& !m_editorEnabled
-				&& m_authUi.IsInitialized()
-				&& m_authUi.IsFlowComplete();
-			if (inGameNoMenu && !chatBlocks
-				&& m_input.WasPressed(KeyFromName(m_cfg.GetString("controls.keybind.skillbook", "F2"), engine::platform::Key::F_2)))
-			{
-				m_skillBookVisible = !m_skillBookVisible;
-				if (m_skillBookVisible)
-				{
-					m_skillBookUi.RequestList();
-				}
-				LOG_INFO(Core, "[Engine] F2 toggle skillbook (visible={})", m_skillBookVisible);
-			}
-		}
+		// Chantier 1 — touche F2 (Skill Book) LIBÉRÉE : le livre de compétences est
+		// désormais l'onglet Compétences de la fenêtre Personnage unifiée (F1). Le
+		// RequestList() est déclenché à l'ouverture de la fenêtre côté conteneur au
+		// besoin ; l'ancien toggle F2 autonome est retiré.
 
-		// Grimoire (Task 13) — Touche I remappable post-auth toggle le panneau
-		// Grimoire / Carnet de techniques. Même guards que B (chat + pause + editor).
-		// Defaut = I : V etait en collision avec le talk marchand (SendTalkRequest,
-		// meme touche), ce qui ouvrait le Grimoire ET la boutique simultanement.
-		{
-			const bool chatBlocks = m_chatUi.IsInitialized() && m_chatUi.IsChatFocusActive();
-			const bool inGameNoMenu = !m_inGamePauseMenuVisible
-				&& !m_inGameOptionsPanelVisible
-				&& !m_editorEnabled
-				&& m_authUi.IsInitialized()
-				&& m_authUi.IsFlowComplete();
-			const engine::platform::Key grimoireKey =
-				KeyFromName(m_cfg.GetString("controls.keybind.grimoire", "F3"), engine::platform::Key::F_3);
-			if (inGameNoMenu && !chatBlocks && m_input.WasPressed(grimoireKey))
-			{
-				m_grimoireVisible = !m_grimoireVisible;
-				LOG_INFO(Core, "[Engine] Grimoire toggle (visible={})", m_grimoireVisible);
-			}
-		}
-
-		// SP-D — Touche W remappable post-auth toggle l'arbre de compétences par-classe.
-		// Même guards que Grimoire (chat + pause + editor). Defaut = W : Y etait en
-		// collision avec le panneau Meteo (meme touche Y), ce qui ouvrait l'arbre ET
-		// la meteo simultanement. W est libre en disposition ZQSD (deplacement = Z/Q/S/D)
-		// comme en AZERTY ; remappable via controls.keybind.skilltree pour les claviers
-		// QWERTY ou W sert au deplacement avant.
-		{
-			const bool chatBlocks = m_chatUi.IsInitialized() && m_chatUi.IsChatFocusActive();
-			const bool inGameNoMenu = !m_inGamePauseMenuVisible
-				&& !m_inGameOptionsPanelVisible
-				&& !m_editorEnabled
-				&& m_authUi.IsInitialized()
-				&& m_authUi.IsFlowComplete();
-			const engine::platform::Key treeKey =
-				KeyFromName(m_cfg.GetString("controls.keybind.skilltree", "F4"), engine::platform::Key::F_4);
-			if (inGameNoMenu && !chatBlocks && m_input.WasPressed(treeKey))
-			{
-				m_classSkillTreeVisible = !m_classSkillTreeVisible;
-				LOG_INFO(Core, "[Engine] ClassSkillTree toggle (visible={})", m_classSkillTreeVisible);
-			}
-		}
+		// Chantier 1 — touches F3 (Grimoire) et F4 (arbre) LIBÉRÉES : ces panneaux
+		// sont désormais des onglets de la fenêtre Personnage unifiée ouverte par F1
+		// (cf. bloc F1 plus bas). Leurs anciens toggles autonomes sont retirés.
 
 		// Bascule HUD carte — Touche U remappable post-auth masque/affiche le
 		// « cluster carte » : boussole + radar minimap + tracker de quêtes (retour
@@ -7911,16 +7856,23 @@ namespace engine
 				m_lootRollVisible = !m_lootRollVisible;
 				LOG_INFO(Core, "[Engine] F7 toggle loot roll (visible={})", m_lootRollVisible);
 			}
-			// R1-B (Task 4) — Touche C (mnemonique naturel « Character ») : toggle la
-			// feuille de personnage (stats derivees). Pas de fetch a l'ouverture :
-			// playerStats est deja peuple dans le modele UI a l'enter-world. L'action
-			// "punch" (controls.keybind.punch) a ete deplacee sur X pour liberer C.
-			// Memes guards que les autres toggles (chat focus, pause, editor, auth flow).
+			// Chantier 1 — Touche F1 : ouvre/ferme la fenêtre Personnage unifiée à
+			// onglets (perso 3D + inventaire + caractéristiques + argent, plus les
+			// onglets Compétences/Techniques/Arbre). Remplace l'ancien toggle de la
+			// fiche autonome ; F2/F3/F4/I sont désormais libres. Clé de config
+			// conservée (controls.keybind.charactersheet, défaut F1). Mêmes guards.
 			if (inGameNoMenu && !chatBlocks
 				&& m_input.WasPressed(KeyFromName(m_cfg.GetString("controls.keybind.charactersheet", "F1"), engine::platform::Key::F_1)))
 			{
-				m_characterSheetVisible = !m_characterSheetVisible;
-				LOG_INFO(Core, "[Engine] F1 toggle character sheet (visible={})", m_characterSheetVisible);
+				if (m_characterWindowImGui)
+				{
+					m_characterWindowImGui->ToggleVisible();
+					// Peupler l'onglet Compétences à l'ouverture (l'ancien toggle F2 le
+					// faisait ; le Skill Book se remplit via RequestList côté serveur).
+					if (m_characterWindowImGui->IsVisible())
+						m_skillBookUi.RequestList();
+				}
+				LOG_INFO(Core, "[Engine] F1 toggle fenetre Personnage");
 			}
 		}
 
@@ -8269,6 +8221,13 @@ namespace engine
 				}
 				m_classSkillTreeImGui->SetIconCache(&m_skillIconCache);
 				if (m_grimoireImGui) { m_grimoireImGui->SetIconCache(&m_skillIconCache); }
+				// Chantier 1 — fenêtre Personnage unifiée à onglets (F1). Regroupe les 3
+				// panneaux (pilotés en mode embarqué) + inventaire + argent + perso 3D
+				// (viewport branché en Task 4). Bind après création des sous-renderers et
+				// init du cache d'icônes.
+				m_characterWindowImGui = std::make_unique<engine::render::CharacterWindowImGuiRenderer>();
+				m_characterWindowImGui->Bind(&m_cfg, &m_uiModelBinding, &m_invUi, &m_skillIconCache,
+					m_skillBookImGui.get(), m_grimoireImGui.get(), m_classSkillTreeImGui.get());
 				// CMANGOS.21 (Phase 5.21 step 3+4) — Renderer ImGui du panneau
 				// Arena. Visible uniquement quand m_arenaVisible (toggle via
 				// /arena ou touche A). Le popup proposal s'affiche aussi quand
@@ -10694,10 +10653,10 @@ namespace engine
 				// debordent par-dessus et rendent le panneau illisible (ex. le label
 				// « Sanglier des collines » au milieu de l'arbre de competences).
 				const bool worldOverlaysHidden = m_inGamePauseMenuVisible || m_inGameOptionsPanelVisible
-					|| m_classSkillTreeVisible || m_grimoireVisible || m_skillBookVisible
+					|| (m_characterWindowImGui && m_characterWindowImGui->IsVisible())
 					|| m_auctionHouseVisible || m_arenaVisible || m_battleGroundVisible
 					|| m_outdoorPvpVisible || m_guildVisible || m_lootRollVisible
-					|| m_characterSheetVisible || m_craftingVisible || m_advancedCombatVisible
+					|| m_craftingVisible || m_advancedCombatVisible
 					|| m_weatherVisible;
 				if (!worldOverlaysHidden)
 				for (std::size_t ii = 0; ii < m_interactables.size(); ++ii)
@@ -11316,12 +11275,8 @@ namespace engine
 						m_advancedCombatVisible = !m_advancedCombatVisible;
 					}
 
-					// --- I : fenetre d'inventaire (grille objets). Retour joueur
-					// 2026-07-08 : l'inventaire etait calcule mais jamais affichable.
-					if (keysAllowed && m_input.WasPressed(engine::platform::Key::I))
-					{
-						m_inventoryVisible = !m_inventoryVisible;
-					}
+					// Chantier 1 — la touche I est LIBÉRÉE : l'inventaire est désormais
+					// l'onglet Personnage de la fenêtre unifiée (ouverte par F1).
 
 					// --- Cadre cible (haut-centre) : nom + barre de PV. Les PV de la
 					// cible suivent les snapshots (cf. UIModelBinding::ApplySnapshot).
@@ -12376,187 +12331,6 @@ namespace engine
 						}
 					}
 
-					// --- Fenetre d'inventaire (bascule touche I). La grille 4x4 est
-					// deja calculee par InventoryUiPresenter (slots, icones, quantites)
-					// mais n'etait jamais dessinee ni ouvrable. On la rend ici en fenetre
-					// ImGui deplacable + fermable. Retour joueur 2026-07-08.
-					if (m_inventoryVisible)
-					{
-						const engine::client::InventoryPanelState& inv = m_invUi.GetState();
-						const int invCols = (inv.columns > 0u) ? static_cast<int>(inv.columns) : 4;
-						const int invSlotCount = static_cast<int>(inv.slots.size());
-						const int invRows = (invSlotCount + invCols - 1) / invCols;
-						const float invCell = 54.0f;
-						const float invGap = 6.0f;
-						const float invPad = 12.0f;
-						const float invGridW = static_cast<float>(invCols) * invCell
-							+ static_cast<float>(invCols - 1) * invGap;
-						const float invGridH = static_cast<float>(invRows) * invCell
-							+ static_cast<float>(std::max(0, invRows - 1)) * invGap;
-						const float invWinW = invGridW + invPad * 2.0f;
-						ImGui::SetNextWindowPos(ImVec2((dw - invWinW) * 0.5f, dh * 0.26f), ImGuiCond_Appearing);
-						ImGui::SetNextWindowBgAlpha(0.95f);
-						ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.06f, 0.07f, 0.10f, 0.95f));
-						ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.47f, 0.39f, 0.16f, 0.86f));
-						const ImGuiWindowFlags invFlags = ImGuiWindowFlags_NoSavedSettings
-							| ImGuiWindowFlags_NoResize
-							| ImGuiWindowFlags_AlwaysAutoResize;
-						if (ImGui::Begin("Inventaire##ln_inventory", &m_inventoryVisible, invFlags))
-						{
-							ImDrawList* wdl = ImGui::GetWindowDrawList();
-							const ImVec2 invOrigin = ImGui::GetCursorScreenPos();
-							int invOccupied = 0;
-							for (int i = 0; i < invSlotCount; ++i)
-							{
-								const engine::client::InventorySlotState& slot =
-									inv.slots[static_cast<size_t>(i)];
-								const int r = i / invCols;
-								const int c = i % invCols;
-								const float cx0 = invOrigin.x + static_cast<float>(c) * (invCell + invGap);
-								const float cy0 = invOrigin.y + static_cast<float>(r) * (invCell + invGap);
-								const ImVec2 mn(cx0, cy0);
-								const ImVec2 mx(cx0 + invCell, cy0 + invCell);
-								const bool occupied = slot.occupied && slot.itemId != 0u;
-								wdl->AddRectFilled(mn, mx,
-									occupied ? IM_COL32(26, 30, 40, 235) : IM_COL32(16, 18, 24, 200), 5.0f);
-								wdl->AddRect(mn, mx,
-									occupied ? IM_COL32(150, 130, 60, 220) : IM_COL32(64, 66, 74, 180),
-									5.0f, 0, 1.5f);
-								if (!occupied)
-									continue;
-								++invOccupied;
-								bool hasIcon = false;
-								if (!slot.iconPath.empty())
-								{
-									const uint64_t texId = m_skillIconCache.GetOrLoad(slot.iconPath);
-									if (texId != 0)
-									{
-										const float ip = 3.0f;
-										wdl->AddImage(static_cast<ImTextureID>(texId),
-											ImVec2(cx0 + ip, cy0 + ip), ImVec2(mx.x - ip, mx.y - ip));
-										hasIcon = true;
-									}
-								}
-								if (!hasIcon && !slot.label.empty())
-								{
-									const std::string lbl = slot.label.substr(0, 8);
-									wdl->AddText(ImVec2(cx0 + 4.0f, cy0 + 6.0f),
-										IM_COL32(220, 220, 225, 255), lbl.c_str());
-								}
-								if (slot.quantity > 1u)
-								{
-									char qty[12];
-									std::snprintf(qty, sizeof(qty), "%u", slot.quantity);
-									const ImVec2 qs = ImGui::CalcTextSize(qty);
-									wdl->AddText(ImVec2(mx.x - qs.x - 4.0f, mx.y - qs.y - 3.0f),
-										IM_COL32(255, 240, 190, 255), qty);
-								}
-								if (ImGui::IsMouseHoveringRect(mn, mx) && !slot.label.empty())
-								{
-									ImGui::BeginTooltip();
-									ImGui::TextUnformatted(slot.label.c_str());
-									ImGui::EndTooltip();
-								}
-							}
-							// Reserve l'espace de la grille (dessinee au draw list manuel).
-							ImGui::Dummy(ImVec2(invGridW, invGridH));
-							if (invOccupied == 0)
-								ImGui::TextDisabled("Inventaire vide");
-						}
-						ImGui::End();
-						ImGui::PopStyleColor(2);
-					}
-
-					// --- Fenetre d'inventaire (bascule touche I). La grille 4x4 est
-					// deja calculee par InventoryUiPresenter (slots, icones, quantites)
-					// mais n'etait jamais dessinee ni ouvrable. On la rend ici en fenetre
-					// ImGui deplacable + fermable. Retour joueur 2026-07-08.
-					if (m_inventoryVisible)
-					{
-						const engine::client::InventoryPanelState& inv = m_invUi.GetState();
-						const int invCols = (inv.columns > 0u) ? static_cast<int>(inv.columns) : 4;
-						const int invSlotCount = static_cast<int>(inv.slots.size());
-						const int invRows = (invSlotCount + invCols - 1) / invCols;
-						const float invCell = 54.0f;
-						const float invGap = 6.0f;
-						const float invPad = 12.0f;
-						const float invGridW = static_cast<float>(invCols) * invCell
-							+ static_cast<float>(invCols - 1) * invGap;
-						const float invGridH = static_cast<float>(invRows) * invCell
-							+ static_cast<float>(std::max(0, invRows - 1)) * invGap;
-						const float invWinW = invGridW + invPad * 2.0f;
-						ImGui::SetNextWindowPos(ImVec2((dw - invWinW) * 0.5f, dh * 0.26f), ImGuiCond_Appearing);
-						ImGui::SetNextWindowBgAlpha(0.95f);
-						ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.06f, 0.07f, 0.10f, 0.95f));
-						ImGui::PushStyleColor(ImGuiCol_Border, ImVec4(0.47f, 0.39f, 0.16f, 0.86f));
-						const ImGuiWindowFlags invFlags = ImGuiWindowFlags_NoSavedSettings
-							| ImGuiWindowFlags_NoResize
-							| ImGuiWindowFlags_AlwaysAutoResize;
-						if (ImGui::Begin("Inventaire##ln_inventory", &m_inventoryVisible, invFlags))
-						{
-							ImDrawList* wdl = ImGui::GetWindowDrawList();
-							const ImVec2 invOrigin = ImGui::GetCursorScreenPos();
-							int invOccupied = 0;
-							for (int i = 0; i < invSlotCount; ++i)
-							{
-								const engine::client::InventorySlotState& slot =
-									inv.slots[static_cast<size_t>(i)];
-								const int r = i / invCols;
-								const int c = i % invCols;
-								const float cx0 = invOrigin.x + static_cast<float>(c) * (invCell + invGap);
-								const float cy0 = invOrigin.y + static_cast<float>(r) * (invCell + invGap);
-								const ImVec2 mn(cx0, cy0);
-								const ImVec2 mx(cx0 + invCell, cy0 + invCell);
-								const bool occupied = slot.occupied && slot.itemId != 0u;
-								wdl->AddRectFilled(mn, mx,
-									occupied ? IM_COL32(26, 30, 40, 235) : IM_COL32(16, 18, 24, 200), 5.0f);
-								wdl->AddRect(mn, mx,
-									occupied ? IM_COL32(150, 130, 60, 220) : IM_COL32(64, 66, 74, 180),
-									5.0f, 0, 1.5f);
-								if (!occupied)
-									continue;
-								++invOccupied;
-								bool hasIcon = false;
-								if (!slot.iconPath.empty())
-								{
-									const uint64_t texId = m_skillIconCache.GetOrLoad(slot.iconPath);
-									if (texId != 0)
-									{
-										const float ip = 3.0f;
-										wdl->AddImage(static_cast<ImTextureID>(texId),
-											ImVec2(cx0 + ip, cy0 + ip), ImVec2(mx.x - ip, mx.y - ip));
-										hasIcon = true;
-									}
-								}
-								if (!hasIcon && !slot.label.empty())
-								{
-									const std::string lbl = slot.label.substr(0, 8);
-									wdl->AddText(ImVec2(cx0 + 4.0f, cy0 + 6.0f),
-										IM_COL32(220, 220, 225, 255), lbl.c_str());
-								}
-								if (slot.quantity > 1u)
-								{
-									char qty[12];
-									std::snprintf(qty, sizeof(qty), "%u", slot.quantity);
-									const ImVec2 qs = ImGui::CalcTextSize(qty);
-									wdl->AddText(ImVec2(mx.x - qs.x - 4.0f, mx.y - qs.y - 3.0f),
-										IM_COL32(255, 240, 190, 255), qty);
-								}
-								if (ImGui::IsMouseHoveringRect(mn, mx) && !slot.label.empty())
-								{
-									ImGui::BeginTooltip();
-									ImGui::TextUnformatted(slot.label.c_str());
-									ImGui::EndTooltip();
-								}
-							}
-							// Reserve l'espace de la grille (dessinee au draw list manuel).
-							ImGui::Dummy(ImVec2(invGridW, invGridH));
-							if (invOccupied == 0)
-								ImGui::TextDisabled("Inventaire vide");
-						}
-						ImGui::End();
-						ImGui::PopStyleColor(2);
-					}
 
 					// --- Ecran de mort : overlay sombre + bouton Reapparaitre →
 					// RespawnRequest (le serveur ne l'honore que si le flag dead est pose ;
@@ -12691,15 +12465,9 @@ namespace engine
 				m_reputationImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_reputationImGui->Render();
 			}
-			// R1-B (Task 4) — Render de la feuille de personnage si visible. Lit
-			// directement le modele UI (playerStats) ; le renderer gere lui-meme
-			// le cas hasSheet == false (affiche "Statistiques indisponibles").
-			if (m_characterSheetVisible && m_characterSheetImGui)
-			{
-				m_characterSheetImGui->SetEnabled(true);
-				m_characterSheetImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
-				m_characterSheetImGui->Render(m_uiModelBinding.GetModel());
-			}
+			// Chantier 1 — les caractéristiques (ex-fiche F1) sont désormais dans
+			// l'onglet Personnage de la fenêtre unifiée (rendu plus bas). Ancien
+			// panneau F1 autonome retiré.
 			// CMANGOS.33 (Phase 5.33 step 3+4) — Render du panneau LFG si visible.
 			// Le modal proposal s'affiche aussi quand hasProposal == true (meme si
 			// le panneau principal est masque), pour que le joueur ne rate pas
@@ -12724,12 +12492,8 @@ namespace engine
 			// render le panneau Skill Book si visible. L'indicateur Use est rendu
 			// en plus de la liste si actif (overlay non bloquant).
 			m_skillBookUi.TickIndicator(static_cast<float>(m_time.DeltaSeconds()));
-			if (m_skillBookVisible && m_skillBookImGui && m_skillBookUi.IsInitialized())
-			{
-				m_skillBookImGui->SetEnabled(true);
-				m_skillBookImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
-				m_skillBookImGui->Render();
-			}
+			// Chantier 1 — le Skill Book est désormais l'onglet Compétences de la
+			// fenêtre unifiée (rendu embarqué plus bas). Panneau autonome retiré.
 			// Grimoire (Task 13) — Sync du presenter (profil + layout autoritaire)
 			// puis render conditionnel si le panneau est ouvert.
 			// SP-C — kit effectif : compétences de classe connues (fallback kit profil).
@@ -12761,12 +12525,8 @@ namespace engine
 				}
 				m_grimoireUi.Sync(gProfileId, grimoireModel.playerStats.actionBarLayout, grimoireEffectiveKit);
 			}
-			if (m_grimoireVisible && m_grimoireImGui && m_grimoireUi.IsInitialized())
-			{
-				m_grimoireImGui->SetEnabled(true);
-				m_grimoireImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
-				m_grimoireImGui->Render();
-			}
+			// Chantier 1 — le Grimoire est désormais l'onglet Techniques de la fenêtre
+			// unifiée (rendu embarqué plus bas). Le Sync ci-dessus reste nécessaire.
 			// SP-D — Sync + render conditionnel de l'arbre de compétences par-classe.
 			// Niveau réel du perso (capturé à EnterWorld depuis CHARACTER_LIST) : verrouille
 			// les paliers > niveau et affiche le bon « Niveau joueur ». Le serveur revalide.
@@ -12783,12 +12543,18 @@ namespace engine
 				if (treeModel.playerStats.hasXp && treeModel.playerStats.level > m_activeCharacterLevel)
 					m_activeCharacterLevel = treeModel.playerStats.level;
 				m_classSkillTreeUi.Sync(treeModel.classId, treeModel.knownSkillIds, m_activeCharacterLevel);
-				if (m_classSkillTreeVisible && m_classSkillTreeImGui && m_classSkillTreeUi.IsInitialized())
-				{
-					m_classSkillTreeImGui->SetEnabled(true);
-					m_classSkillTreeImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
-					m_classSkillTreeImGui->Render();
-				}
+				// Chantier 1 — l'arbre est désormais l'onglet Arbre de la fenêtre unifiée
+				// (rendu embarqué juste après). Le Sync ci-dessus reste nécessaire.
+			}
+			// Chantier 1 — fenêtre Personnage unifiée à onglets (F1). Rendue APRÈS les
+			// Sync du Grimoire et de l'arbre (leurs presenters embarqués lisent l'état à
+			// jour). Point single-pass (même bloc que les autres panneaux) -> pas de
+			// doublon d'inventaire (le bug de #958 venait d'un rendu dans la région HUD
+			// avant-plan, finalisée par deux ImGui::Render()).
+			if (m_characterWindowImGui)
+			{
+				m_characterWindowImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
+				m_characterWindowImGui->Render(m_uiModelBinding.GetModel());
 			}
 			// CMANGOS.21 (Phase 5.21 step 3+4) — Render du panneau Arena si
 			// visible. Le popup proposal s'affiche aussi quand pendingProposalId

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7867,10 +7867,19 @@ namespace engine
 				if (m_characterWindowImGui)
 				{
 					m_characterWindowImGui->ToggleVisible();
-					// Peupler l'onglet Compétences à l'ouverture (l'ancien toggle F2 le
-					// faisait ; le Skill Book se remplit via RequestList côté serveur).
 					if (m_characterWindowImGui->IsVisible())
+					{
+						// Peupler l'onglet Compétences (l'ancien toggle F2 le faisait ;
+						// le Skill Book se remplit via RequestList côté serveur).
 						m_skillBookUi.RequestList();
+						// Task 4 — pose l'avatar du joueur dans le viewport 3D À
+						// L'OUVERTURE seulement : SetMesh réinitialise l'animation, il ne
+						// doit PAS être rappelé chaque frame (sinon l'anim reste figée à
+						// t=0). Le Tick/RenderOffscreen se font ensuite tant que ouvert.
+						m_racePreviewViewport.SetGender(m_avatarGender);
+						m_racePreviewViewport.SetSkinTone(m_avatarSkinTone);
+						m_racePreviewViewport.SetMesh(m_currentSkinnedMesh);
+					}
 				}
 				LOG_INFO(Core, "[Engine] F1 toggle fenetre Personnage");
 			}
@@ -8228,6 +8237,9 @@ namespace engine
 				m_characterWindowImGui = std::make_unique<engine::render::CharacterWindowImGuiRenderer>();
 				m_characterWindowImGui->Bind(&m_cfg, &m_uiModelBinding, &m_invUi, &m_skillIconCache,
 					m_skillBookImGui.get(), m_grimoireImGui.get(), m_classSkillTreeImGui.get());
+				// Task 4 — aperçu 3D : le conteneur affiche la texture offscreen du
+				// viewport perso (alimenté quand la fenêtre est ouverte, cf. Update).
+				m_characterWindowImGui->SetRaceViewport(&m_racePreviewViewport);
 				// CMANGOS.21 (Phase 5.21 step 3+4) — Renderer ImGui du panneau
 				// Arena. Visible uniquement quand m_arenaVisible (toggle via
 				// /arena ou touche A). Le popup proposal s'affiche aussi quand
@@ -12546,11 +12558,26 @@ namespace engine
 				// Chantier 1 — l'arbre est désormais l'onglet Arbre de la fenêtre unifiée
 				// (rendu embarqué juste après). Le Sync ci-dessus reste nécessaire.
 			}
+			// Task 4 — aperçu 3D : fait tourner + rend l'avatar du joueur dans l'image
+			// offscreen tant que la fenêtre Personnage est ouverte, AVANT que la draw
+			// list ImGui n'échantillonne la texture. RenderOffscreen est autonome
+			// (submit + wait idle) : coûteux (stall GPU) -> uniquement fenêtre ouverte.
+			// Le mesh/genre/teinte sont posés à l'ouverture (toggle F1) ; ici on ne fait
+			// qu'avancer l'anim/orbit et rendre.
+			if (m_characterWindowImGui && m_characterWindowImGui->IsVisible())
+			{
+				const float pNow = EngineNowSec();
+				float pDt = (m_racePreviewLastNowSec > 0.0f) ? (pNow - m_racePreviewLastNowSec) : 0.0f;
+				m_racePreviewLastNowSec = pNow;
+				if (pDt < 0.0f) pDt = 0.0f;
+				if (pDt > 0.1f) pDt = 0.1f; // clamp gros hitch
+				m_racePreviewViewport.Tick(pDt);
+				m_racePreviewViewport.RenderOffscreen();
+			}
 			// Chantier 1 — fenêtre Personnage unifiée à onglets (F1). Rendue APRÈS les
 			// Sync du Grimoire et de l'arbre (leurs presenters embarqués lisent l'état à
 			// jour). Point single-pass (même bloc que les autres panneaux) -> pas de
-			// doublon d'inventaire (le bug de #958 venait d'un rendu dans la région HUD
-			// avant-plan, finalisée par deux ImGui::Render()).
+			// doublon d'inventaire.
 			if (m_characterWindowImGui)
 			{
 				m_characterWindowImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9973,7 +9973,12 @@ namespace engine
 				}
 
 				const bool rmbLook = m_input.IsMouseDown(engine::platform::MouseButton::Right);
-				m_orbitalCameraController.Update(m_input, dt, mouseSensitivity, invertY, rmbLook, !mouseOverRadar, out.camera);
+				// applyZoom coupé aussi quand ImGui capte la souris : sinon la molette
+				// utilisée pour défiler dans une fenêtre (ex. onglet Arbre de la fenêtre
+				// Personnage) zoomait AUSSI la caméra du jeu (retour joueur 2026-07-09).
+				const bool imguiWantsMouse = ImGui::GetIO().WantCaptureMouse;
+				m_orbitalCameraController.Update(m_input, dt, mouseSensitivity, invertY, rmbLook,
+					!mouseOverRadar && !imguiWantsMouse, out.camera);
 
 				// --- Clamp anti-sous-sol : la caméra ne descend pas sous le terrain. ---
 				const bool occEnabled = m_cfg.GetBool("client.camera.occlusion_fade.enabled", true);
@@ -10799,6 +10804,22 @@ namespace engine
 						// (x,y,z,w = gauche,haut,droite,bas). Une nouvelle plaque qui en
 						// recouvre une est remontee d'une hauteur de plaque (empilement).
 						std::vector<ImVec4> placedLabelRects;
+					// Le Journal de quêtes (coin haut-gauche, toujours visible) est une
+					// fenêtre ImGui ; les plaques de mob passent par le foreground draw
+					// list, donc AU-DESSUS. On récupère son rectangle pour sauter toute
+					// plaque qui retomberait dessus (retour joueur 2026-07-09 : « Sanglier
+					// des collines » s'affichait par-dessus le journal).
+					ImVec4 journalRect(0.0f, 0.0f, 0.0f, 0.0f);
+					bool hasJournalRect = false;
+					{
+						const engine::client::QuestUiState& qs = m_questUi.GetState();
+						if (qs.layoutValid)
+						{
+							const engine::client::QuestUiRect& jb = qs.journalPanelBounds;
+							journalRect = ImVec4(jb.x, jb.y, jb.x + jb.width, jb.y + jb.height);
+							hasJournalRect = true;
+						}
+					}
 					for (const engine::client::UIRemoteEntity& re : remotes)
 					{
 						// Combat SP1 : les mobs (archetypeId != 0) ont leur plaque.
@@ -10921,6 +10942,16 @@ namespace engine
 							}
 							if (!overlap) break;
 							syp -= (plateH + 3.0f);
+						}
+						// Ne pas dessiner la plaque si elle retombe sur le Journal de quêtes
+						// (elle serait masquée par la fenêtre de toute façon, mais le
+						// foreground la peindrait par-dessus -> illisible).
+						if (hasJournalRect
+							&& (sxp - plateHalfW) < journalRect.z && (sxp + plateHalfW) > journalRect.x
+							&& (syp - ts.y - 2.0f) < journalRect.w
+							&& (syp + (drawMobHealthBar ? 24.0f : 4.0f)) > journalRect.y)
+						{
+							continue;
 						}
 						placedLabelRects.emplace_back(sxp - plateHalfW, syp - ts.y - 2.0f,
 							sxp + plateHalfW, syp + (drawMobHealthBar ? 24.0f : 4.0f));

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -142,6 +142,7 @@ namespace engine::render
 	class SkillBookImGuiRenderer;
 	class GrimoireImGuiRenderer;
 	class ClassSkillTreeImGuiRenderer;
+	class CharacterWindowImGuiRenderer;
 	class ArenaImGuiRenderer;
 	class BattleGroundImGuiRenderer;
 	class OutdoorPvpImGuiRenderer;
@@ -1386,6 +1387,10 @@ namespace engine
 		/// SP-D — Renderer ImGui du panneau arbre de compétences.
 		/// Forward-déclaré dans Engine.h (ClassSkillTreeImGuiRenderer).
 		std::unique_ptr<engine::render::ClassSkillTreeImGuiRenderer> m_classSkillTreeImGui;
+		/// Chantier 1 — fenêtre Personnage unifiée à onglets (touche F1). Regroupe
+		/// perso 3D + inventaire + caractéristiques + argent (onglet défaut) et
+		/// délègue aux renderers Compétences/Techniques/Arbre en mode embarqué.
+		std::unique_ptr<engine::render::CharacterWindowImGuiRenderer> m_characterWindowImGui;
 		/// SP-E - Cache d'icones de competences (PNG -> texture ImGui), partage par
 		/// l'arbre, le Grimoire et la barre d'action. Init apres ImGui, Shutdown avant.
 		engine::client::SkillIconCache m_skillIconCache;
@@ -1568,11 +1573,6 @@ namespace engine
 		std::unordered_map<std::string, float> m_spellCooldownUiUntilSec;
 		/// Combat SP2 — visibilité du panneau combat avancé (touche J).
 		bool m_advancedCombatVisible = false;
-		/// Inventaire — visibilité de la fenêtre d'inventaire (touche I). Retour
-		/// joueur 2026-07-08 : « je gagne un objet mais je ne peux pas afficher
-		/// l'inventaire ». La grille était calculée (InventoryUiPresenter) mais
-		/// jamais dessinée ni ouvrable.
-		bool m_inventoryVisible = false;
 		/// Combat SP2 — throttle local d'envoi d'AttackRequest (le serveur reste
 		/// l'autorité du cooldown réel ; ceci évite juste le spam réseau).
 		float m_attackSendCooldownSec = 0.0f;

--- a/src/client/inventory/InventoryUi.cpp
+++ b/src/client/inventory/InventoryUi.cpp
@@ -12,10 +12,10 @@ namespace engine::client
 {
 	namespace
 	{
-		// Capacité augmentée (retour joueur 2026-07-09 : « plus d'objets »). 6x5 = 30
-		// emplacements affichés (la grille de la fenêtre Personnage lit ces valeurs).
-		inline constexpr uint32_t kInventoryColumns = 6;
-		inline constexpr uint32_t kInventoryRows = 5;
+		// Capacité augmentée (retours joueur 2026-07-09). 8x8 = 64 emplacements
+		// affichés (la grille de la fenêtre Personnage lit ces valeurs).
+		inline constexpr uint32_t kInventoryColumns = 8;
+		inline constexpr uint32_t kInventoryRows = 8;
 		inline constexpr size_t kPickupFeedbackMaxEntries = 3;
 		inline constexpr float kPickupFeedbackDurationSeconds = 2.0f;
 

--- a/src/client/inventory/InventoryUi.cpp
+++ b/src/client/inventory/InventoryUi.cpp
@@ -12,8 +12,10 @@ namespace engine::client
 {
 	namespace
 	{
-		inline constexpr uint32_t kInventoryColumns = 4;
-		inline constexpr uint32_t kInventoryRows = 4;
+		// Capacité augmentée (retour joueur 2026-07-09 : « plus d'objets »). 6x5 = 30
+		// emplacements affichés (la grille de la fenêtre Personnage lit ces valeurs).
+		inline constexpr uint32_t kInventoryColumns = 6;
+		inline constexpr uint32_t kInventoryRows = 5;
 		inline constexpr size_t kPickupFeedbackMaxEntries = 3;
 		inline constexpr float kPickupFeedbackDurationSeconds = 2.0f;
 

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -42,8 +42,9 @@ namespace engine::render
 
 		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.0f;
 		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.0f;
-		const float winW = 660.0f;
-		const float winH = 460.0f;
+		// Fenêtre agrandie (retour joueur 2026-07-09 : « trop petite, textes compacts »).
+		const float winW = 940.0f;
+		const float winH = 640.0f;
 		ImGui::SetNextWindowPos(ImVec2((vpW - winW) * 0.5f, (vpH - winH) * 0.5f), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowSize(ImVec2(winW, winH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.96f);
@@ -130,8 +131,11 @@ namespace engine::render
 
 			// Caractéristiques compactes (ex-fiche F1).
 			const engine::client::UIPlayerStats& ps = model.playerStats;
+			ImGui::Spacing();
 			ImGui::Text("Niveau %u", ps.level);
-			ImGui::Text("Points de vie : %u", ps.maxHealth);
+			// PV : sheetMaxHealth (peuplé par PlayerStats, comme l'ancienne fiche F1) ;
+			// maxHealth est piloté par le snapshot et peut rester 0 hors combat.
+			ImGui::Text("Points de vie : %u", ps.sheetMaxHealth);
 			ImGui::Text("Ressource : %u", ps.secondaryResourceMax);
 			ImGui::Text("Degats : %u", ps.damage);
 		}

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -13,6 +13,7 @@
 #if defined(_WIN32)
 #	include "imgui.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <string>
 
@@ -102,30 +103,37 @@ namespace engine::render
 	{
 		// Deux colonnes : gauche (3D + slots équipement inactifs + caractéristiques),
 		// droite (inventaire + argent).
-		const float leftW = ImGui::GetContentRegionAvail().x * 0.46f;
+		const float leftW = ImGui::GetContentRegionAvail().x * 0.44f;
 
 		ImGui::BeginChild("##ln_char_left", ImVec2(leftW, 0.0f), false);
 		{
 			const ImVec2 avail = ImGui::GetContentRegionAvail();
-			const float previewH = 190.0f;
+			// Aperçu CARRÉ (la texture du viewport est 512x512) : dessiner en largeur
+			// pleine l'écrasait verticalement (retour joueur 2026-07-09). On centre un
+			// carré de côté = min(largeur dispo, 320).
+			const float side = std::min(avail.x, 320.0f);
+			const float offX = (avail.x - side) * 0.5f;
 			if (m_raceViewport != nullptr && m_raceViewport->GetImguiTextureId() != 0u)
 			{
+				ImGui::SetCursorPosX(ImGui::GetCursorPosX() + offX);
 				ImGui::Image(static_cast<ImTextureID>(m_raceViewport->GetImguiTextureId()),
-					ImVec2(avail.x, previewH));
+					ImVec2(side, side));
 			}
 			else
 			{
-				// Placeholder tant que le viewport 3D n'est pas branché (Task 4).
+				// Placeholder tant que le viewport 3D n'est pas branché.
 				ImDrawList* dl = ImGui::GetWindowDrawList();
-				const ImVec2 p0 = ImGui::GetCursorScreenPos();
-				dl->AddRectFilled(p0, ImVec2(p0.x + avail.x, p0.y + previewH), IM_COL32(14, 16, 22, 255), 6.0f);
+				const ImVec2 p0raw = ImGui::GetCursorScreenPos();
+				const ImVec2 p0(p0raw.x + offX, p0raw.y);
+				dl->AddRectFilled(p0, ImVec2(p0.x + side, p0.y + side), IM_COL32(14, 16, 22, 255), 6.0f);
 				const char* lbl = "Apercu 3D";
 				const ImVec2 ts = ImGui::CalcTextSize(lbl);
-				dl->AddText(ImVec2(p0.x + (avail.x - ts.x) * 0.5f, p0.y + previewH * 0.5f - ts.y * 0.5f),
+				dl->AddText(ImVec2(p0.x + (side - ts.x) * 0.5f, p0.y + side * 0.5f - ts.y * 0.5f),
 					IM_COL32(120, 130, 160, 255), lbl);
-				ImGui::Dummy(ImVec2(avail.x, previewH));
+				ImGui::Dummy(ImVec2(avail.x, side));
 			}
 
+			ImGui::Spacing();
 			ImGui::TextDisabled("Equipement — Chantier 2");
 			ImGui::Separator();
 
@@ -146,14 +154,16 @@ namespace engine::render
 		ImGui::BeginChild("##ln_char_right", ImVec2(0.0f, 0.0f), false);
 		{
 			ImGui::TextUnformatted("Inventaire");
+			ImGui::Spacing();
 
 			if (m_inv != nullptr)
 			{
 				const engine::client::InventoryPanelState& gi = m_inv->GetState();
 				const int cols = (gi.columns > 0u) ? static_cast<int>(gi.columns) : 4;
 				const int count = static_cast<int>(gi.slots.size());
-				const float cell = 48.0f;
-				const float gap = 6.0f;
+				// Cellules plus grandes (retour joueur 2026-07-09 : inventaire trop petit).
+				const float cell = 66.0f;
+				const float gap = 8.0f;
 				ImDrawList* wdl = ImGui::GetWindowDrawList();
 				const ImVec2 origin = ImGui::GetCursorScreenPos();
 				for (int i = 0; i < count; ++i)

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -1,0 +1,220 @@
+#include "src/client/render/CharacterWindowImGuiRenderer.h"
+
+#include "src/client/render/SkillBookImGuiRenderer.h"
+#include "src/client/render/GrimoireImGuiRenderer.h"
+#include "src/client/render/ClassSkillTreeImGuiRenderer.h"
+#include "src/client/render/race/RacePreviewViewport.h"
+#include "src/client/render/SkillIconCache.h"
+#include "src/client/ui_common/UIModel.h"
+#include "src/client/ui_common/CurrencyFormat.h"
+#include "src/client/inventory/InventoryUi.h"
+#include "src/shared/core/Config.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+
+#include <cstdio>
+#include <string>
+
+namespace engine::render
+{
+	void CharacterWindowImGuiRenderer::Bind(const engine::core::Config* cfg,
+		const engine::client::UIModelBinding* uiBinding,
+		const engine::client::InventoryUiPresenter* inv,
+		engine::client::SkillIconCache* icons,
+		engine::render::SkillBookImGuiRenderer* skillBook,
+		engine::render::GrimoireImGuiRenderer* grimoire,
+		engine::render::ClassSkillTreeImGuiRenderer* classTree)
+	{
+		m_cfg = cfg;
+		m_uiBinding = uiBinding;
+		m_inv = inv;
+		m_icons = icons;
+		m_skillBook = skillBook;
+		m_grimoire = grimoire;
+		m_classTree = classTree;
+	}
+
+	void CharacterWindowImGuiRenderer::Render(const engine::client::UIModel& model)
+	{
+		if (!m_visible)
+			return;
+
+		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.0f;
+		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.0f;
+		const float winW = 660.0f;
+		const float winH = 460.0f;
+		ImGui::SetNextWindowPos(ImVec2((vpW - winW) * 0.5f, (vpH - winH) * 0.5f), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowSize(ImVec2(winW, winH), ImGuiCond_FirstUseEver);
+		ImGui::SetNextWindowBgAlpha(0.96f);
+
+		if (ImGui::Begin("Personnage##ln_character_window", &m_visible, ImGuiWindowFlags_NoCollapse))
+		{
+			if (ImGui::BeginTabBar("##ln_character_tabs"))
+			{
+				if (ImGui::BeginTabItem("Personnage"))
+				{
+					m_activeTab = Tab::Personnage;
+					RenderPersonnageTab(model);
+					ImGui::EndTabItem();
+				}
+				if (ImGui::BeginTabItem("Competences"))
+				{
+					m_activeTab = Tab::Competences;
+					if (m_skillBook)
+					{
+						m_skillBook->SetEmbedded(true);
+						m_skillBook->SetEnabled(true);
+						m_skillBook->Render();
+					}
+					ImGui::EndTabItem();
+				}
+				if (ImGui::BeginTabItem("Techniques"))
+				{
+					m_activeTab = Tab::Techniques;
+					if (m_grimoire)
+					{
+						m_grimoire->SetEmbedded(true);
+						m_grimoire->SetEnabled(true);
+						m_grimoire->Render();
+					}
+					ImGui::EndTabItem();
+				}
+				if (ImGui::BeginTabItem("Arbre"))
+				{
+					m_activeTab = Tab::Arbre;
+					if (m_classTree)
+					{
+						m_classTree->SetEmbedded(true);
+						m_classTree->SetEnabled(true);
+						m_classTree->Render();
+					}
+					ImGui::EndTabItem();
+				}
+				ImGui::EndTabBar();
+			}
+		}
+		ImGui::End();
+	}
+
+	void CharacterWindowImGuiRenderer::RenderPersonnageTab(const engine::client::UIModel& model)
+	{
+		// Deux colonnes : gauche (3D + slots équipement inactifs + caractéristiques),
+		// droite (inventaire + argent).
+		const float leftW = ImGui::GetContentRegionAvail().x * 0.46f;
+
+		ImGui::BeginChild("##ln_char_left", ImVec2(leftW, 0.0f), false);
+		{
+			const ImVec2 avail = ImGui::GetContentRegionAvail();
+			const float previewH = 190.0f;
+			if (m_raceViewport != nullptr && m_raceViewport->GetImguiTextureId() != 0u)
+			{
+				ImGui::Image(static_cast<ImTextureID>(m_raceViewport->GetImguiTextureId()),
+					ImVec2(avail.x, previewH));
+			}
+			else
+			{
+				// Placeholder tant que le viewport 3D n'est pas branché (Task 4).
+				ImDrawList* dl = ImGui::GetWindowDrawList();
+				const ImVec2 p0 = ImGui::GetCursorScreenPos();
+				dl->AddRectFilled(p0, ImVec2(p0.x + avail.x, p0.y + previewH), IM_COL32(14, 16, 22, 255), 6.0f);
+				const char* lbl = "Apercu 3D";
+				const ImVec2 ts = ImGui::CalcTextSize(lbl);
+				dl->AddText(ImVec2(p0.x + (avail.x - ts.x) * 0.5f, p0.y + previewH * 0.5f - ts.y * 0.5f),
+					IM_COL32(120, 130, 160, 255), lbl);
+				ImGui::Dummy(ImVec2(avail.x, previewH));
+			}
+
+			ImGui::TextDisabled("Equipement — Chantier 2");
+			ImGui::Separator();
+
+			// Caractéristiques compactes (ex-fiche F1).
+			const engine::client::UIPlayerStats& ps = model.playerStats;
+			ImGui::Text("Niveau %u", ps.level);
+			ImGui::Text("Points de vie : %u", ps.maxHealth);
+			ImGui::Text("Ressource : %u", ps.secondaryResourceMax);
+			ImGui::Text("Degats : %u", ps.damage);
+		}
+		ImGui::EndChild();
+
+		ImGui::SameLine();
+
+		ImGui::BeginChild("##ln_char_right", ImVec2(0.0f, 0.0f), false);
+		{
+			ImGui::TextUnformatted("Inventaire");
+
+			if (m_inv != nullptr)
+			{
+				const engine::client::InventoryPanelState& gi = m_inv->GetState();
+				const int cols = (gi.columns > 0u) ? static_cast<int>(gi.columns) : 4;
+				const int count = static_cast<int>(gi.slots.size());
+				const float cell = 48.0f;
+				const float gap = 6.0f;
+				ImDrawList* wdl = ImGui::GetWindowDrawList();
+				const ImVec2 origin = ImGui::GetCursorScreenPos();
+				for (int i = 0; i < count; ++i)
+				{
+					const engine::client::InventorySlotState& s = gi.slots[static_cast<size_t>(i)];
+					const int r = i / cols;
+					const int c = i % cols;
+					const float x0 = origin.x + static_cast<float>(c) * (cell + gap);
+					const float y0 = origin.y + static_cast<float>(r) * (cell + gap);
+					const ImVec2 mn(x0, y0);
+					const ImVec2 mx(x0 + cell, y0 + cell);
+					const bool occ = s.occupied && s.itemId != 0u;
+					wdl->AddRectFilled(mn, mx, occ ? IM_COL32(26, 30, 40, 235) : IM_COL32(16, 18, 24, 200), 5.0f);
+					wdl->AddRect(mn, mx, occ ? IM_COL32(150, 130, 60, 220) : IM_COL32(64, 66, 74, 180), 5.0f, 0, 1.5f);
+					if (!occ)
+						continue;
+					bool hasIcon = false;
+					if (m_icons != nullptr && !s.iconPath.empty())
+					{
+						const uint64_t tex = m_icons->GetOrLoad(s.iconPath);
+						if (tex != 0)
+						{
+							wdl->AddImage(static_cast<ImTextureID>(tex), ImVec2(x0 + 3, y0 + 3), ImVec2(mx.x - 3, mx.y - 3));
+							hasIcon = true;
+						}
+					}
+					if (!hasIcon && !s.label.empty())
+						wdl->AddText(ImVec2(x0 + 4, y0 + 5), IM_COL32(220, 220, 225, 255), s.label.substr(0, 7).c_str());
+					if (s.quantity > 1u)
+					{
+						char q[12];
+						std::snprintf(q, sizeof(q), "%u", s.quantity);
+						const ImVec2 qs = ImGui::CalcTextSize(q);
+						wdl->AddText(ImVec2(mx.x - qs.x - 3, mx.y - qs.y - 2), IM_COL32(255, 240, 190, 255), q);
+					}
+					if (ImGui::IsMouseHoveringRect(mn, mx) && !s.label.empty())
+					{
+						ImGui::BeginTooltip();
+						ImGui::TextUnformatted(s.label.c_str());
+						ImGui::EndTooltip();
+					}
+				}
+				const int rows = (count + cols - 1) / cols;
+				ImGui::Dummy(ImVec2(0.0f, static_cast<float>(rows) * (cell + gap)));
+			}
+
+			// Bourse or/argent/bronze (base = bronze, cf. CurrencyFormat.h).
+			const engine::client::CoinBreakdown coins = engine::client::SplitCoins(model.wallet.gold);
+			ImGui::Separator();
+			ImGui::Text("Or %u   Arg %u   Br %u", coins.gold, coins.silver, coins.bronze);
+		}
+		ImGui::EndChild();
+	}
+}
+
+#else // !_WIN32 — stub no-op.
+
+namespace engine::render
+{
+	void CharacterWindowImGuiRenderer::Bind(const engine::core::Config*, const engine::client::UIModelBinding*,
+		const engine::client::InventoryUiPresenter*, engine::client::SkillIconCache*,
+		engine::render::SkillBookImGuiRenderer*, engine::render::GrimoireImGuiRenderer*,
+		engine::render::ClassSkillTreeImGuiRenderer*) {}
+	void CharacterWindowImGuiRenderer::Render(const engine::client::UIModel&) {}
+	void CharacterWindowImGuiRenderer::RenderPersonnageTab(const engine::client::UIModel&) {}
+}
+
+#endif

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -44,9 +44,9 @@ namespace engine::render
 		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.0f;
 		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.0f;
 		// Fenêtre agrandie (retours joueur 2026-07-09) : plus haute pour l'aperçu 3D
-		// et plus large pour un inventaire 6x5.
-		const float winW = 980.0f;
-		const float winH = 720.0f;
+		// et assez large pour un inventaire 8x8.
+		const float winW = 1120.0f;
+		const float winH = 740.0f;
 		ImGui::SetNextWindowPos(ImVec2((vpW - winW) * 0.5f, (vpH - winH) * 0.5f), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowSize(ImVec2(winW, winH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.96f);
@@ -109,7 +109,7 @@ namespace engine::render
 	{
 		// Deux colonnes : gauche (3D + slots équipement inactifs + caractéristiques),
 		// droite (inventaire + argent).
-		const float leftW = ImGui::GetContentRegionAvail().x * 0.42f;
+		const float leftW = ImGui::GetContentRegionAvail().x * 0.38f;
 
 		ImGui::BeginChild("##ln_char_left", ImVec2(leftW, 0.0f), false);
 		{
@@ -172,9 +172,9 @@ namespace engine::render
 				const engine::client::InventoryPanelState& gi = m_inv->GetState();
 				const int cols = (gi.columns > 0u) ? static_cast<int>(gi.columns) : 4;
 				const int count = static_cast<int>(gi.slots.size());
-				// Cellules plus grandes (retour joueur 2026-07-09 : inventaire trop petit).
-				const float cell = 66.0f;
-				const float gap = 8.0f;
+				// Cellules dimensionnées pour loger 8 colonnes dans la fenêtre élargie.
+				const float cell = 58.0f;
+				const float gap = 7.0f;
 				ImDrawList* wdl = ImGui::GetWindowDrawList();
 				const ImVec2 origin = ImGui::GetCursorScreenPos();
 				for (int i = 0; i < count; ++i)

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -43,24 +43,29 @@ namespace engine::render
 
 		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.0f;
 		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.0f;
-		// Fenêtre agrandie (retour joueur 2026-07-09 : « trop petite, textes compacts »).
-		const float winW = 940.0f;
-		const float winH = 640.0f;
+		// Fenêtre agrandie (retours joueur 2026-07-09) : plus haute pour l'aperçu 3D
+		// et plus large pour un inventaire 6x5.
+		const float winW = 980.0f;
+		const float winH = 720.0f;
 		ImGui::SetNextWindowPos(ImVec2((vpW - winW) * 0.5f, (vpH - winH) * 0.5f), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowSize(ImVec2(winW, winH), ImGuiCond_FirstUseEver);
 		ImGui::SetNextWindowBgAlpha(0.96f);
 
 		if (ImGui::Begin("Personnage##ln_character_window", &m_visible, ImGuiWindowFlags_NoCollapse))
 		{
+			// Sélection d'onglet programmatique (OpenAtTab via slash commands / menu).
+			auto tabFlag = [&](Tab t) -> ImGuiTabItemFlags {
+				return (m_hasPendingTab && m_pendingTab == t) ? ImGuiTabItemFlags_SetSelected : 0;
+			};
 			if (ImGui::BeginTabBar("##ln_character_tabs"))
 			{
-				if (ImGui::BeginTabItem("Personnage"))
+				if (ImGui::BeginTabItem("Personnage", nullptr, tabFlag(Tab::Personnage)))
 				{
 					m_activeTab = Tab::Personnage;
 					RenderPersonnageTab(model);
 					ImGui::EndTabItem();
 				}
-				if (ImGui::BeginTabItem("Competences"))
+				if (ImGui::BeginTabItem("Competences", nullptr, tabFlag(Tab::Competences)))
 				{
 					m_activeTab = Tab::Competences;
 					if (m_skillBook)
@@ -71,7 +76,7 @@ namespace engine::render
 					}
 					ImGui::EndTabItem();
 				}
-				if (ImGui::BeginTabItem("Techniques"))
+				if (ImGui::BeginTabItem("Techniques", nullptr, tabFlag(Tab::Techniques)))
 				{
 					m_activeTab = Tab::Techniques;
 					if (m_grimoire)
@@ -82,7 +87,7 @@ namespace engine::render
 					}
 					ImGui::EndTabItem();
 				}
-				if (ImGui::BeginTabItem("Arbre"))
+				if (ImGui::BeginTabItem("Arbre", nullptr, tabFlag(Tab::Arbre)))
 				{
 					m_activeTab = Tab::Arbre;
 					if (m_classTree)
@@ -95,6 +100,7 @@ namespace engine::render
 				}
 				ImGui::EndTabBar();
 			}
+			m_hasPendingTab = false; // sélection consommée pour cette frame.
 		}
 		ImGui::End();
 	}
@@ -103,21 +109,26 @@ namespace engine::render
 	{
 		// Deux colonnes : gauche (3D + slots équipement inactifs + caractéristiques),
 		// droite (inventaire + argent).
-		const float leftW = ImGui::GetContentRegionAvail().x * 0.44f;
+		const float leftW = ImGui::GetContentRegionAvail().x * 0.42f;
 
 		ImGui::BeginChild("##ln_char_left", ImVec2(leftW, 0.0f), false);
 		{
 			const ImVec2 avail = ImGui::GetContentRegionAvail();
-			// Aperçu CARRÉ (la texture du viewport est 512x512) : dessiner en largeur
-			// pleine l'écrasait verticalement (retour joueur 2026-07-09). On centre un
-			// carré de côté = min(largeur dispo, 320).
-			const float side = std::min(avail.x, 320.0f);
+			// Aperçu CARRÉ (texture 512x512) agrandi ; rotation MANUELLE au drag et vue
+			// de face par défaut (retour joueur 2026-07-09 : pas de rotation auto).
+			const float side = std::min(avail.x, 400.0f);
 			const float offX = (avail.x - side) * 0.5f;
 			if (m_raceViewport != nullptr && m_raceViewport->GetImguiTextureId() != 0u)
 			{
 				ImGui::SetCursorPosX(ImGui::GetCursorPosX() + offX);
 				ImGui::Image(static_cast<ImTextureID>(m_raceViewport->GetImguiTextureId()),
 					ImVec2(side, side));
+				// Rotation manuelle : glisser (bouton gauche) sur l'aperçu tourne le
+				// perso ; au repos il reste immobile, face caméra. Auto-orbit coupée.
+				m_raceViewport->SetAutoOrbit(false);
+				if (ImGui::IsItemHovered() && ImGui::IsMouseDragging(ImGuiMouseButton_Left))
+					m_previewYaw += ImGui::GetIO().MouseDelta.x * 0.012f;
+				m_raceViewport->SetOrbitYaw(m_previewYaw);
 			}
 			else
 			{

--- a/src/client/render/CharacterWindowImGuiRenderer.h
+++ b/src/client/render/CharacterWindowImGuiRenderer.h
@@ -8,7 +8,8 @@
 
 namespace engine::core { class Config; }
 namespace engine::client { class UIModelBinding; class InventoryUiPresenter; class SkillIconCache; struct UIModel; }
-namespace engine::render { class SkillBookImGuiRenderer; class GrimoireImGuiRenderer; class ClassSkillTreeImGuiRenderer; class RacePreviewViewport; }
+namespace engine::render { class SkillBookImGuiRenderer; class GrimoireImGuiRenderer; class ClassSkillTreeImGuiRenderer; }
+namespace engine::render::race { class RacePreviewViewport; }
 
 namespace engine::render
 {
@@ -28,7 +29,7 @@ namespace engine::render
 			engine::render::ClassSkillTreeImGuiRenderer* classTree);
 
 		/// Viewport 3D du perso (optionnel ; Task 4). Nul -> placeholder dessiné.
-		void SetRaceViewport(engine::render::RacePreviewViewport* vp) { m_raceViewport = vp; }
+		void SetRaceViewport(engine::render::race::RacePreviewViewport* vp) { m_raceViewport = vp; }
 		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
 		void SetVisible(bool v) { m_visible = v; }
 		void ToggleVisible() { m_visible = !m_visible; }
@@ -50,7 +51,7 @@ namespace engine::render
 		engine::render::SkillBookImGuiRenderer* m_skillBook = nullptr;
 		engine::render::GrimoireImGuiRenderer* m_grimoire = nullptr;
 		engine::render::ClassSkillTreeImGuiRenderer* m_classTree = nullptr;
-		engine::render::RacePreviewViewport* m_raceViewport = nullptr;
+		engine::render::race::RacePreviewViewport* m_raceViewport = nullptr;
 		uint32_t m_viewportW = 0;
 		uint32_t m_viewportH = 0;
 		bool m_visible = false;

--- a/src/client/render/CharacterWindowImGuiRenderer.h
+++ b/src/client/render/CharacterWindowImGuiRenderer.h
@@ -36,6 +36,12 @@ namespace engine::render
 		bool IsVisible() const { return m_visible; }
 		void SetActiveTab(Tab t) { m_activeTab = t; }
 		Tab ActiveTab() const { return m_activeTab; }
+		/// Ouvre la fenêtre ET force l'onglet demandé (sélection programmatique au
+		/// prochain rendu). Utilisé par les slash commands /skills //grimoire //arbre
+		/// et l'item de menu pause pour router vers la fenêtre unifiée.
+		void OpenAtTab(Tab t) { m_visible = true; m_pendingTab = t; m_hasPendingTab = true; }
+		/// Remet l'aperçu 3D face à la caméra (appelé à l'ouverture F1).
+		void ResetPreviewOrientation() { m_previewYaw = 0.0f; }
 
 		/// À appeler entre ImGui::NewFrame() et ImGui::Render(), dans le bloc des
 		/// panneaux (single-pass). No-op si non visible.
@@ -56,5 +62,8 @@ namespace engine::render
 		uint32_t m_viewportH = 0;
 		bool m_visible = false;
 		Tab m_activeTab = Tab::Personnage;
+		Tab m_pendingTab = Tab::Personnage;   ///< Onglet à forcer (OpenAtTab).
+		bool m_hasPendingTab = false;         ///< Vrai tant que la sélection forcée n'est pas consommée.
+		float m_previewYaw = 0.0f;            ///< Angle orbit du perso 3D (drag souris).
 	};
 }

--- a/src/client/render/CharacterWindowImGuiRenderer.h
+++ b/src/client/render/CharacterWindowImGuiRenderer.h
@@ -1,0 +1,59 @@
+#pragma once
+// Fenêtre Personnage unifiée à onglets (Chantier 1). Regroupe perso 3D +
+// inventaire + caractéristiques + argent (onglet défaut) et délègue aux
+// renderers Compétences/Techniques/Arbre en mode embarqué. Rendu au même point
+// de frame que les panneaux existants (bloc single-pass) -> pas de doublon.
+
+#include <cstdint>
+
+namespace engine::core { class Config; }
+namespace engine::client { class UIModelBinding; class InventoryUiPresenter; class SkillIconCache; struct UIModel; }
+namespace engine::render { class SkillBookImGuiRenderer; class GrimoireImGuiRenderer; class ClassSkillTreeImGuiRenderer; class RacePreviewViewport; }
+
+namespace engine::render
+{
+	class CharacterWindowImGuiRenderer
+	{
+	public:
+		enum class Tab { Personnage = 0, Competences, Techniques, Arbre };
+
+		/// Câble les dépendances (pointeurs non possédés). Les 3 renderers de
+		/// panneaux sont pilotés en mode embarqué par cette fenêtre.
+		void Bind(const engine::core::Config* cfg,
+			const engine::client::UIModelBinding* uiBinding,
+			const engine::client::InventoryUiPresenter* inv,
+			engine::client::SkillIconCache* icons,
+			engine::render::SkillBookImGuiRenderer* skillBook,
+			engine::render::GrimoireImGuiRenderer* grimoire,
+			engine::render::ClassSkillTreeImGuiRenderer* classTree);
+
+		/// Viewport 3D du perso (optionnel ; Task 4). Nul -> placeholder dessiné.
+		void SetRaceViewport(engine::render::RacePreviewViewport* vp) { m_raceViewport = vp; }
+		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
+		void SetVisible(bool v) { m_visible = v; }
+		void ToggleVisible() { m_visible = !m_visible; }
+		bool IsVisible() const { return m_visible; }
+		void SetActiveTab(Tab t) { m_activeTab = t; }
+		Tab ActiveTab() const { return m_activeTab; }
+
+		/// À appeler entre ImGui::NewFrame() et ImGui::Render(), dans le bloc des
+		/// panneaux (single-pass). No-op si non visible.
+		void Render(const engine::client::UIModel& model);
+
+	private:
+		void RenderPersonnageTab(const engine::client::UIModel& model);
+
+		const engine::core::Config* m_cfg = nullptr;
+		const engine::client::UIModelBinding* m_uiBinding = nullptr;
+		const engine::client::InventoryUiPresenter* m_inv = nullptr;
+		engine::client::SkillIconCache* m_icons = nullptr;
+		engine::render::SkillBookImGuiRenderer* m_skillBook = nullptr;
+		engine::render::GrimoireImGuiRenderer* m_grimoire = nullptr;
+		engine::render::ClassSkillTreeImGuiRenderer* m_classTree = nullptr;
+		engine::render::RacePreviewViewport* m_raceViewport = nullptr;
+		uint32_t m_viewportW = 0;
+		uint32_t m_viewportH = 0;
+		bool m_visible = false;
+		Tab m_activeTab = Tab::Personnage;
+	};
+}

--- a/src/client/render/ClassSkillTreeImGuiRenderer.cpp
+++ b/src/client/render/ClassSkillTreeImGuiRenderer.cpp
@@ -11,24 +11,30 @@ namespace engine::render
 {
 	void ClassSkillTreeImGuiRenderer::Render()
 	{
-		if (m_presenter == nullptr || !m_enabled || !m_presenter->IsInitialized())
+		if (m_presenter == nullptr || (!m_embedded && !m_enabled) || !m_presenter->IsInitialized())
 		{
 			return;
 		}
 		const auto& state = m_presenter->GetState();
 
-		const float panelW = 860.f;
-		const float panelH = 620.f;
-		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
-		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
-		ImGui::SetNextWindowPos(ImVec2((vpW - panelW) * 0.5f, (vpH - panelH) * 0.5f),
-		                        ImGuiCond_FirstUseEver);
-		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
-		ImGui::SetNextWindowBgAlpha(0.96f);
+		// Mode embarqué : dessine dans l'onglet courant sans fenêtre propre.
+		bool open = true;
+		if (!m_embedded)
+		{
+			const float panelW = 860.f;
+			const float panelH = 620.f;
+			const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+			const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+			ImGui::SetNextWindowPos(ImVec2((vpW - panelW) * 0.5f, (vpH - panelH) * 0.5f),
+			                        ImGuiCond_FirstUseEver);
+			ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+			ImGui::SetNextWindowBgAlpha(0.96f);
 
-		// Titre sans la classe (elle est deja affichee dans la ligne « Classe : ... »
-		// ci-dessous -> evite le doublon). ##id stable pour ImGui.
-		if (ImGui::Begin("Arbre de competences##ln_skilltree", nullptr, ImGuiWindowFlags_NoCollapse))
+			// Titre sans la classe (elle est deja affichee dans la ligne « Classe : ... »
+			// ci-dessous -> evite le doublon). ##id stable pour ImGui.
+			open = ImGui::Begin("Arbre de competences##ln_skilltree", nullptr, ImGuiWindowFlags_NoCollapse);
+		}
+		if (open)
 		{
 			ImGui::TextDisabled("Classe : %s   |   Niveau joueur : %u",
 			    state.classId.empty() ? "(inconnue)" : state.classId.c_str(),
@@ -158,7 +164,8 @@ namespace engine::render
 				ImGui::EndChild(); // wrapper de colonne (alignement)
 			}
 		}
-		ImGui::End();
+		if (!m_embedded)
+			ImGui::End();
 	}
 }
 

--- a/src/client/render/ClassSkillTreeImGuiRenderer.h
+++ b/src/client/render/ClassSkillTreeImGuiRenderer.h
@@ -27,6 +27,10 @@ namespace engine::render
 		/// \return true si la fenêtre est actuellement active.
 		bool IsEnabled() const { return m_enabled; }
 
+		/// Mode embarqué : dessine dans l'onglet courant sans fenêtre propre
+		/// (conteneur CharacterWindowImGuiRenderer). Défaut false = fenêtre autonome.
+		void SetEmbedded(bool e) { m_embedded = e; }
+
 		/// Met à jour la taille du viewport pour centrer la fenêtre.
 		/// \param w Largeur du viewport en pixels.
 		/// \param h Hauteur du viewport en pixels.
@@ -40,6 +44,7 @@ namespace engine::render
 		engine::client::ClassSkillTreeUiPresenter* m_presenter = nullptr;
 		engine::client::SkillIconCache* m_iconCache = nullptr;
 		bool     m_enabled   = false;
+		bool     m_embedded  = false;
 		uint32_t m_viewportW = 0;
 		uint32_t m_viewportH = 0;
 	};

--- a/src/client/render/GrimoireImGuiRenderer.cpp
+++ b/src/client/render/GrimoireImGuiRenderer.cpp
@@ -20,22 +20,28 @@ namespace engine::render
 
 	void GrimoireImGuiRenderer::Render()
 	{
-		if (m_presenter == nullptr || !m_enabled || !m_presenter->IsInitialized())
+		if (m_presenter == nullptr || (!m_embedded && !m_enabled) || !m_presenter->IsInitialized())
 		{
 			return;
 		}
 		const auto& state = m_presenter->GetState();
 
-		const float panelW = 720.f;
-		const float panelH = 540.f;
-		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
-		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
-		ImGui::SetNextWindowPos(ImVec2((vpW - panelW) * 0.5f, (vpH - panelH) * 0.5f), ImGuiCond_FirstUseEver);
-		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
-		ImGui::SetNextWindowBgAlpha(0.96f);
-
-		const char* title = state.isCaster ? "Grimoire##ln_grimoire" : "Carnet de techniques##ln_grimoire";
-		if (ImGui::Begin(title, nullptr, ImGuiWindowFlags_NoCollapse))
+		// Mode embarqué (conteneur CharacterWindow) : pas de fenêtre propre, on
+		// dessine directement dans l'onglet courant. Mode autonome : fenêtre centrée.
+		bool open = true;
+		if (!m_embedded)
+		{
+			const float panelW = 720.f;
+			const float panelH = 540.f;
+			const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+			const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+			ImGui::SetNextWindowPos(ImVec2((vpW - panelW) * 0.5f, (vpH - panelH) * 0.5f), ImGuiCond_FirstUseEver);
+			ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+			ImGui::SetNextWindowBgAlpha(0.96f);
+			const char* title = state.isCaster ? "Grimoire##ln_grimoire" : "Carnet de techniques##ln_grimoire";
+			open = ImGui::Begin(title, nullptr, ImGuiWindowFlags_NoCollapse);
+		}
+		if (open)
 		{
 			// --- Recherche
 			static char searchBuf[64] = {0};
@@ -120,7 +126,8 @@ namespace engine::render
 
 			ImGui::Columns(1);
 		}
-		ImGui::End();
+		if (!m_embedded)
+			ImGui::End();
 	}
 }
 

--- a/src/client/render/GrimoireImGuiRenderer.h
+++ b/src/client/render/GrimoireImGuiRenderer.h
@@ -19,6 +19,10 @@ namespace engine::render
 		void SetIconCache(engine::client::SkillIconCache* cache) { m_iconCache = cache; }
 		void SetEnabled(bool on) { m_enabled = on; }
 		bool IsEnabled() const { return m_enabled; }
+		/// Mode embarqué : Render() dessine son contenu dans la fenêtre/onglet
+		/// courant sans ouvrir sa propre fenêtre ImGui (piloté par le conteneur
+		/// CharacterWindowImGuiRenderer). Défaut false = fenêtre autonome.
+		void SetEmbedded(bool e) { m_embedded = e; }
 		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
 
 		/// À appeler entre ImGui::NewFrame() et ImGui::Render() si presenter valide.
@@ -28,6 +32,7 @@ namespace engine::render
 		engine::client::GrimoireUiPresenter* m_presenter = nullptr;
 		engine::client::SkillIconCache* m_iconCache = nullptr;
 		bool m_enabled = false;
+		bool m_embedded = false;
 		uint32_t m_viewportW = 0;
 		uint32_t m_viewportH = 0;
 	};

--- a/src/client/render/QuestImGuiRenderer.cpp
+++ b/src/client/render/QuestImGuiRenderer.cpp
@@ -407,11 +407,15 @@ namespace engine::render
 			dl->AddCircleFilled(knob, 5.5f, fillCol);
 			dl->AddCircle(knob, 5.5f, knobRing, 20, 1.5f);
 
-			// 5) Valeur numérique du cran courant (« 600 m »), centrée en haut du radar.
+			// 5) Valeur numérique du cran courant (« 600 m »), centrée AU-DESSUS de la
+			// glissière en arc (retour joueur 2026-07-09 : le texte était sous l'arc,
+			// dans le disque du radar). L'arc culmine à cy - rArc (90°) ; on place le
+			// texte juste au-dessus.
 			const std::string zoomText =
 				std::to_string(static_cast<int>(engine::client::RadiusForZoomIndex(zoomIdx))) + " m";
 			const ImVec2 zts = ImGui::CalcTextSize(zoomText.c_str());
-			dl->AddText(ImVec2(cx - zts.x * 0.5f, y0 + 3.0f), IM_COL32(220, 225, 235, 235), zoomText.c_str());
+			dl->AddText(ImVec2(cx - zts.x * 0.5f, cy - rArc - zts.y - 4.0f),
+				IM_COL32(220, 225, 235, 235), zoomText.c_str());
 		}
 	}
 

--- a/src/client/render/SkillBookImGuiRenderer.cpp
+++ b/src/client/render/SkillBookImGuiRenderer.cpp
@@ -58,38 +58,45 @@ namespace engine::render
 
 	void SkillBookImGuiRenderer::Render()
 	{
-		if (m_presenter == nullptr || !m_enabled)
+		if (m_presenter == nullptr || (!m_embedded && !m_enabled))
 			return;
 		if (!m_presenter->IsInitialized())
 			return;
 		RenderListPanel();
-		RenderUseIndicator();
+		// L'indicateur Use est un toast plein écran : on l'omet en mode embarqué
+		// (il ne doit pas s'ouvrir comme fenêtre imbriquée dans l'onglet).
+		if (!m_embedded)
+			RenderUseIndicator();
 	}
 
 	void SkillBookImGuiRenderer::RenderListPanel()
 	{
 		const auto& state = m_presenter->GetState();
 
-		// Geometrie : panneau ancre droite, 380x520. Decale legerement vs
-		// reputation pour eviter le chevauchement direct si les deux sont
-		// ouverts en meme temps.
-		const float panelW = 380.f;
-		const float panelH = 520.f;
-		const float margin = 24.f;
-		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
-		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
-		const float posX = std::max(0.f, vpW - panelW - margin);
-		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
+		// Mode embarqué : dessine directement dans l'onglet courant (pas de fenêtre
+		// propre). Mode autonome : panneau ancré droite, 380x520.
+		bool open = true;
+		if (!m_embedded)
+		{
+			const float panelW = 380.f;
+			const float panelH = 520.f;
+			const float margin = 24.f;
+			const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+			const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
+			const float posX = std::max(0.f, vpW - panelW - margin);
+			const float posY = std::max(0.f, (vpH - panelH) * 0.5f);
 
-		ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
-		ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
-		ImGui::SetNextWindowBgAlpha(0.95f);
+			ImGui::SetNextWindowPos(ImVec2(posX, posY), ImGuiCond_FirstUseEver);
+			ImGui::SetNextWindowSize(ImVec2(panelW, panelH), ImGuiCond_FirstUseEver);
+			ImGui::SetNextWindowBgAlpha(0.95f);
 
-		ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
-		ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
+			ImGui::PushStyleColor(ImGuiCol_WindowBg, ToImVec4(LnTheme::PanelBg(0.95f)));
+			ImGui::PushStyleColor(ImGuiCol_Border,   ToImVec4(LnTheme::kBorder));
 
-		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
-		if (ImGui::Begin("Livre de competences (F2)##ln_skillbook_panel", nullptr, flags))
+			const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+			open = ImGui::Begin("Livre de competences (F2)##ln_skillbook_panel", nullptr, flags);
+		}
+		if (open)
 		{
 			// Erreur transitoire (rouge) — non bloquante.
 			if (!state.lastErrorText.empty())
@@ -183,8 +190,11 @@ namespace engine::render
 				}
 			}
 		}
-		ImGui::End();
-		ImGui::PopStyleColor(2);
+		if (!m_embedded)
+		{
+			ImGui::End();
+			ImGui::PopStyleColor(2);
+		}
 	}
 
 	void SkillBookImGuiRenderer::RenderUseIndicator()

--- a/src/client/render/SkillBookImGuiRenderer.cpp
+++ b/src/client/render/SkillBookImGuiRenderer.cpp
@@ -134,9 +134,9 @@ namespace engine::render
 				if (ImGui::BeginTable("##ln_skillbook_list", 4, tableFlags, ImVec2(0.f, 0.f)))
 				{
 					ImGui::TableSetupColumn("Competence", ImGuiTableColumnFlags_WidthStretch);
-					ImGui::TableSetupColumn("Valeur",     ImGuiTableColumnFlags_WidthFixed,  90.f);
-					ImGui::TableSetupColumn("Progres",    ImGuiTableColumnFlags_WidthFixed,  90.f);
-					ImGui::TableSetupColumn("",           ImGuiTableColumnFlags_WidthFixed,  60.f);
+					ImGui::TableSetupColumn("Valeur",     ImGuiTableColumnFlags_WidthFixed,  80.f);
+					ImGui::TableSetupColumn("Progres",    ImGuiTableColumnFlags_WidthFixed,  110.f);
+					ImGui::TableSetupColumn("Action",     ImGuiTableColumnFlags_WidthFixed,  92.f);
 					ImGui::TableHeadersRow();
 
 					for (const auto& e : state.skills)

--- a/src/client/render/SkillBookImGuiRenderer.h
+++ b/src/client/render/SkillBookImGuiRenderer.h
@@ -23,6 +23,10 @@ namespace engine::render
 
 		void SetEnabled(bool on) { m_enabled = on; }
 		bool IsEnabled() const   { return m_enabled; }
+		/// Mode embarqué : dessine la liste dans l'onglet courant sans fenêtre
+		/// propre (conteneur CharacterWindowImGuiRenderer). L'indicateur Use
+		/// transitoire est omis en embarqué. Défaut false = fenêtre autonome.
+		void SetEmbedded(bool e) { m_embedded = e; }
 
 		/// Met a jour la viewport pour le placement du panneau.
 		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
@@ -38,6 +42,7 @@ namespace engine::render
 
 		engine::client::SkillBookUiPresenter* m_presenter = nullptr;
 		bool                                  m_enabled   = false;
+		bool                                  m_embedded  = false;
 		uint32_t                              m_viewportW = 0;
 		uint32_t                              m_viewportH = 0;
 	};

--- a/src/client/render/race/RacePreviewViewport.cpp
+++ b/src/client/render/race/RacePreviewViewport.cpp
@@ -593,7 +593,10 @@ namespace engine::render::race
 		// Accumule l'angle orbit, puis wrap mod 2pi pour eviter
 		// l'accumulation flottante sur de longues sessions.
 		constexpr float kDegToRad = 3.14159265358979323846f / 180.0f;
-		m_orbitYawRad += kOrbitDegPerSec * dt * kDegToRad;
+		// Rotation orbit automatique seulement si activée (écran de création). La
+		// fenêtre Personnage la coupe et pilote l'angle via SetOrbitYaw (drag).
+		if (m_autoOrbit)
+			m_orbitYawRad += kOrbitDegPerSec * dt * kDegToRad;
 		while (m_orbitYawRad >= k2Pi) m_orbitYawRad -= k2Pi;
 		while (m_orbitYawRad <  0.0f) m_orbitYawRad += k2Pi;
 

--- a/src/client/render/race/RacePreviewViewport.h
+++ b/src/client/render/race/RacePreviewViewport.h
@@ -114,6 +114,15 @@ namespace engine::render::race
 		/// teinte claire si le matériau foncé n'existe pas (id 0).
 		void SetSkinTone(int tone);
 
+		/// Active/désactive la rotation orbit automatique (défaut true). Off => la
+		/// caméra reste à l'angle courant (piloté par SetOrbitYaw, ex. drag souris
+		/// dans la fenêtre Personnage). L'animation continue indépendamment.
+		void SetAutoOrbit(bool a) { m_autoOrbit = a; }
+
+		/// Fixe l'angle orbit (radians). 0 = vue de face (caméra en +Z regardant le
+		/// perso). Utilisé quand l'auto-orbit est off (rotation manuelle).
+		void SetOrbitYaw(float rad) { m_orbitYawRad = rad; }
+
 		/// Matériaux de l'avatar (set bindless + ids + noms peau + depth bias),
 		/// fournis par Engine après création des matériaux au boot. À appeler une
 		/// fois avant le 1er RenderOffscreen (re-appelable sans risque).
@@ -237,6 +246,10 @@ namespace engine::render::race
 		/// Angle de rotation orbit accumule depuis Init, en radians.
 		/// Wrap mod 2pi dans Tick pour eviter l'accumulation flottante.
 		float          m_orbitYawRad    = 0.0f;
+
+		/// Rotation automatique de l'orbit dans Tick (défaut true, ex. écran de
+		/// création). La fenêtre Personnage la coupe pour une rotation manuelle.
+		bool           m_autoOrbit      = true;
 
 		/// Anim sampling state mis a jour par Tick, consomme par Render.
 		/// m_localBoneMatrices : matrices TRS locales echantillonnees du clip Idle.


### PR DESCRIPTION
Regroupe les panneaux personnage dans **une seule fenêtre à onglets ouverte par F1**. Retour joueur 2026-07-08 : « trop d'interface personnage ». **100% client.**

Spec : `docs/superpowers/specs/2026-07-09-fenetre-personnage-unifiee-design.md` · Plan : `docs/superpowers/plans/2026-07-09-fenetre-personnage-unifiee.md`

## Contenu (Chantier 1, Tasks 1-3)
- **`SetEmbedded`** sur SkillBook/Grimoire/ClassSkillTree : rendu dans un onglet sans fenêtre propre.
- **`CharacterWindowImGuiRenderer`** : fenêtre à 4 onglets (Personnage / Compétences / Techniques / Arbre). Onglet Personnage = aperçu 3D (placeholder, branché en Task 4) + caractéristiques + inventaire 4×4 + bourse or/argent/bronze.
- **F1** ouvre/ferme la fenêtre ; **F2/F3/F4/I libérées** (anciens toggles retirés).
- **Fix doublon inventaire (#958)** : le bloc inventaire était **dupliqué en source** (deux `if (m_inventoryVisible)` consécutifs). Les deux sont retirés ; l'inventaire est rendu **une seule fois** dans le bloc panneaux (single-pass).

## Reste (suivi, hors ce Chantier 1)
- **Task 4** : brancher le perso 3D (`RacePreviewViewport`) — commit à venir sur cette branche après validation en jeu des Tasks 1-3.
- Slash `/skills` `/grimoire` `/arbre` + item menu pause « Carnet de sorts » : deviennent des no-op (à router vers la fenêtre en suivi).

## Déploiement
✅ **client uniquement, pas de redéploiement serveur.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)