### PR TITLE
feat(ch2-sp1): groundwork avatar modulaire — ModularAvatar + PlaceholderPart (Tasks 1-2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -710,6 +710,8 @@ add_library(engine_core
   src/client/render/skinned/SkinnedMesh.cpp
   src/client/render/skinned/SkinnedRenderer.cpp
   src/client/render/skinned/AvatarMaterialRouting.cpp
+  src/client/render/skinned/ModularAvatar.cpp
+  src/client/render/skinned/PlaceholderPart.cpp
   src/client/render/static_mesh/StaticMeshLoader.cpp
   src/client/gameplay/CharacterController.cpp
   src/client/gameplay/TerrainCollider.cpp

--- a/docs/superpowers/plans/2026-07-09-ch2-sp1-modular-avatar-groundwork.md
+++ b/docs/superpowers/plans/2026-07-09-ch2-sp1-modular-avatar-groundwork.md
@@ -1,0 +1,384 @@
+# Chantier 2 SP1 — groundwork avatar modulaire — plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Composer/rendre/échanger plusieurs parties skinnées partageant un squelette (avatar modulaire), démontré avec des placeholders procéduraux et une commande de test.
+
+**Architecture:** Un `ModularAvatar` (client) tient un squelette partagé + une carte slot→partie (`SkinnedMesh*`). Le rendu calcule les matrices d'os UNE fois et appelle `SkinnedRenderer::Record` pour chaque partie active. Les placeholders sont des boîtes skinnées à 100% sur un os, générées par code (aucun asset).
+
+**Tech Stack:** C++17/20, Vulkan (via `SkinnedRenderer` existant), cgltf (loader existant), CMake + ctest.
+
+## Global Constraints
+
+- **Client-rendu uniquement** pour SP1 (rendu + placeholders). La commande de test peut être soit admin-via-master (log), soit un flag debug strictement client (cf. Task 4 — décision au début de Task 4).
+- **Pas de toolchain locale** : compilation + ctest via CI. `ModularAvatar`/`PlaceholderPart` sont **pures (données CPU, pas de Vulkan/ImGui)** → testables par **ctest sur Linux**. L'intégration Engine + rendu = vérif **CI Windows + en jeu**.
+- **PascalCase** nouveau code ; commentaires français.
+- **Ne PAS toucher** `frontFace`/`cullMode` d'aucun pipeline (garde CLAUDE.md). On réutilise `SkinnedRenderer` tel quel.
+- Nouveau `.cpp` → l'ajouter à `CMakeLists.txt` racine (moteur/engine_core) ET, pour les tests, à la cible de test skinnée existante (chercher dans `CMakeLists.txt` racine ET `src/CMakeLists.txt` — piège doublon).
+- Skeleton partagé : toute partie doit avoir `skeleton.bones.size()` == celui du Body ET même ordre de noms, sinon rejet + log.
+
+## Prérequis
+
+SP1 étend le rendu avatar que #960 modifie. Base la branche sur #960 (déjà fait :
+`claude/ch2-sp1-modular-avatar` part de la HEAD de `claude/character-window`).
+Quand #960 merge dans `main`, rebaser sur `origin/main`.
+
+---
+
+## File Structure
+
+- **Create** `src/client/render/skinned/ModularAvatar.h` / `.cpp` — composant slots+parties.
+- **Create** `src/client/render/skinned/PlaceholderPart.h` / `.cpp` — génération de parties boîte skinnées à un os.
+- **Create** `src/client/render/skinned/tests/ModularAvatarTests.cpp` — tests unitaires.
+- **Create** `src/client/render/skinned/tests/PlaceholderPartTests.cpp` — tests unitaires.
+- **Modify** `src/client/app/Engine.h` — membre `ModularAvatar m_modularAvatar;` + parties placeholder.
+- **Modify** `src/client/app/Engine.cpp` — Body = mesh courant ; boucle `Record` sur `ActiveParts()` ; commande `/modular`.
+- **Modify** `CMakeLists.txt` (+ `src/CMakeLists.txt` si la cible test y est) — nouveaux sources + tests.
+
+---
+
+## Task 1 : `ModularAvatar` (logique pure) + tests
+
+**Files:**
+- Create: `src/client/render/skinned/ModularAvatar.h`, `ModularAvatar.cpp`
+- Create/Test: `src/client/render/skinned/tests/ModularAvatarTests.cpp`
+- Modify: `CMakeLists.txt` (source engine_core + test)
+
+**Interfaces:**
+- Produces :
+  - `enum class EquipVisualSlot { Body=0, Head, Chest, Legs, Feet, Hands, Weapon, Offhand, Count };`
+  - `class ModularAvatar` avec :
+    - `void SetBody(const SkinnedMesh* body)` — définit le corps + le squelette de référence.
+    - `bool SetPart(EquipVisualSlot slot, const SkinnedMesh* mesh)` — pose (mesh) / retire (nullptr) une partie ; retourne false + log si squelette incompatible (bones.size / ordre noms). `Body` refusé ici (utiliser SetBody).
+    - `void ClearPart(EquipVisualSlot slot)`.
+    - `std::vector<const SkinnedMesh*> ActiveParts() const` — Body d'abord (s'il existe), puis les slots occupés dans l'ordre de l'enum.
+    - `const Skeleton* SharedSkeleton() const` — squelette du Body, ou nullptr.
+    - `bool HasBody() const`.
+
+- [ ] **Step 1 : Écrire le header**
+
+`ModularAvatar.h` :
+
+```cpp
+#pragma once
+#include <cstdint>
+#include <vector>
+
+namespace engine::render::skinned
+{
+struct SkinnedMesh;
+struct Skeleton;
+
+/// Slots visuels d'équipement (SP1 : le pipeline, pas tous peuplés d'assets).
+enum class EquipVisualSlot : uint32_t
+{
+    Body = 0, Head, Chest, Legs, Feet, Hands, Weapon, Offhand, Count
+};
+
+/// Avatar composé de plusieurs parties skinnées partageant UN squelette.
+/// Le rendu calcule les matrices d'os une fois puis dessine chaque partie active.
+class ModularAvatar
+{
+public:
+    void SetBody(const SkinnedMesh* body);
+    bool SetPart(EquipVisualSlot slot, const SkinnedMesh* mesh);
+    void ClearPart(EquipVisualSlot slot);
+
+    std::vector<const SkinnedMesh*> ActiveParts() const;
+    const Skeleton* SharedSkeleton() const;
+    bool HasBody() const { return m_body != nullptr; }
+
+private:
+    /// true si `mesh` partage le squelette du Body (même nb de bones + mêmes noms/ordre).
+    bool SkeletonCompatible(const SkinnedMesh* mesh) const;
+
+    const SkinnedMesh* m_body = nullptr;
+    const SkinnedMesh* m_parts[static_cast<size_t>(EquipVisualSlot::Count)] = {};
+};
+}
+```
+
+- [ ] **Step 2 : Écrire les tests (ils échoueront tant que .cpp absent)**
+
+`tests/ModularAvatarTests.cpp` — suivre le style des tests skinnés existants
+(chercher un `*Tests.cpp` du dossier pour le framework : assert maison ou gtest).
+Construire des `SkinnedMesh` CPU minimaux (skeleton avec N bones nommés ; pas
+besoin de buffers GPU pour ces tests — n'utiliser que `.skeleton`). Cas :
+
+```cpp
+// Body pose le squelette ; ActiveParts contient le Body.
+// SetPart avec squelette compatible (mêmes noms/ordre) -> true, apparait dans ActiveParts.
+// SetPart avec bones.size() different -> false, pas ajoute.
+// SetPart avec noms/ordre differents -> false.
+// ClearPart retire la partie.
+// ActiveParts ordre : Body d'abord puis slots par ordre d'enum.
+// SetPart(Body,...) -> refuse (utiliser SetBody).
+```
+
+Écrire des helpers `MakeSkel({"root","head"})` qui remplissent `SkinnedMesh.skeleton.bones[].name`.
+
+- [ ] **Step 3 : Implémenter `ModularAvatar.cpp`**
+
+```cpp
+#include "src/client/render/skinned/ModularAvatar.h"
+#include "src/client/render/skinned/SkinnedMesh.h"
+#include "src/shared/core/Log.h"
+
+namespace engine::render::skinned
+{
+void ModularAvatar::SetBody(const SkinnedMesh* body) { m_body = body; }
+
+bool ModularAvatar::SkeletonCompatible(const SkinnedMesh* mesh) const
+{
+    if (m_body == nullptr || mesh == nullptr) return false;
+    const auto& a = m_body->skeleton.bones;
+    const auto& b = mesh->skeleton.bones;
+    if (a.size() != b.size()) return false;
+    for (size_t i = 0; i < a.size(); ++i)
+        if (a[i].name != b[i].name) return false;
+    return true;
+}
+
+bool ModularAvatar::SetPart(EquipVisualSlot slot, const SkinnedMesh* mesh)
+{
+    if (slot == EquipVisualSlot::Body || slot >= EquipVisualSlot::Count) return false;
+    if (mesh != nullptr && !SkeletonCompatible(mesh))
+    {
+        LOG_WARN(Render, "[ModularAvatar] partie rejetee : squelette incompatible (slot={})",
+            static_cast<uint32_t>(slot));
+        return false;
+    }
+    m_parts[static_cast<size_t>(slot)] = mesh;
+    return true;
+}
+
+void ModularAvatar::ClearPart(EquipVisualSlot slot)
+{
+    if (slot != EquipVisualSlot::Body && slot < EquipVisualSlot::Count)
+        m_parts[static_cast<size_t>(slot)] = nullptr;
+}
+
+std::vector<const SkinnedMesh*> ModularAvatar::ActiveParts() const
+{
+    std::vector<const SkinnedMesh*> out;
+    if (m_body) out.push_back(m_body);
+    for (size_t i = 0; i < static_cast<size_t>(EquipVisualSlot::Count); ++i)
+        if (m_parts[i]) out.push_back(m_parts[i]);
+    return out;
+}
+
+const Skeleton* ModularAvatar::SharedSkeleton() const
+{
+    return m_body ? &m_body->skeleton : nullptr;
+}
+}
+```
+
+> `EquipVisualSlot::Count` comparaisons : `slot >= EquipVisualSlot::Count` nécessite
+> que l'enum soit comparable — ajouter `static_cast<uint32_t>` si le compilateur
+> refuse la comparaison directe sur `enum class`.
+
+- [ ] **Step 4 : CMake — ajouter source + test**
+
+Ajouter `src/client/render/skinned/ModularAvatar.cpp` à la liste engine_core.
+Ajouter `ModularAvatarTests.cpp` à la cible de tests skinnés (repérer comment les
+autres `skinned/tests/*Tests.cpp` sont enregistrés ; `add_test` associé).
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add src/client/render/skinned/ModularAvatar.h src/client/render/skinned/ModularAvatar.cpp \
+        src/client/render/skinned/tests/ModularAvatarTests.cpp CMakeLists.txt
+git commit -m "feat(ch2-sp1): ModularAvatar (slots + parties partageant un squelette) + tests"
+```
+
+**Vérification :** CI Linux (ctest) — les tests `ModularAvatar*` passent. CI Windows compile.
+
+---
+
+## Task 2 : `PlaceholderPart` (génération procédurale) + tests
+
+**Files:**
+- Create: `src/client/render/skinned/PlaceholderPart.h`, `PlaceholderPart.cpp`
+- Create/Test: `src/client/render/skinned/tests/PlaceholderPartTests.cpp`
+- Modify: `CMakeLists.txt`
+
+**Interfaces:**
+- Consumes : `Skeleton`, `SkinnedVertex`, `SkinnedMeshCpuData` (SkinnedMeshLoader.h).
+- Produces :
+  - `SkinnedMeshCpuData MakePlaceholderBoxPart(const Skeleton& skel, int boneIndex, float halfExtentM, uint32_t materialTagIndexUnused = 0)` — une boîte (24 sommets, 36 indices) centrée sur la position bind-globale de l'os `boneIndex`, tous les sommets **100% weight sur `boneIndex`** (boneIndices[0]=boneIndex, weights[0]=1, autres 0), 1 submesh couvrant tout. `skeleton`/`clips` copiés du `skel` fourni (pour partager la pose).
+
+- [ ] **Step 1 : Header**
+
+```cpp
+#pragma once
+#include "src/client/render/skinned/SkinnedMeshLoader.h" // SkinnedMeshCpuData
+namespace engine::render::skinned
+{
+struct Skeleton;
+/// Génère une boîte skinnée à 100% sur `boneIndex`, centrée sur la position
+/// bind-globale de cet os. Sert de PARTIE placeholder (aucun asset). Le squelette
+/// est copié pour partager la pose de l'avatar.
+SkinnedMeshCpuData MakePlaceholderBoxPart(const Skeleton& skel, int boneIndex, float halfExtentM);
+}
+```
+
+- [ ] **Step 2 : Tests**
+
+`tests/PlaceholderPartTests.cpp` :
+
+```cpp
+// Skeleton 2 os : root (identite), head (translation connue).
+// MakePlaceholderBoxPart(skel, headIndex, 0.1f) :
+//  - vertices.size()==24, indices.size()==36, submeshes.size()==1.
+//  - tous les vertices : boneIndices[0]==headIndex, weights[0]==1.0f, weights[1..3]==0.
+//  - la position moyenne des 24 sommets ≈ translation bind-globale de head (a epsilon).
+//  - skeleton copie (bones.size == skel.bones.size).
+```
+
+Pour la position bind-globale : `bindGlobal = inverse(bone.inverseBindGlobal)` ;
+la translation = colonne de translation. (Vérifier l'API `Mat4::Inverse`/accès
+translation dans `Math.h`.)
+
+- [ ] **Step 3 : Implémentation**
+
+Construire 24 `SkinnedVertex` (boîte : 6 faces × 4 sommets, normales par face),
+positions = centre(os) ± halfExtent sur x/y/z, uv basiques (0/1), `boneIndices={boneIndex,0,0,0}`,
+`weights={1,0,0,0}`. 36 indices (2 triangles/face). Un `SkinnedSubMesh{0,36,""}`.
+Copier `skel` dans `cpu.skeleton`. Laisser `clips` vide (la pose vient du Body au rendu).
+
+Centre = translation de `inverse(skel.bones[boneIndex].inverseBindGlobal)`.
+
+- [ ] **Step 4 : CMake source + test.**
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add src/client/render/skinned/PlaceholderPart.h src/client/render/skinned/PlaceholderPart.cpp \
+        src/client/render/skinned/tests/PlaceholderPartTests.cpp CMakeLists.txt
+git commit -m "feat(ch2-sp1): PlaceholderPart (boite skinnee a un os) + tests"
+```
+
+**Vérification :** CI Linux (ctest) `PlaceholderPart*` passent. CI Windows compile.
+
+---
+
+## Task 3 : Intégration Engine — avatar modulaire + boucle de rendu
+
+**Files:**
+- Modify: `src/client/app/Engine.h`, `src/client/app/Engine.cpp`
+
+**Interfaces:**
+- Consumes : `ModularAvatar` (Task 1), `SkinnedRenderer::Record` (existant), `finals`
+  (existant, `Engine.cpp` ~5508).
+
+- [ ] **Step 1 : Engine.h — membres**
+
+```cpp
+engine::render::skinned::ModularAvatar m_modularAvatar;
+// Parties placeholder possédées (uploadées GPU) pour le test /modular (Task 4).
+std::vector<std::unique_ptr<engine::render::skinned::SkinnedMesh>> m_placeholderParts;
+```
+Include `ModularAvatar.h`.
+
+- [ ] **Step 2 : Engine.cpp — Body = mesh courant**
+
+Là où l'avatar local est résolu (EnterWorld, `m_currentSkinnedMesh` posé) et à
+chaque changement de mesh : `m_modularAvatar.SetBody(m_currentSkinnedMesh);`.
+
+- [ ] **Step 3 : Engine.cpp — boucle de Record**
+
+Au draw avatar (~5598-5615) : `finals` est déjà calculé. Remplacer le `Record`
+unique par une boucle sur les parties actives, MÊME `finals`/model. Le Body garde
+son routage matériau (submeshMaterialIndices) ; les placeholders utilisent le
+chemin mono-draw (submeshes 1 entrée, materialIndex par défaut) :
+
+```cpp
+for (const engine::render::skinned::SkinnedMesh* part : m_modularAvatar.ActiveParts())
+{
+    const bool isBody = (part == m_currentSkinnedMesh);
+    m_skinnedRenderer.Record(m_vkDeviceContext.GetDevice(), innerCmd, m_vkSwapchain.GetExtent(),
+        m_pipeline->GetGeometryPass().GetRenderPassLoad(), VK_NULL_HANDLE,
+        rs.prevViewProjMatrix.m, rs.viewProjMatrix.m,
+        *part, finals, materialCache.GetDescriptorSet(), finalModelMat.m,
+        isBody ? skinnedMaterialIndex : 0u,
+        isBody ? submeshMaterialIndices : std::vector<uint32_t>{},
+        isBody ? bodyMaterialId : 0u,
+        m_avatarSkinDepthBiasConstant, m_avatarSkinDepthBiasSlope);
+}
+```
+
+> Le lambda capture actuel `submeshMaterialIndices = std::move(...)` doit rester
+> valide dans la boucle : ne pas `move` avant la boucle ; capturer par copie ou
+> restructurer. Vérifier la capture exacte à l'implémentation.
+
+Fallback : si `ActiveParts()` est vide (Body pas encore posé), ne rien dessiner
+(comportement actuel préservé quand `m_currentSkinnedMesh` nul).
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git add src/client/app/Engine.h src/client/app/Engine.cpp
+git commit -m "feat(ch2-sp1): avatar local rendu via ModularAvatar (boucle Record parties)"
+```
+
+**Vérification :** CI (Windows) + en jeu — l'avatar s'affiche/anime EXACTEMENT
+comme avant (seul le Body est actif ; aucune régression visuelle). Linux compile.
+
+---
+
+## Task 4 : Commande de test `/modular` (swap live)
+
+**Décision d'ouverture (choisir au début de la task) :** admin-via-master (log,
+convention repo) OU flag debug `client.debug.modular_test` (strictement client).
+Reco SP1 : **flag debug client** — plus simple, purement visuel, zéro serveur.
+Documenter le choix dans le commit.
+
+**Files:**
+- Modify: `src/client/app/Engine.cpp` (+ éventuel handler master si admin choisi).
+
+- [ ] **Step 1 : À l'ouverture de la fenêtre / au boot, générer 2 parties placeholder**
+
+Depuis le squelette du Body : pour un slot de démo (ex. `Head`), créer 2 variantes
+via `MakePlaceholderBoxPart(skel, headBoneIndex, 0.12f)` et `(…, 0.18f)`, les
+**Upload** en `SkinnedMesh` (host-visible) stockés dans `m_placeholderParts`.
+Repérer `headBoneIndex` via `skeleton.FindBoneIndex("mixamorig:Head")` (nom réel
+à confirmer dans le squelette Ranger ; fallback : un os plausible).
+
+- [ ] **Step 2 : Commande `/modular <slot> <A|B|off>`**
+
+Dans le dispatcher de commandes chat (là où `/skills` etc. sont gérés) :
+`/modular head A` → `m_modularAvatar.SetPart(Head, partA)` ; `B` → partB ;
+`off` → `ClearPart(Head)`. Logguer. (Si admin : router via master + audit ;
+si debug flag : n'exécuter que si `client.debug.modular_test`.)
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git add src/client/app/Engine.cpp src/client/app/Engine.h
+git commit -m "feat(ch2-sp1): commande /modular (swap live d'une partie placeholder)"
+```
+
+**Vérification :** en jeu — `/modular head A` fait apparaître une boîte sur la tête
+de l'avatar-monde, qui **suit l'animation** ; `head B` l'échange ; `head off` la
+retire. Aucun crash Vulkan. Prouve le pipeline modulaire de bout en bout.
+
+---
+
+## Task 5 (optionnel SP1) : aperçu 3D multi-parties
+
+`RacePreviewViewport::RenderOffscreen` : boucler le draw sur les parties actives
+(mêmes `finals`) pour voir l'équipement dans la fenêtre Personnage. Peut être
+différé au SP « UI paperdoll » si SP1 se concentre sur l'avatar-monde.
+
+---
+
+## Self-Review (couverture spec)
+
+- Composer plusieurs parties partageant un squelette → Task 1 (`ModularAvatar`).
+- Rendu = bones 1x + Record par partie → Task 3.
+- Swap live → Task 4.
+- Placeholders sans asset → Task 2 (`PlaceholderPart`) + Task 4.
+- Compat squelette (rejet) → Task 1 (`SetPart` + tests).
+- Testable ctest Linux (logique pure) → Tasks 1-2.
+- Client-only / SP suivants hors scope → aucun catalogue/wire/DB/stats/asset dans le plan. ✅

--- a/docs/superpowers/specs/2026-07-09-ch2-sp1-modular-avatar-groundwork-design.md
+++ b/docs/superpowers/specs/2026-07-09-ch2-sp1-modular-avatar-groundwork-design.md
@@ -1,0 +1,163 @@
+# Chantier 2 — SP1 : groundwork moteur avatar modulaire — design
+
+Date : 2026-07-09
+Statut : direction validée par l'utilisateur (modulaire + groundwork-first + placeholders + commande admin de test).
+
+## Contexte
+
+Chantier 2 = système d'équipement complet. Décision d'apparence : **personnage
+modulaire** (équiper REMPLACE un morceau du corps, pas de superposition).
+L'analyse du mesh actuel (cf. [[project_character_window_unified]]) a montré que
+l'avatar est **un `.glb` unique baké** : impossible de remplacer une partie. Le
+modulaire exige (a) des assets modulaires — travail d'art, **hors code**, plus
+tard — et (b) une **capacité moteur** à composer/rendre/échanger des parties.
+
+Décision : **construire d'abord la capacité moteur (SP1), testée avec des parties
+placeholder**, pour brancher les vrais assets plus tard sans re-architecturer.
+
+## Objectif SP1
+
+Rendre l'avatar-monde à partir de **plusieurs meshes de parties partageant un
+même squelette**, avec **échange de partie en direct**, démontré par des
+**placeholders** et une **commande admin de test**. **100% client-rendu.** Aucun
+serveur, wire, DB, stats, asset final, ni logique d'équipement (SP suivants).
+
+## Faisabilité (ancrage code)
+
+- `SkinnedRenderer::Record(mesh, finalBoneMatrices, …)` dessine **un** mesh
+  skinné avec des matrices d'os fournies (SSBO), en multi-sous-mesh/matériau.
+- Le draw avatar actuel : `Engine.cpp` ~5600, `m_skinnedRenderer.Record(
+  *m_currentSkinnedMesh, finals, …)`. `finals` = matrices d'os de la frame,
+  calculées depuis le squelette + pose d'animation courante.
+- **Modulaire = calculer `finals` UNE fois (squelette partagé) puis appeler
+  `Record` pour CHAQUE partie active**, même `finals` + même model matrix. Les
+  parties doivent être riggées au **même squelette** (même nombre/ordre d'os) →
+  les mêmes `finals` s'appliquent à toutes.
+
+Changement moteur **minimal** : boucle de `Record` au lieu d'un seul.
+
+## Architecture
+
+### Nouveau composant : `ModularAvatar` (client)
+
+Fichier `src/client/render/skinned/ModularAvatar.{h,cpp}`. Rôle : représenter un
+avatar composé de parties.
+
+- **Slots** : enum `EquipVisualSlot` (SP1 minimal mais extensible) —
+  `Body` (corps de base, toujours présent), `Head`, `Chest`, `Legs`, `Feet`,
+  `Hands`, `Weapon`, `Offhand`. SP1 démontre le pipeline ; tous les slots ne sont
+  pas peuplés d'assets.
+- **État** : un pointeur `SkinnedMesh*` par slot occupé (non-owning ; les meshes
+  appartiennent à un cache/registre). Le `Body` est le corps de base ; les autres
+  slots sont vides par défaut.
+- **Squelette partagé** : `ModularAvatar` référence UN squelette (celui du `Body`).
+  Invariant SP1 : toute partie ajoutée doit avoir un squelette compatible
+  (même `skeleton.bones.size()` et même ordre) — sinon rejet + log (les
+  `finals` ne s'appliqueraient pas).
+- **API** :
+  - `void SetPart(EquipVisualSlot slot, const SkinnedMesh* mesh)` — pose/retire
+    (nullptr) une partie ; valide la compatibilité squelette.
+  - `void ClearPart(EquipVisualSlot slot)`.
+  - `std::vector<const SkinnedMesh*> ActiveParts() const` — parties à dessiner
+    (Body + slots occupés).
+  - `const Skeleton& SharedSkeleton() const`.
+
+### Rendu
+
+Remplacer le draw mono-mesh de l'avatar local par une **boucle sur
+`ActiveParts()`** :
+
+```
+finals = ComputeFinalBoneMatrices(sharedSkeleton, currentPose)   // 1x
+for (const SkinnedMesh* part : modularAvatar.ActiveParts())
+    m_skinnedRenderer.Record(*part, finals, model, submeshMatIdx(part), …)
+```
+
+- `finals` inchangé (déjà calculé pour l'avatar). Les parties partagent la pose.
+- Chaque partie garde son propre routage matériau (habit/peau via
+  `submeshMaterialIndices`, comme aujourd'hui).
+- Idem pour l'aperçu 3D (`RacePreviewViewport`) : boucle de rendu sur les parties
+  (permet de voir l'équipement dans la fenêtre Personnage). Étape optionnelle
+  SP1 (le monde suffit à valider) mais souhaitable.
+
+### Chargement des parties partageant un squelette
+
+- Le loader actuel (`SkinnedMeshLoader`) charge un `.glb` → un `SkinnedMesh`
+  (skeleton + vertices + indices + submeshes + clips).
+- SP1 : charger des parties depuis des `.glb` **et réutiliser un squelette
+  commun**. Deux voies possibles ; SP1 retient la plus simple :
+  - Chaque part-`.glb` porte le même squelette (exporté sur le même rig) ; on
+    charge le mesh de la partie et on **ignore/valide** son squelette contre
+    celui du `Body`. La pose (`finals`) vient du `Body`.
+- **Placeholders SP1 (aucun asset)** : générer des parties **procédurales**
+  simples (ex. une boîte skinnée à 100% sur un os donné — tête, main…) via un
+  petit helper `MakePlaceholderPart(skeleton, boneIndex, dims)`. Cela prouve :
+  (a) plusieurs parties rendues avec les os partagés, (b) l'échange live change
+  l'avatar. Deux variantes par slot (ex. « casque A » vs « casque B ») pour
+  démontrer le SWAP.
+
+### Déclencheur de test (commande admin)
+
+Commande chat **admin-only + loguée serveur** (convention repo, cf.
+[[feedback_admin_commands_logging]] / [[reference_slash_commands]]) :
+`/modular <slot> <variante>` — pose la partie placeholder `<variante>` sur
+`<slot>` de l'avatar local ; `/modular <slot> off` retire. Purement client dans
+son effet visuel SP1 (pas de persistance) ; passe par le master pour le gating
+admin + le log, comme les autres commandes.
+
+> Alternative si le gating admin complique SP1 : une touche debug derrière un
+> flag config `client.debug.modular_test` (défaut false). À trancher au plan.
+
+## Fichiers
+
+- **Create** `src/client/render/skinned/ModularAvatar.{h,cpp}` — composant + slots.
+- **Create** `src/client/render/skinned/PlaceholderPart.{h,cpp}` — génération de
+  parties procédurales (boîte skinnée à un os) partageant un squelette.
+- **Modify** `src/client/app/Engine.cpp` — l'avatar local devient un
+  `ModularAvatar` (Body = mesh courant) ; boucle de `Record` sur `ActiveParts()` ;
+  commande `/modular`.
+- **Modify** `src/client/app/Engine.h` — membre `ModularAvatar`.
+- **Modify** (optionnel SP1) `RacePreviewViewport` — rendu multi-parties.
+- **Tests** : `ModularAvatar` a une logique pure testable (compat squelette,
+  ActiveParts, SetPart/ClearPart) → test unitaire ctest (Linux). `PlaceholderPart`
+  génère des données CPU testables (bones weights = 1 sur l'os visé).
+- **Modify** `CMakeLists.txt` (+ liste de tests) — nouveaux `.cpp` + test target.
+
+## Hors périmètre SP1 (→ SP suivants)
+
+- Catalogue d'objets (type/slot/stats/apparence par `itemId`).
+- Wire equip/unequip + état d'équipement + persistance DB. ⚠️ serveur.
+- Recalcul des stats depuis le stuff.
+- UI paperdoll : glisser l'inventaire vers les slots d'équipement.
+- **Assets modulaires réels** (art) — SP1 n'utilise que des placeholders.
+
+## Vérification
+
+- **Unitaire (ctest/Linux)** : compat squelette (rejet si bone count/ordre
+  différent), `ActiveParts` (Body + slots occupés, ordre stable), SetPart/ClearPart,
+  `PlaceholderPart` (poids d'os corrects). Ces tests sont **portables** (données
+  CPU, pas de Vulkan/ImGui) → tournent sur Linux.
+- **En jeu (Windows)** : `/modular head A` fait apparaître une partie placeholder
+  sur la tête de l'avatar-monde ; `/modular head B` l'échange ; `/modular head off`
+  la retire — le tout en direct, l'avatar continue de s'animer normalement (les
+  parties suivent la pose). Aucun crash Vulkan.
+
+## Risques
+
+- **Squelette identique obligatoire** : une partie mal riggée (ordre d'os
+  différent) se déformerait. SP1 valide bone count/ordre et rejette sinon. Les
+  placeholders procéduraux utilisent le squelette du Body → toujours compatibles.
+- **Perf** : N `Record` = N draws + N uploads SSBO de `finals`. SP1 : peu de
+  parties, avatar local seul → négligeable. (Optim future : uploader `finals`
+  une fois pour toutes les parties.)
+- **Convention winding Vulkan** : réutiliser le pipeline `SkinnedRenderer`
+  existant tel quel — ne pas toucher aux `frontFace`/`cullMode` (cf. CLAUDE.md).
+- **Gating admin de `/modular`** : si le circuit master/admin alourdit SP1,
+  repli sur un flag debug config (décision au plan).
+
+## Déploiement
+
+✅ **Client uniquement** pour le rendu et les placeholders. La commande
+`/modular`, SI routée admin via master (pour le log), suit le circuit commandes
+existant — à préciser au plan si un handler master est nécessaire (sinon repli
+flag debug = strictement client).

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -940,6 +940,16 @@ elseif(UNIX)
   lcdlln_add_simple_test(avatar_material_routing_tests
     ${CMAKE_SOURCE_DIR}/src/client/render/skinned/tests/AvatarMaterialRoutingTests.cpp)
 
+  # Chantier 2 SP1 : ModularAvatar (composition de parties partageant un squelette,
+  # logique pure). ModularAvatar.cpp est compile dans engine_core (CMakeLists racine).
+  lcdlln_add_simple_test(modular_avatar_tests
+    ${CMAKE_SOURCE_DIR}/src/client/render/skinned/tests/ModularAvatarTests.cpp)
+
+  # Chantier 2 SP1 : PlaceholderPart (boite skinnee a un os, donnees CPU).
+  # PlaceholderPart.cpp est compile dans engine_core (CMakeLists racine).
+  lcdlln_add_simple_test(placeholder_part_tests
+    ${CMAKE_SOURCE_DIR}/src/client/render/skinned/tests/PlaceholderPartTests.cpp)
+
   # Chargeur de mesh glTF statique (props, chantier B). StaticMeshLoader.cpp est
   # compile dans engine_core ; cgltf y est resolu via SkinnedMeshLoader.cpp (CGLTF_IMPLEMENTATION).
   lcdlln_add_simple_test(static_mesh_loader_tests

--- a/src/client/render/skinned/ModularAvatar.cpp
+++ b/src/client/render/skinned/ModularAvatar.cpp
@@ -1,0 +1,68 @@
+#include "src/client/render/skinned/ModularAvatar.h"
+
+#include "src/client/render/skinned/SkinnedMesh.h"
+#include "src/shared/core/Log.h"
+
+namespace engine::render::skinned
+{
+	void ModularAvatar::SetBody(const SkinnedMesh* body)
+	{
+		m_body = body;
+	}
+
+	bool ModularAvatar::SkeletonCompatible(const SkinnedMesh* mesh) const
+	{
+		if (m_body == nullptr || mesh == nullptr)
+			return false;
+		const std::vector<Bone>& a = m_body->skeleton.bones;
+		const std::vector<Bone>& b = mesh->skeleton.bones;
+		if (a.size() != b.size())
+			return false;
+		for (std::size_t i = 0; i < a.size(); ++i)
+		{
+			if (a[i].name != b[i].name)
+				return false;
+		}
+		return true;
+	}
+
+	bool ModularAvatar::SetPart(EquipVisualSlot slot, const SkinnedMesh* mesh)
+	{
+		const std::uint32_t idx = static_cast<std::uint32_t>(slot);
+		if (slot == EquipVisualSlot::Body || idx >= static_cast<std::uint32_t>(EquipVisualSlot::Count))
+			return false;
+		if (mesh != nullptr && !SkeletonCompatible(mesh))
+		{
+			LOG_WARN(Render,
+				"[ModularAvatar] partie rejetee : squelette incompatible (slot={})", idx);
+			return false;
+		}
+		m_parts[idx] = mesh;
+		return true;
+	}
+
+	void ModularAvatar::ClearPart(EquipVisualSlot slot)
+	{
+		const std::uint32_t idx = static_cast<std::uint32_t>(slot);
+		if (slot != EquipVisualSlot::Body && idx < static_cast<std::uint32_t>(EquipVisualSlot::Count))
+			m_parts[idx] = nullptr;
+	}
+
+	std::vector<const SkinnedMesh*> ModularAvatar::ActiveParts() const
+	{
+		std::vector<const SkinnedMesh*> out;
+		if (m_body != nullptr)
+			out.push_back(m_body);
+		for (std::size_t i = 0; i < static_cast<std::size_t>(EquipVisualSlot::Count); ++i)
+		{
+			if (m_parts[i] != nullptr)
+				out.push_back(m_parts[i]);
+		}
+		return out;
+	}
+
+	const Skeleton* ModularAvatar::SharedSkeleton() const
+	{
+		return m_body != nullptr ? &m_body->skeleton : nullptr;
+	}
+}

--- a/src/client/render/skinned/ModularAvatar.h
+++ b/src/client/render/skinned/ModularAvatar.h
@@ -1,0 +1,65 @@
+#pragma once
+// Chantier 2 SP1 — avatar modulaire : composé de plusieurs parties skinnées
+// partageant UN squelette. Le rendu calcule les matrices d'os une seule fois
+// (squelette + pose partagés) puis dessine chaque partie active. Logique pure
+// (données CPU) — pas de Vulkan ici, testable en ctest.
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace engine::render::skinned
+{
+	struct SkinnedMesh;
+	struct Skeleton;
+
+	/// Slots visuels d'équipement. SP1 démontre le pipeline (pas tous peuplés
+	/// d'assets). `Body` = corps de base (toujours présent). `Count` = borne.
+	enum class EquipVisualSlot : uint32_t
+	{
+		Body = 0,
+		Head,
+		Chest,
+		Legs,
+		Feet,
+		Hands,
+		Weapon,
+		Offhand,
+		Count
+	};
+
+	/// Avatar composé de parties skinnées partageant le squelette du corps de base.
+	/// Pointeurs non-possédés : les meshes appartiennent à un cache/registre externe.
+	class ModularAvatar
+	{
+	public:
+		/// Définit le corps de base ; son squelette devient la référence partagée.
+		void SetBody(const SkinnedMesh* body);
+
+		/// Pose (`mesh` != nullptr) ou retire (`mesh` == nullptr) une partie sur un
+		/// slot. Rejette (retourne false + log) si le squelette de `mesh` n'est pas
+		/// compatible avec celui du corps (même nombre d'os ET mêmes noms/ordre), ou
+		/// si `slot` == Body / hors borne.
+		bool SetPart(EquipVisualSlot slot, const SkinnedMesh* mesh);
+
+		/// Retire la partie d'un slot (no-op sur Body / hors borne).
+		void ClearPart(EquipVisualSlot slot);
+
+		/// Parties à dessiner : le corps d'abord (s'il existe), puis les slots
+		/// occupés dans l'ordre de l'enum. Toutes partagent le squelette du corps.
+		std::vector<const SkinnedMesh*> ActiveParts() const;
+
+		/// Squelette partagé (celui du corps), ou nullptr si aucun corps.
+		const Skeleton* SharedSkeleton() const;
+
+		bool HasBody() const { return m_body != nullptr; }
+
+	private:
+		/// true si `mesh` partage le squelette du corps (même nb d'os + mêmes
+		/// noms dans le même ordre). false si pas de corps ou `mesh` nul.
+		bool SkeletonCompatible(const SkinnedMesh* mesh) const;
+
+		const SkinnedMesh* m_body = nullptr;
+		const SkinnedMesh* m_parts[static_cast<std::size_t>(EquipVisualSlot::Count)] = {};
+	};
+}

--- a/src/client/render/skinned/PlaceholderPart.cpp
+++ b/src/client/render/skinned/PlaceholderPart.cpp
@@ -1,0 +1,93 @@
+#include "src/client/render/skinned/PlaceholderPart.h"
+
+#include "src/client/render/skinned/Skeleton.h"
+#include "src/shared/math/Math.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::render::skinned
+{
+	SkinnedMeshCpuData MakePlaceholderBoxPart(const Skeleton& skel, int boneIndex, float halfExtentM)
+	{
+		SkinnedMeshCpuData cpu;
+		cpu.skeleton = skel; // squelette partagé (copie) — la pose vient du corps au rendu.
+
+		// Position bind-globale de l'os cible. Même convention que
+		// AnimationSampler::ComputeGlobalMatrices : global = parent * bindLocal
+		// (bones topo-ordonnés parent-avant-enfant). Translation = colonne 3.
+		float cx = 0.0f, cy = 0.0f, cz = 0.0f;
+		const bool boneOk = (boneIndex >= 0)
+			&& (static_cast<std::size_t>(boneIndex) < skel.bones.size());
+		if (boneOk)
+		{
+			std::vector<engine::math::Mat4> globals(skel.bones.size());
+			for (std::size_t i = 0; i < skel.bones.size(); ++i)
+			{
+				const int parent = skel.bones[i].parentIndex;
+				globals[i] = (parent < 0)
+					? skel.bones[i].bindLocal
+					: globals[static_cast<std::size_t>(parent)] * skel.bones[i].bindLocal;
+			}
+			const engine::math::Mat4& g = globals[static_cast<std::size_t>(boneIndex)];
+			cx = g.m[12];
+			cy = g.m[13];
+			cz = g.m[14];
+		}
+
+		const std::uint16_t bone = static_cast<std::uint16_t>(boneOk ? boneIndex : 0);
+		const float h = halfExtentM;
+
+		// 6 faces (normale sortante) ; 4 sommets CCW vus de l'extérieur.
+		struct Face { float n[3]; float c[4][3]; };
+		const Face faces[6] = {
+			{{ 0.f, 0.f, 1.f}, {{-h,-h, h},{ h,-h, h},{ h, h, h},{-h, h, h}}}, // +Z
+			{{ 0.f, 0.f,-1.f}, {{ h,-h,-h},{-h,-h,-h},{-h, h,-h},{ h, h,-h}}}, // -Z
+			{{ 1.f, 0.f, 0.f}, {{ h,-h, h},{ h,-h,-h},{ h, h,-h},{ h, h, h}}}, // +X
+			{{-1.f, 0.f, 0.f}, {{-h,-h,-h},{-h,-h, h},{-h, h, h},{-h, h,-h}}}, // -X
+			{{ 0.f, 1.f, 0.f}, {{-h, h, h},{ h, h, h},{ h, h,-h},{-h, h,-h}}}, // +Y
+			{{ 0.f,-1.f, 0.f}, {{-h,-h,-h},{ h,-h,-h},{ h,-h, h},{-h,-h, h}}}, // -Y
+		};
+		const float uvs[4][2] = {{0.f,0.f},{1.f,0.f},{1.f,1.f},{0.f,1.f}};
+
+		cpu.vertices.reserve(24);
+		cpu.indices.reserve(36);
+		for (int f = 0; f < 6; ++f)
+		{
+			const std::uint32_t base = static_cast<std::uint32_t>(cpu.vertices.size());
+			for (int v = 0; v < 4; ++v)
+			{
+				SkinnedVertex sv{};
+				sv.pos[0] = cx + faces[f].c[v][0];
+				sv.pos[1] = cy + faces[f].c[v][1];
+				sv.pos[2] = cz + faces[f].c[v][2];
+				sv.normal[0] = faces[f].n[0];
+				sv.normal[1] = faces[f].n[1];
+				sv.normal[2] = faces[f].n[2];
+				sv.uv[0] = uvs[v][0];
+				sv.uv[1] = uvs[v][1];
+				sv.boneIndices[0] = bone;
+				sv.boneIndices[1] = 0u;
+				sv.boneIndices[2] = 0u;
+				sv.boneIndices[3] = 0u;
+				sv.weights[0] = 1.0f;
+				sv.weights[1] = 0.0f;
+				sv.weights[2] = 0.0f;
+				sv.weights[3] = 0.0f;
+				cpu.vertices.push_back(sv);
+			}
+			cpu.indices.push_back(base + 0u);
+			cpu.indices.push_back(base + 1u);
+			cpu.indices.push_back(base + 2u);
+			cpu.indices.push_back(base + 0u);
+			cpu.indices.push_back(base + 2u);
+			cpu.indices.push_back(base + 3u);
+		}
+
+		cpu.submeshes.push_back(
+			SkinnedSubMesh{0u, static_cast<std::uint32_t>(cpu.indices.size()), std::string()});
+		return cpu;
+	}
+}

--- a/src/client/render/skinned/PlaceholderPart.h
+++ b/src/client/render/skinned/PlaceholderPart.h
@@ -1,0 +1,19 @@
+#pragma once
+// Chantier 2 SP1 — génération d'une PARTIE placeholder (aucun asset) : une boîte
+// skinnée à 100% sur un os, centrée sur la position bind-globale de cet os. Sert
+// à valider le pipeline modulaire (composition/swap) en attendant les vrais
+// assets. Données CPU uniquement (pas de Vulkan) — testable en ctest.
+
+#include "src/client/render/skinned/SkinnedMeshLoader.h" // SkinnedMeshCpuData
+
+namespace engine::render::skinned
+{
+	struct Skeleton;
+
+	/// Construit une boîte (24 sommets, 36 indices, 1 sous-maillage) de demi-côté
+	/// `halfExtentM`, centrée sur la position bind-globale de l'os `boneIndex`,
+	/// entièrement pondérée (poids 1) sur cet os. Le squelette `skel` est COPIÉ
+	/// dans les données CPU pour partager la pose de l'avatar au rendu.
+	/// \param boneIndex hors borne ou < 0 → boîte à l'origine, pondérée sur l'os 0.
+	SkinnedMeshCpuData MakePlaceholderBoxPart(const Skeleton& skel, int boneIndex, float halfExtentM);
+}

--- a/src/client/render/skinned/tests/ModularAvatarTests.cpp
+++ b/src/client/render/skinned/tests/ModularAvatarTests.cpp
@@ -1,0 +1,140 @@
+#include "src/client/render/skinned/ModularAvatar.h"
+#include "src/client/render/skinned/SkinnedMesh.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+using engine::render::skinned::EquipVisualSlot;
+using engine::render::skinned::ModularAvatar;
+using engine::render::skinned::SkinnedMesh;
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { std::fprintf(stderr, "[FAIL] %s:%d %s\n", __FILE__, __LINE__, #cond); ++g_failed; } \
+	} while (0)
+
+	/// Construit un SkinnedMesh CPU minimal : uniquement le squelette (noms d'os).
+	/// Aucune ressource GPU (les handles restent VK_NULL_HANDLE, pas d'Upload).
+	SkinnedMesh MakeMesh(const std::vector<std::string>& boneNames)
+	{
+		SkinnedMesh m;
+		m.skeleton.bones.resize(boneNames.size());
+		for (std::size_t i = 0; i < boneNames.size(); ++i)
+		{
+			m.skeleton.bones[i].name = boneNames[i];
+			m.skeleton.bones[i].parentIndex = (i == 0) ? -1 : static_cast<int>(i - 1);
+		}
+		return m;
+	}
+
+	void Test_NoBody_EmptyAndNullSkeleton()
+	{
+		ModularAvatar a;
+		REQUIRE(!a.HasBody());
+		REQUIRE(a.ActiveParts().empty());
+		REQUIRE(a.SharedSkeleton() == nullptr);
+		// SetPart sans corps -> rejet (squelette incompatible car pas de ref).
+		SkinnedMesh part = MakeMesh({"root", "head"});
+		REQUIRE(!a.SetPart(EquipVisualSlot::Head, &part));
+	}
+
+	void Test_SetBody_ExposesBodyAndSkeleton()
+	{
+		SkinnedMesh body = MakeMesh({"root", "head", "hand"});
+		ModularAvatar a;
+		a.SetBody(&body);
+		REQUIRE(a.HasBody());
+		REQUIRE(a.SharedSkeleton() == &body.skeleton);
+		const auto parts = a.ActiveParts();
+		REQUIRE(parts.size() == 1);
+		REQUIRE(parts[0] == &body);
+	}
+
+	void Test_SetPart_CompatibleSkeleton_Accepted()
+	{
+		SkinnedMesh body = MakeMesh({"root", "head", "hand"});
+		SkinnedMesh helmet = MakeMesh({"root", "head", "hand"}); // mêmes noms/ordre
+		ModularAvatar a;
+		a.SetBody(&body);
+		REQUIRE(a.SetPart(EquipVisualSlot::Head, &helmet));
+		const auto parts = a.ActiveParts();
+		REQUIRE(parts.size() == 2);
+		REQUIRE(parts[0] == &body);   // corps d'abord
+		REQUIRE(parts[1] == &helmet); // puis la partie
+	}
+
+	void Test_SetPart_DifferentBoneCount_Rejected()
+	{
+		SkinnedMesh body = MakeMesh({"root", "head", "hand"});
+		SkinnedMesh bad = MakeMesh({"root", "head"}); // 2 os != 3
+		ModularAvatar a;
+		a.SetBody(&body);
+		REQUIRE(!a.SetPart(EquipVisualSlot::Head, &bad));
+		REQUIRE(a.ActiveParts().size() == 1); // pas ajoutée
+	}
+
+	void Test_SetPart_DifferentBoneNames_Rejected()
+	{
+		SkinnedMesh body = MakeMesh({"root", "head", "hand"});
+		SkinnedMesh bad = MakeMesh({"root", "HEAD", "hand"}); // nom différent
+		ModularAvatar a;
+		a.SetBody(&body);
+		REQUIRE(!a.SetPart(EquipVisualSlot::Head, &bad));
+		REQUIRE(a.ActiveParts().size() == 1);
+	}
+
+	void Test_SetPart_BodySlot_Rejected()
+	{
+		SkinnedMesh body = MakeMesh({"root", "head"});
+		SkinnedMesh other = MakeMesh({"root", "head"});
+		ModularAvatar a;
+		a.SetBody(&body);
+		REQUIRE(!a.SetPart(EquipVisualSlot::Body, &other));
+	}
+
+	void Test_ClearPart_RemovesPart()
+	{
+		SkinnedMesh body = MakeMesh({"root", "head"});
+		SkinnedMesh helmet = MakeMesh({"root", "head"});
+		ModularAvatar a;
+		a.SetBody(&body);
+		REQUIRE(a.SetPart(EquipVisualSlot::Head, &helmet));
+		REQUIRE(a.ActiveParts().size() == 2);
+		a.ClearPart(EquipVisualSlot::Head);
+		REQUIRE(a.ActiveParts().size() == 1);
+		REQUIRE(a.ActiveParts()[0] == &body);
+	}
+
+	void Test_ActiveParts_OrderedByEnum()
+	{
+		SkinnedMesh body = MakeMesh({"root", "head"});
+		SkinnedMesh chest = MakeMesh({"root", "head"});
+		SkinnedMesh head = MakeMesh({"root", "head"});
+		ModularAvatar a;
+		a.SetBody(&body);
+		// Pose Chest avant Head : l'ordre de sortie doit suivre l'enum (Head < Chest).
+		REQUIRE(a.SetPart(EquipVisualSlot::Chest, &chest));
+		REQUIRE(a.SetPart(EquipVisualSlot::Head, &head));
+		const auto parts = a.ActiveParts();
+		REQUIRE(parts.size() == 3);
+		REQUIRE(parts[0] == &body);
+		REQUIRE(parts[1] == &head);  // Head (enum 1) avant
+		REQUIRE(parts[2] == &chest); // Chest (enum 2)
+	}
+}
+
+int main()
+{
+	Test_NoBody_EmptyAndNullSkeleton();
+	Test_SetBody_ExposesBodyAndSkeleton();
+	Test_SetPart_CompatibleSkeleton_Accepted();
+	Test_SetPart_DifferentBoneCount_Rejected();
+	Test_SetPart_DifferentBoneNames_Rejected();
+	Test_SetPart_BodySlot_Rejected();
+	Test_ClearPart_RemovesPart();
+	Test_ActiveParts_OrderedByEnum();
+	return g_failed == 0 ? 0 : 1;
+}

--- a/src/client/render/skinned/tests/PlaceholderPartTests.cpp
+++ b/src/client/render/skinned/tests/PlaceholderPartTests.cpp
@@ -1,0 +1,94 @@
+#include "src/client/render/skinned/PlaceholderPart.h"
+#include "src/client/render/skinned/Skeleton.h"
+#include "src/shared/math/Math.h"
+
+#include <cmath>
+#include <cstdio>
+
+using engine::math::Mat4;
+using engine::math::Vec3;
+using engine::render::skinned::Bone;
+using engine::render::skinned::MakePlaceholderBoxPart;
+using engine::render::skinned::Skeleton;
+using engine::render::skinned::SkinnedMeshCpuData;
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { std::fprintf(stderr, "[FAIL] %s:%d %s\n", __FILE__, __LINE__, #cond); ++g_failed; } \
+	} while (0)
+
+	bool Approx(float a, float b, float eps = 1e-3f) { return std::fabs(a - b) <= eps; }
+
+	/// Squelette 2 os : root (identité) puis head translaté de (0, 1.5, 0).
+	Skeleton MakeSkel()
+	{
+		Skeleton s;
+		s.bones.resize(2);
+		s.bones[0].name = "root";
+		s.bones[0].parentIndex = -1;
+		s.bones[0].bindLocal = Mat4::Identity();
+		s.bones[1].name = "head";
+		s.bones[1].parentIndex = 0;
+		s.bones[1].bindLocal = Mat4::Translate(Vec3{0.0f, 1.5f, 0.0f});
+		return s;
+	}
+
+	void Test_BoxCounts()
+	{
+		SkinnedMeshCpuData part = MakePlaceholderBoxPart(MakeSkel(), 1, 0.1f);
+		REQUIRE(part.vertices.size() == 24);
+		REQUIRE(part.indices.size() == 36);
+		REQUIRE(part.submeshes.size() == 1);
+		REQUIRE(part.submeshes[0].firstIndex == 0u);
+		REQUIRE(part.submeshes[0].indexCount == 36u);
+		REQUIRE(part.skeleton.bones.size() == 2); // squelette copié
+	}
+
+	void Test_AllVertsWeightedToTargetBone()
+	{
+		SkinnedMeshCpuData part = MakePlaceholderBoxPart(MakeSkel(), 1, 0.1f);
+		for (const auto& v : part.vertices)
+		{
+			REQUIRE(v.boneIndices[0] == 1);
+			REQUIRE(Approx(v.weights[0], 1.0f));
+			REQUIRE(Approx(v.weights[1], 0.0f));
+			REQUIRE(Approx(v.weights[2], 0.0f));
+			REQUIRE(Approx(v.weights[3], 0.0f));
+		}
+	}
+
+	void Test_BoxCenteredOnBoneBindGlobal()
+	{
+		SkinnedMeshCpuData part = MakePlaceholderBoxPart(MakeSkel(), 1, 0.1f);
+		// Centre = moyenne des 24 sommets (boîte symétrique) ≈ position bind-globale
+		// de head = (0, 1.5, 0).
+		float sx = 0.0f, sy = 0.0f, sz = 0.0f;
+		for (const auto& v : part.vertices) { sx += v.pos[0]; sy += v.pos[1]; sz += v.pos[2]; }
+		const float n = static_cast<float>(part.vertices.size());
+		REQUIRE(Approx(sx / n, 0.0f));
+		REQUIRE(Approx(sy / n, 1.5f));
+		REQUIRE(Approx(sz / n, 0.0f));
+	}
+
+	void Test_OutOfRangeBone_FallsBackToOrigin()
+	{
+		SkinnedMeshCpuData part = MakePlaceholderBoxPart(MakeSkel(), 99, 0.1f);
+		REQUIRE(part.vertices.size() == 24);
+		for (const auto& v : part.vertices)
+			REQUIRE(v.boneIndices[0] == 0); // repli sur l'os 0
+		float sy = 0.0f;
+		for (const auto& v : part.vertices) sy += v.pos[1];
+		REQUIRE(Approx(sy / static_cast<float>(part.vertices.size()), 0.0f)); // origine
+	}
+}
+
+int main()
+{
+	Test_BoxCounts();
+	Test_AllVertsWeightedToTargetBone();
+	Test_BoxCenteredOnBoneBindGlobal();
+	Test_OutOfRangeBone_FallsBackToOrigin();
+	return g_failed == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Chantier 2 (équipement) — **SP1 : groundwork moteur avatar modulaire**. Tasks 1-2 (logique pure, testable). **Indépendant de #960.**

Spec : `docs/superpowers/specs/2026-07-09-ch2-sp1-modular-avatar-groundwork-design.md`
Plan : `docs/superpowers/plans/2026-07-09-ch2-sp1-modular-avatar-groundwork.md`

## Contenu
- **`ModularAvatar`** : compose un avatar de plusieurs parties skinnées partageant UN squelette (Body + slots ; `ActiveParts()` ; validation de compatibilité squelette). Logique pure.
- **`PlaceholderPart`** : génère une boîte skinnée à 100% sur un os, centrée sur sa position bind-globale — **partie placeholder sans asset** pour valider le pipeline.
- **Tests ctest** (`modular_avatar_tests`, `placeholder_part_tests`) — données CPU, pas de Vulkan → tournent sur Linux.

## À suivre (mêmes SP, après merge de #960)
- **Task 3** : l'avatar-monde rendu via `ModularAvatar` (boucle `Record`).
- **Task 4** : commande `/modular` (swap live). Ces tasks touchent le rendu avatar de `Engine.cpp` que #960 modifie → faites une fois #960 mergé.

## Déploiement
✅ **client uniquement.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)