### PR TITLE
fix(ch2-sp1): boite /modular via pose os identite (court-circuite le rig UE5 casse)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -5666,6 +5666,15 @@ namespace engine
 															// routage matériau (habit/peau) ; les parties placeholder utilisent le
 															// chemin mono-draw (materialIndex 0). ActiveParts() = Body seul tant
 															// qu'aucune partie n'est équipée -> rendu identique à avant.
+															// Matrices d'os IDENTITÉ pour les parties placeholder : le rig UE5
+															// a des os inexploitables (bind-globales à l'origine) -> peser une
+															// boîte a un os la projette n'importe ou. Avec une pose identité, la
+															// partie n'est plus deformee par le squelette : posee en espace
+															// MODELE (~1.6 m = tete) puis placee par finalModelMat (la meme
+															// matrice qui positionne tout l'avatar), elle se pose sur la tete et
+															// suit position + orientation du perso. Suivi fin par os -> rig propre.
+															std::vector<engine::math::Mat4> identityFinals(
+																finals.size(), engine::math::Mat4::Identity());
 															for (const engine::render::skinned::SkinnedMesh* part : m_modularAvatar.ActiveParts())
 															{
 																const bool isBody = (part == m_currentSkinnedMesh);
@@ -5676,7 +5685,7 @@ namespace engine
 																	VK_NULL_HANDLE,
 																	rs.prevViewProjMatrix.m, rs.viewProjMatrix.m,
 																	*part,
-																	finals,
+																	isBody ? finals : identityFinals,
 																	materialCache.GetDescriptorSet(),
 																	finalModelMat.m,
 																	isBody ? skinnedMaterialIndex : 0u,


### PR DESCRIPTION
## Contexte

Suite du merge #962 (avatar modulaire SP1 + commande `/modular`). Testée en jeu,
la boîte placeholder ne se posait pas sur le personnage : elle atterrissait aux
pieds puis, selon les tentatives, **loin dans le décor**.

## Cause (confirmée par diagnostic en jeu)

Le rig UE5 de l'avatar a des **os inexploitables** : leur bind-globale est à
l'**origine** (l'os tête est à Y≈0, pas à ~1.6 m) et la matrice `finals` de
skinning projette un point attaché à l'os n'importe où. Peser la boîte à un os
(tête ou racine) la déplaçait donc hors du personnage. Le corps se rend
correctement car sa géométrie porte les positions — les matrices d'os ≈ identité.

## Fix

Au rendu des **parties placeholder** uniquement, on passe une pose d'os
**identité** (`identityFinals`) au lieu des `finals` animés. La partie n'est
alors plus déformée par le squelette : posée en espace **modèle** (~1,6 m =
hauteur tête, déjà géré dans `PlaceholderPart`) puis placée par `finalModelMat`
— **la même matrice qui positionne correctement tout l'avatar**. La boîte se pose
donc sur la tête et suit position + orientation du personnage. Le **Body** garde
ses `finals` animés (aucune régression sur l'avatar).

Le suivi fin par os (casque qui tourne avec la tête) reviendra avec un rig propre
et de vrais assets modulaires — l'objectif de SP1 étant de **prouver que le
pipeline dessine bien une pièce attachée à l'avatar**.

## Déploiement

✅ **Client uniquement** (rendu). Aucun changement protocole/serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)