### PR TITLE
Chantier 2 SP-A (PR2/2 client) : panneau équipement F1 + tooltips

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,7 @@ add_library(engine_core
   src/client/render/vk/VkUtils.cpp
   src/shared/core/Clock.cpp
   src/shared/core/Config.cpp
+  src/shared/items/ItemCatalog.cpp
   src/shared/core/ServerEndpoints.cpp
   src/shared/core/Profiler.cpp
   src/shared/core/jobs/JobSystem.cpp

--- a/docs/superpowers/specs/2026-07-10-ch2-spA-item-catalog-equipment-design.md
+++ b/docs/superpowers/specs/2026-07-10-ch2-spA-item-catalog-equipment-design.md
@@ -1,0 +1,288 @@
+# Chantier 2 — SP-A : Catalogue d'objets + Équipement — Design
+
+**Date :** 2026-07-10
+**Statut :** spec à valider
+
+## Objectif
+
+Donner une identité à chaque objet (type, slot d'équipement, bonus de stats,
+apparence) et permettre de l'**équiper depuis l'inventaire**, avec état
+d'équipement autoritaire serveur, persistance DB, et recalcul des stats. Objectif
+en jeu : équiper un objet ramassé → l'effet est visible **immédiatement** dans
+l'inventaire ET sur la fiche (stats). L'apparence 3D sur l'avatar-monde et le
+drag paperdoll complet sont des SP ultérieurs (C, D).
+
+## Périmètre (décidé)
+
+SP-A fusionne « catalogue » + « équiper ». Inclus :
+- Catalogue d'objets partagé (données) : type, slot, bonus stats, apparence.
+- 10 slots d'équipement : 7 visuels (Tête, Torse, Jambes, Pieds, Mains, Arme,
+  2ᵈᵉ main) + 3 non visuels (Amulette, Anneau 1, Anneau 2).
+- Bonus possible sur n'importe laquelle des **11 stats dérivées** existantes.
+- État d'équipement serveur + table DB + persistance.
+- Opcodes réseau equip/unequip + snapshot d'équipement (**wire-breaking**).
+- Recalcul stats avec contribution d'équipement.
+- UI minimale : le panneau gauche « Équipement » de la fenêtre Personnage (F1)
+  affiche les slots + l'objet équipé ; équiper/déséquiper via clic (bouton /
+  clic droit) sur un objet d'inventaire ou un slot.
+
+Hors périmètre (SP ultérieurs) :
+- Apparence 3D de l'équipement sur l'avatar-monde et sur les avatars distants (SP-D + broadcast).
+- Drag & drop complet inventaire↔paperdoll (SP-C).
+- Instances d'objets uniques (durabilité, enchantements) : **non** — modèle par `itemId` (cf. §4).
+
+## Global Constraints
+
+- C++ (client Windows/Vulkan, serveur Linux master + shardd). Commentaires FR, clarté > brièveté.
+- Nouveau code en **PascalCase** (classes/fichiers/dossiers) ; `m_camelCase`/`kPascalCase` conservés.
+- Serveur : `character_stats` recalcul **déterministe, sans accès disque** pour les
+  tables de stats (embarqué). Le **catalogue d'objets**, lui, peut être lu depuis
+  `game/data/` sur le shard (comme les loot tables) — l'important anti-triche est
+  que le serveur calcule slot/bonus depuis **sa propre** copie, jamais des valeurs
+  fournies par le client.
+- `server_app`/`shardd` ne linkent pas `engine_core` : tout `.cpp` partagé ajouté
+  doit être listé dans les cibles serveur de `src/CMakeLists.txt` (et racine).
+- Bump `kProtocolVersion` (14→15) car nouveaux opcodes + snapshot ⇒ déploiement
+  **lock-step master + shardd + client**.
+
+## 1. Catalogue d'objets (partagé)
+
+### 1.1 Modèle de données — `src/shared/items/ItemDefinition.h`
+
+```cpp
+namespace engine::items
+{
+    // Slot d'équipement gameplay. 0 = objet non équipable (consommable, quête…).
+    enum class EquipmentSlot : std::uint8_t {
+        None = 0,
+        Head, Chest, Legs, Feet, Hands, MainHand, OffHand, // 7 visuels
+        Amulet, Ring1, Ring2,                              // 3 non visuels
+        Count
+    };
+
+    // Catégorie d'objet (pour tri/UI ; pas de logique lourde en SP-A).
+    enum class ItemType : std::uint8_t {
+        Misc = 0, Weapon, Armor, Accessory, Consumable, Quest
+    };
+
+    // Les 11 stats dérivées existantes (miroir de shardd DerivedStats).
+    // Un bonus d'équipement additionne ces champs à la stat calculée.
+    struct StatBonus {
+        std::int32_t hp = 0;
+        std::int32_t resource = 0;
+        std::int32_t damage = 0;
+        std::int32_t accuracy = 0;
+        float        range = 0.f;
+        float        critRate = 0.f;
+        float        critMult = 0.f;
+        float        speedWalk = 0.f;
+        float        speedRun = 0.f;
+        float        speedSprint = 0.f;
+        std::int32_t stamina = 0;
+        std::int32_t perception = 0;
+        std::int32_t stealth = 0;
+    };
+
+    struct ItemDefinition {
+        std::uint32_t id = 0;
+        std::string   name;
+        std::string   description;
+        std::string   iconPath;
+        ItemType      type = ItemType::Misc;
+        EquipmentSlot slot = EquipmentSlot::None; // None => non équipable
+        StatBonus     bonus;                      // additif quand équipé
+        // Apparence modulaire (SP-D) : slot visuel + réf. asset. Facultatif ici.
+        std::string   visualMesh;                 // vide en SP-A (placeholder)
+    };
+}
+```
+
+*Note : `StatBonus` liste 13 champs (les 11 « dérivées » + resource/stealth) pour
+couvrir tout `DerivedStats` ; on garde l'ensemble complet pour éviter un 2ᵉ
+passage plus tard. Le mapping `EquipmentSlot` → `EquipVisualSlot` (rendu) est une
+fonction utilitaire `ToVisualSlot(EquipmentSlot)` renvoyant `Count` pour les slots
+non visuels (Amulet/Ring).*
+
+### 1.2 Chargeur — `src/shared/items/ItemCatalog.{h,cpp}`
+
+```cpp
+class ItemCatalog {
+public:
+    // Charge depuis un contenu JSON (texte). Renvoie false si JSON invalide.
+    bool LoadFromJson(const std::string& json);
+    const ItemDefinition* Find(std::uint32_t itemId) const; // nullptr si absent
+    std::size_t Count() const;
+private:
+    std::unordered_map<std::uint32_t, ItemDefinition> m_items;
+};
+```
+
+- Parseur JSON : réutiliser le même utilitaire JSON que `CharacterStatsTables`
+  (à identifier lors du plan ; sinon parseur minimal cohérent avec le repo).
+- **Client** : charge `game/data/items/items.json` via `FileSystem`.
+- **Shard** : charge le même fichier depuis `game/data/items/items.json` au boot.
+- Tolérant : un item mal formé est ignoré avec un WARN (comme `inventory_items.txt`).
+
+### 1.3 Fichier de données — `game/data/items/items.json`
+
+Reprend les 4 objets existants de `inventory_items.txt` + exemples équipables :
+
+```json
+{
+  "items": [
+    { "id": 2001, "name": "Épée rouillée", "type": "weapon", "slot": "main_hand",
+      "icon": "ui/icons/item_2001.png", "description": "Butin de mêlée de base.",
+      "bonus": { "damage": 3 } },
+    { "id": 2002, "name": "Potion mineure", "type": "consumable", "slot": "none",
+      "icon": "ui/icons/item_2002.png", "description": "Consommable empilable." },
+    { "id": 3001, "name": "Relique de quête", "type": "quest", "slot": "none",
+      "icon": "ui/icons/item_3001.png", "description": "Récompense de quête." },
+    { "id": 4001, "name": "Sceau d'événement", "type": "accessory", "slot": "amulet",
+      "icon": "ui/icons/item_4001.png", "description": "Amulette d'événement.",
+      "bonus": { "hp": 10, "perception": 2 } },
+    { "id": 5001, "name": "Casque de cuir", "type": "armor", "slot": "head",
+      "icon": "ui/icons/item_5001.png", "description": "Protège la tête.",
+      "bonus": { "hp": 8 } },
+    { "id": 5002, "name": "Plastron de cuir", "type": "armor", "slot": "chest",
+      "icon": "ui/icons/item_5002.png", "description": "Protège le torse.",
+      "bonus": { "hp": 15 } }
+  ]
+}
+```
+
+`inventory_items.txt` reste en place (compat) mais le client privilégie le
+catalogue JSON quand un itemId y figure (fallback .txt sinon). *Décision plan :
+migrer entièrement puis retirer .txt, ou garder le fallback — à trancher au plan ;
+défaut = garder le fallback pour ne rien casser.*
+
+## 2. État d'équipement (serveur autoritaire)
+
+Par personnage : `equipment[EquipmentSlot] = itemId` (0 = vide). Vit dans
+`ConnectedClient` côté `shardd` (à côté de `inventory` = `vector<ItemStack>`).
+
+```cpp
+// 10 slots utiles (indices 1..10 ; 0 = None non stocké).
+std::array<std::uint32_t, /*Count-1*/ 10> equipment{}; // itemId par slot
+```
+
+### 2.1 Logique équiper / déséquiper (serveur)
+
+- **Équiper `itemId`** :
+  1. Résoudre `def = catalog.Find(itemId)`. Rejeter si absent ou `def.slot == None`.
+  2. Vérifier que le joueur **possède** `itemId` (inventaire, quantity ≥ 1).
+  3. Slot cible = `def.slot`. Si un objet y est déjà équipé, il est **déséquipé**
+     (rendu à l'inventaire) d'abord.
+  4. Décrémenter l'inventaire de 1 (retirer le stack si quantity tombe à 0).
+  5. `equipment[slot] = itemId`.
+  6. Recalculer stats (avec bonus), envoyer `PlayerStats` + `EquipmentUpdate` +
+     `InventoryDelta` ; sauvegarder.
+- **Déséquiper `slot`** :
+  1. `itemId = equipment[slot]` ; no-op si vide.
+  2. `equipment[slot] = 0` ; rendre `itemId` à l'inventaire (+1 / nouveau stack).
+  3. Recalcul stats + `EquipmentUpdate` + `InventoryDelta` + save.
+
+Anti-triche : slot et bonus proviennent **toujours** du catalogue serveur ; le
+client n'envoie qu'un `itemId` (équiper) ou un indice de `slot` (déséquiper).
+
+## 3. Recalcul des stats avec équipement
+
+Point d'extension : `ComputeStats(tables, factionId, classId, sex, level)`
+(`src/shardd/gameplay/character/CharacterStatsEngine.{h,cpp}`).
+
+- Nouvelle surcharge / paramètre : `ComputeStats(..., const StatBonus& equipmentBonus)`
+  où `equipmentBonus` = somme des `def.bonus` de tous les slots équipés.
+- La contribution s'**additionne** aux stats dérivées après interpolation
+  classe/race/sexe (ex. `derived.hp += equipmentBonus.hp`). Clamp à ≥ 0.
+- Appelé à : boot (avec l'équipement chargé de la DB), equip, unequip, level-up.
+- `SendPlayerStats` inchangé côté wire (11 stats) — seules les valeurs changent.
+
+## 4. Modèle « pas d'instances »
+
+Un objet équipé est identifié par son `itemId` seul (pas d'instanceId, pas de
+durabilité). Conséquences assumées :
+- Deux exemplaires du même `itemId` sont interchangeables.
+- Équiper = déplacer 1 unité inventaire → slot ; déséquiper = l'inverse.
+- Suffisant pour SP-A ; les instances uniques (enchant/durabilité) seront un SP
+  dédié si le design du jeu l'exige.
+
+## 5. Persistance (shardd)
+
+- **Table DB** (SQLite persistance shard) — nouvelle migration
+  `game/data/persistence/db/migrations/0002_character_equipment.sql` :
+  ```sql
+  CREATE TABLE IF NOT EXISTS character_equipment (
+      character_key INTEGER NOT NULL,
+      slot          INTEGER NOT NULL,     -- valeur EquipmentSlot (1..10)
+      item_id       INTEGER NOT NULL,
+      PRIMARY KEY (character_key, slot),
+      FOREIGN KEY (character_key) REFERENCES characters(character_key)
+  );
+  ```
+- **Sérialisation KV** (chemin réel utilisé par `CharacterPersistence`) : ajouter
+  `equipment.count`, `equipment.N.slot`, `equipment.N.item_id` à côté du bloc
+  `inventory.*` (`CharacterPersistence.cpp`). Charger au boot → remplir
+  `ConnectedClient.equipment` avant le 1ᵉʳ recalcul stats.
+
+## 6. Réseau (wire-breaking → bump protocole 14→15)
+
+`src/shared/network/ServerProtocol.h` :
+
+- **Nouveaux opcodes** :
+  - `EquipRequest` (client→shard) : `{ clientId, action:uint8 (0=equip,1=unequip),
+    itemId:uint32, slot:uint8 }`. Pour equip, `itemId` compte ; pour unequip,
+    `slot` compte.
+  - `EquipmentUpdate` (shard→client) : snapshot complet
+    `{ clientId, count:uint8, [slot:uint8, itemId:uint32]×count }`.
+- `Encode/DecodeEquipRequest`, `Encode/DecodeEquipmentUpdate` (miroir des helpers
+  inventaire existants).
+- Handler shard `HandleEquipRequest` (près de `PickupRequest`), envoi
+  `EquipmentUpdate` après mutation. Master : relai/route si nécessaire (equip est
+  du ressort shardd, gameplay).
+- Bump `kProtocolVersion` 14 → 15.
+
+## 7. Client
+
+- **Chargeur catalogue** : `ItemCatalog` chargé au boot client ; `InventoryUi`
+  résout nom/icône/infobulle via le catalogue (fallback `inventory_items.txt`).
+  Infobulle enrichie : type, slot, bonus de stats (lignes « +8 PV », « +3 Dégâts »…).
+- **Modèle client** : `UIModel.equipment` = `std::array<uint32_t,10>` alimenté par
+  `EquipmentUpdate` (comme `inventory` par `InventoryDelta`). Flag de changement
+  `UIModelChangeEquipment`.
+- **Panneau Équipement** (fenêtre Personnage F1, panneau gauche « Équipement —
+  Chantier 2 ») : afficher les 10 slots (icône de l'objet équipé ou slot vide +
+  libellé). Clic sur un slot équipé → déséquiper (envoi `EquipRequest` unequip).
+  Clic droit / bouton « Équiper » sur un objet d'inventaire équipable → envoi
+  `EquipRequest` equip. (Le drag complet = SP-C.)
+- **Envoi réseau** : ajouter l'émission `EquipRequest` via le client gameplay
+  (là où `PickupRequest` est émis).
+
+## 8. Tests
+
+- `ItemCatalog` : parse JSON valide (6 items), Find hit/miss, item malformé ignoré.
+- Logique equip/unequip (extraire en fonction pure testable serveur) : équiper
+  déplace l'unité, remplace un slot occupé (rend l'ancien), déséquiper rend
+  l'objet ; rejet si non possédé / non équipable / slot None.
+- `StatBonus` : somme des bonus de plusieurs slots ; `ComputeStats` additionne
+  correctement (ex. hp de base + bonus).
+- `ToVisualSlot` : 7 slots → EquipVisualSlot correspondant, 3 accessoires → Count.
+
+## 9. Découpage en PRs (server-first)
+
+1. **PR1 (shared+serveur, ⚠️ wire-breaking)** : `ItemDefinition`/`ItemCatalog` +
+   `items.json` + état équipement `ConnectedClient` + logique equip/unequip +
+   bonus dans `ComputeStats` + migration DB + persistance KV + opcodes
+   `EquipRequest`/`EquipmentUpdate` + bump protocole 14→15 + tests serveur.
+   *(déployé seul, le client ancien ignore les nouveaux opcodes ; à mettre en
+   lock-step avec PR2)*
+2. **PR2 (client)** : `ItemCatalog` client + infobulle enrichie + `UIModel.equipment`
+   + décodage `EquipmentUpdate` + panneau Équipement (F1) + émission `EquipRequest`.
+
+Merge **lock-step** : master + shardd (PR1) et client (PR2) déployés ensemble
+(protocole 15). Un client 14 ne peut pas parler à un serveur 15.
+
+## Déploiement
+
+⚠️ **REDÉPLOIEMENT SERVEUR REQUIS (master + shardd) en lock-step avec le client** :
+nouveaux opcodes `EquipRequest`/`EquipmentUpdate`, bump `kProtocolVersion` 14→15,
+migration DB `0002_character_equipment.sql`, nouveau handler shard. Un client neuf
+ne peut pas parler à un serveur ancien (et inversement).

--- a/game/data/items/items.json
+++ b/game/data/items/items.json
@@ -1,0 +1,59 @@
+{
+  "_comment": "Catalogue d'objets — Chantier 2 SP-A. Le serveur (shardd) est autoritaire : slot et bonus proviennent TOUJOURS de ce fichier, jamais du client. Ids >= 2000 pour l'equipement de depart (ne pas collisionner avec les objets de quete existants). L'ordre des slots est fige (cf. ItemDefinition.h).",
+  "items": [
+    {
+      "id": 2001,
+      "name": "Heaume de fer",
+      "description": "Un casque de fer simple mais solide.",
+      "icon": "items/heaume_fer.png",
+      "type": "armor",
+      "slot": "head",
+      "bonus": { "hp": 15, "perception": 2 }
+    },
+    {
+      "id": 2002,
+      "name": "Plastron de cuir",
+      "description": "Un plastron de cuir bouilli, leger et souple.",
+      "icon": "items/plastron_cuir.png",
+      "type": "armor",
+      "slot": "chest",
+      "bonus": { "hp": 30, "stamina": 5 }
+    },
+    {
+      "id": 2003,
+      "name": "Bottes de marche",
+      "description": "De bonnes bottes pour arpenter les chemins.",
+      "icon": "items/bottes_marche.png",
+      "type": "armor",
+      "slot": "feet",
+      "bonus": { "hp": 8, "speedWalk": 0.2, "speedRun": 0.3 }
+    },
+    {
+      "id": 2004,
+      "name": "Epee courte",
+      "description": "Une lame courte, fiable au corps a corps.",
+      "icon": "items/epee_courte.png",
+      "type": "weapon",
+      "slot": "mainhand",
+      "bonus": { "damage": 12, "accuracy": 3, "critRate": 0.02 }
+    },
+    {
+      "id": 2005,
+      "name": "Bouclier rond",
+      "description": "Un bouclier de bois cercle de fer.",
+      "icon": "items/bouclier_rond.png",
+      "type": "armor",
+      "slot": "offhand",
+      "bonus": { "hp": 20 }
+    },
+    {
+      "id": 2006,
+      "name": "Anneau de vigueur",
+      "description": "Un anneau grave de runes revigorantes.",
+      "icon": "items/anneau_vigueur.png",
+      "type": "accessory",
+      "slot": "ring1",
+      "bonus": { "hp": 10, "resource": 10, "stamina": 3 }
+    }
+  ]
+}

--- a/game/data/persistence/db/migrations/0002_characters_equipment.sql
+++ b/game/data/persistence/db/migrations/0002_characters_equipment.sql
@@ -1,0 +1,15 @@
+-- Chantier 2 SP-A — équipement porté par personnage.
+-- Note : le store de persistance runtime est aujourd'hui un fichier KV texte
+-- (CharacterPersistenceStore) ; l'équipement y est écrit via les clés plates
+-- equipment.<slot>.item_id. Ce fichier versionne le schéma cible (parité +
+-- future bascule vers un back-end SQL) et documente la table d'équipement.
+--
+-- slot = valeur de engine::items::EquipmentSlot (1..10 ; cf. ItemDefinition.h).
+-- L'ordre des slots est FIGÉ. item_id référence le catalogue game/data/items/items.json.
+CREATE TABLE IF NOT EXISTS character_equipment (
+    character_key INTEGER NOT NULL,
+    slot INTEGER NOT NULL,
+    item_id INTEGER NOT NULL,
+    PRIMARY KEY (character_key, slot),
+    FOREIGN KEY (character_key) REFERENCES characters(character_key)
+);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,6 +87,8 @@ if(WIN32)
     ${CMAKE_SOURCE_DIR}/src/shardd/world/LagCompensation.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/core/Clock.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/core/Config.cpp
+    # Chantier 2 SP-A — catalogue d'objets (server_app WIN32 ne linke pas engine_core).
+    ${CMAKE_SOURCE_DIR}/src/shared/items/ItemCatalog.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/core/ServerEndpoints.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/core/Log.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/core/LogConfig.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -698,6 +698,11 @@ elseif(UNIX)
   lcdlln_add_simple_test(config_loadfromstring_tests
     ${CMAKE_SOURCE_DIR}/src/shared/core/ConfigLoadFromStringTests.cpp)
 
+  # Chantier 2 SP-A — ItemCatalog : parsing items.json (type/slot/bonus) + Find.
+  # ItemCatalog.cpp est compilé dans engine_core (lié par le helper).
+  lcdlln_add_simple_test(item_catalog_tests
+    ${CMAKE_SOURCE_DIR}/src/shared/items/ItemCatalogTests.cpp)
+
   # Character system PR1 — CharacterStatsEngine : 11 stats déterministes depuis
   # les tables JSON embarquées. Bloc explicite (pas lcdlln_add_simple_test) :
   # le test a besoin du dossier des headers générés (${LCDLLN_GEN_DIR}) et de

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8325,6 +8325,18 @@ namespace engine
 				m_characterWindowImGui = std::make_unique<engine::render::CharacterWindowImGuiRenderer>();
 				m_characterWindowImGui->Bind(&m_cfg, &m_uiModelBinding, &m_invUi, &m_skillIconCache,
 					m_skillBookImGui.get(), m_grimoireImGui.get(), m_classSkillTreeImGui.get());
+				// Chantier 2 SP-A — catalogue d'objets client (noms/slots/bonus pour le
+				// panneau équipement + tooltips). Source d'affichage ; le serveur reste
+				// autoritaire. Non fatal : catalogue absent -> noms bruts (#itemId).
+				{
+					const std::string itemsText =
+						engine::platform::FileSystem::ReadAllTextContent(m_cfg, "items/items.json");
+					if (itemsText.empty() || !m_itemCatalog.LoadFromJson(itemsText))
+						LOG_WARN(Net, "[Engine] catalogue d'objets client indisponible (items/items.json)");
+					else
+						LOG_INFO(Net, "[Engine] catalogue d'objets client charge : {} objet(s)", m_itemCatalog.Count());
+					m_characterWindowImGui->SetItemCatalog(&m_itemCatalog);
+				}
 				// Task 4 — aperçu 3D : le conteneur affiche la texture offscreen du
 				// viewport perso (alimenté quand la fenêtre est ouverte, cf. Update).
 				m_characterWindowImGui->SetRaceViewport(&m_racePreviewViewport);
@@ -12712,6 +12724,20 @@ namespace engine
 			{
 				m_characterWindowImGui->SetViewportSize(static_cast<uint32_t>(dw), static_cast<uint32_t>(dh));
 				m_characterWindowImGui->Render(m_uiModelBinding.GetModel());
+				// Chantier 2 SP-A — draine l'intention equip/unequip signalée au clic et
+				// l'envoie au serveur (le renderer n'a pas accès au socket). Le serveur
+				// revalide possession + slot.
+				engine::render::CharacterWindowImGuiRenderer::PendingEquipAction equipAction;
+				if (m_characterWindowImGui->ConsumeEquipAction(equipAction))
+				{
+					const uint32_t equipClientId = m_gameplayUdp.ServerClientId();
+					if (equipAction.kind ==
+						engine::render::CharacterWindowImGuiRenderer::PendingEquipAction::Kind::Equip)
+						(void)m_gameplayUdp.SendEquipRequest(equipClientId, equipAction.itemId);
+					else if (equipAction.kind ==
+						engine::render::CharacterWindowImGuiRenderer::PendingEquipAction::Kind::Unequip)
+						(void)m_gameplayUdp.SendUnequipRequest(equipClientId, equipAction.slot);
+				}
 			}
 			// CMANGOS.21 (Phase 5.21 step 3+4) — Render du panneau Arena si
 			// visible. Le popup proposal s'affiche aussi quand pendingProposalId

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -31,6 +31,7 @@
 #include "src/client/economy/AuctionUi.h"
 #include "src/client/net/GameplayUdpClient.h"
 #include "src/client/inventory/InventoryUi.h"
+#include "src/shared/items/ItemCatalog.h"
 // Combat SP2 — présentateurs combat câblés (HUD cible/log + panneau avancé).
 #include "src/client/combat/CombatHud.h"
 #include "src/client/combat/AdvancedCombatUi.h"
@@ -1505,6 +1506,11 @@ namespace engine
 		engine::client::ShopUiPresenter m_shopUi{};
 		engine::client::AuctionUiPresenter m_auctionUi{};
 		engine::client::InventoryUiPresenter m_invUi{};
+		/// Chantier 2 SP-A — catalogue d'objets client (noms/slots/bonus pour la
+		/// fenêtre Personnage : panneau équipement + tooltips). Chargé au boot depuis
+		/// game/data/items/items.json ; source d'AFFICHAGE seulement (le serveur reste
+		/// autoritaire sur slot/bonus).
+		engine::items::ItemCatalog m_itemCatalog{};
 		// ---------------------------------------------------------------------
 		// Combat SP2 — binds combat (embryon du registre central, Lot E) :
 		//   clic gauche = sélection de cible (pick écran-espace sur les mobs)

--- a/src/client/net/GameplayUdpClient.cpp
+++ b/src/client/net/GameplayUdpClient.cpp
@@ -449,6 +449,44 @@ namespace engine::client
 		return ok;
 	}
 
+	bool GameplayUdpClient::SendEquipRequest(uint32_t clientId, uint32_t itemId)
+	{
+		engine::server::EquipRequestMessage msg{};
+		msg.clientId = clientId;
+		msg.itemId = itemId;
+		const bool ok = SendBytes(engine::server::EncodeEquipRequest(msg));
+		if (ok)
+		{
+			LOG_INFO(Net, "[GameplayUdpClient] EquipRequest sent (client_id={}, item_id={})",
+				clientId, itemId);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] EquipRequest FAILED (client_id={}, item_id={})",
+				clientId, itemId);
+		}
+		return ok;
+	}
+
+	bool GameplayUdpClient::SendUnequipRequest(uint32_t clientId, uint8_t slot)
+	{
+		engine::server::UnequipRequestMessage msg{};
+		msg.clientId = clientId;
+		msg.slot = slot;
+		const bool ok = SendBytes(engine::server::EncodeUnequipRequest(msg));
+		if (ok)
+		{
+			LOG_INFO(Net, "[GameplayUdpClient] UnequipRequest sent (client_id={}, slot={})",
+				clientId, slot);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] UnequipRequest FAILED (client_id={}, slot={})",
+				clientId, slot);
+		}
+		return ok;
+	}
+
 	bool GameplayUdpClient::SendHarvestRequest(uint32_t clientId, uint64_t nodeEntityId)
 	{
 		engine::server::HarvestRequestMessage msg{};

--- a/src/client/net/GameplayUdpClient.h
+++ b/src/client/net/GameplayUdpClient.h
@@ -93,6 +93,14 @@ namespace engine::client
 		/// proximité et propriété, puis pousse l'InventoryDelta).
 		bool SendPickupRequest(uint32_t clientId, uint64_t lootBagEntityId);
 
+		/// Chantier 2 SP-A — demande d'équipement d'un objet du sac (le serveur
+		/// détermine le slot depuis son catalogue, puis pousse EquipmentUpdate +
+		/// InventoryDelta + PlayerStats).
+		bool SendEquipRequest(uint32_t clientId, uint32_t itemId);
+
+		/// Chantier 2 SP-A — demande de retrait de l'objet d'un slot (1..10).
+		bool SendUnequipRequest(uint32_t clientId, uint8_t slot);
+
 		/// Métiers SP1 — démarre une récolte sur un node répliqué (M36.1, le
 		/// serveur valide disponibilité/portée/session unique).
 		bool SendHarvestRequest(uint32_t clientId, uint64_t nodeEntityId);

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -9,6 +9,7 @@
 #include "src/client/ui_common/CurrencyFormat.h"
 #include "src/client/inventory/InventoryUi.h"
 #include "src/shared/core/Config.h"
+#include "src/shared/items/ItemCatalog.h"
 
 #if defined(_WIN32)
 #	include "imgui.h"
@@ -19,6 +20,29 @@
 
 namespace engine::render
 {
+	namespace
+	{
+		// Chantier 2 SP-A — libellé français d'un slot d'équipement (l'enum ToString
+		// renvoie des tokens anglais réservés au wire/JSON).
+		const char* SlotLabelFr(engine::items::EquipmentSlot slot)
+		{
+			switch (slot)
+			{
+			case engine::items::EquipmentSlot::Head:     return "Tete";
+			case engine::items::EquipmentSlot::Chest:    return "Torse";
+			case engine::items::EquipmentSlot::Legs:     return "Jambes";
+			case engine::items::EquipmentSlot::Feet:     return "Pieds";
+			case engine::items::EquipmentSlot::Hands:    return "Mains";
+			case engine::items::EquipmentSlot::MainHand: return "Main droite";
+			case engine::items::EquipmentSlot::OffHand:  return "Main gauche";
+			case engine::items::EquipmentSlot::Amulet:   return "Amulette";
+			case engine::items::EquipmentSlot::Ring1:    return "Anneau 1";
+			case engine::items::EquipmentSlot::Ring2:    return "Anneau 2";
+			default:                                     return "?";
+			}
+		}
+	}
+
 	void CharacterWindowImGuiRenderer::Bind(const engine::core::Config* cfg,
 		const engine::client::UIModelBinding* uiBinding,
 		const engine::client::InventoryUiPresenter* inv,
@@ -119,14 +143,17 @@ namespace engine::render
 			// Hauteur réservée au bloc caractéristiques (titre + séparateur + 4 lignes).
 			const float lineH = ImGui::GetTextLineHeightWithSpacing();
 			const float statsH = lineH * 6.0f + 16.0f;
+			// Chantier 2 SP-A — hauteur réservée au panneau équipement (titre + séparateur
+			// + 5 rangées de 2 slots).
+			const float equipH = lineH * 7.0f + 8.0f;
 			// Aperçu CARRÉ (texture 512x512) agrandi pour remplir la colonne : borné par
-			// la largeur ET par la hauteur restante une fois les stats retirées.
-			float side = std::min(avail.x, avail.y - statsH);
+			// la largeur ET par la hauteur restante une fois équipement + stats retirés.
+			float side = std::min(avail.x, avail.y - statsH - equipH);
 			side = std::max(side, 140.0f);
 			const float offX = (avail.x - side) * 0.5f;
 			// Centrage vertical du bloc (aperçu + stats) : répartit l'espace résiduel
 			// en haut/bas au lieu de le laisser béant sous les stats.
-			const float blockH = side + statsH;
+			const float blockH = side + equipH + statsH;
 			const float padTop = std::max(0.0f, (avail.y - blockH) * 0.5f);
 			if (padTop > 0.0f)
 				ImGui::Dummy(ImVec2(1.0f, padTop));
@@ -158,8 +185,61 @@ namespace engine::render
 			}
 
 			ImGui::Spacing();
-			ImGui::TextDisabled("Equipement — Chantier 2");
+			ImGui::TextDisabled("Equipement");
 			ImGui::Separator();
+
+			// Chantier 2 SP-A — grille des 10 slots (2 colonnes × 5 rangées). Slot occupé
+			// => nom de l'objet porté + clic pour déséquiper (renvoi au sac). Le serveur
+			// est autoritaire : le clic n'émet qu'une intention, drainée par Engine.
+			{
+				// Table slot(1..10) -> itemId porté, depuis le snapshot EquipmentUpdate.
+				uint32_t worn[engine::items::kEquipSlotCount + 1] = {};
+				for (const engine::server::EquipmentEntry& e : model.equipment)
+				{
+					if (e.slot >= 1u && e.slot <= engine::items::kEquipSlotCount)
+						worn[e.slot] = e.itemId;
+				}
+				const float colW = ImGui::GetContentRegionAvail().x * 0.5f - 2.0f;
+				for (std::size_t slot = 1; slot <= engine::items::kEquipSlotCount; ++slot)
+				{
+					const engine::items::EquipmentSlot es = static_cast<engine::items::EquipmentSlot>(slot);
+					const uint32_t itemId = worn[slot];
+					std::string itemName;
+					bool occupied = false;
+					if (itemId != 0u)
+					{
+						occupied = true;
+						if (m_itemCatalog != nullptr)
+						{
+							if (const engine::items::ItemDefinition* def = m_itemCatalog->Find(itemId))
+								itemName = def->name;
+						}
+						if (itemName.empty())
+							itemName = "#" + std::to_string(itemId);
+					}
+					char label[96];
+					std::snprintf(label, sizeof(label), "%s: %s##eqslot%zu",
+						SlotLabelFr(es), occupied ? itemName.c_str() : "-", slot);
+					ImGui::Selectable(label, false, 0, ImVec2(colW, 0.0f));
+					if (occupied && ImGui::IsItemHovered())
+					{
+						ImGui::BeginTooltip();
+						ImGui::TextUnformatted(itemName.c_str());
+						ImGui::TextDisabled("Emplacement : %s", SlotLabelFr(es));
+						ImGui::Separator();
+						ImGui::TextDisabled("Clic : déséquiper");
+						ImGui::EndTooltip();
+					}
+					if (occupied && ImGui::IsItemClicked(ImGuiMouseButton_Left))
+					{
+						m_pendingEquip = PendingEquipAction{
+							PendingEquipAction::Kind::Unequip, 0u, static_cast<uint8_t>(slot)};
+					}
+					// 2 colonnes : slot impair à gauche, pair sur la même ligne à droite.
+					if ((slot % 2u) == 1u && slot != engine::items::kEquipSlotCount)
+						ImGui::SameLine(0.0f, 4.0f);
+				}
+			}
 
 			// Caractéristiques compactes (ex-fiche F1).
 			const engine::client::UIPlayerStats& ps = model.playerStats;
@@ -241,11 +321,47 @@ namespace engine::render
 						const ImVec2 qs = ImGui::CalcTextSize(q);
 						wdl->AddText(ImVec2(mx.x - qs.x - 3, mx.y - qs.y - 2), IM_COL32(255, 240, 190, 255), q);
 					}
+					// Chantier 2 SP-A — objet équipable ? (catalogue client, source d'affichage).
+					const engine::items::ItemDefinition* def =
+						(m_itemCatalog != nullptr) ? m_itemCatalog->Find(s.itemId) : nullptr;
+					const bool equippable = (def != nullptr) && def->IsEquippable();
 					if (ImGui::IsMouseHoveringRect(mn, mx) && !s.label.empty())
 					{
 						ImGui::BeginTooltip();
 						ImGui::TextUnformatted(s.label.c_str());
+						if (def != nullptr)
+						{
+							if (equippable)
+								ImGui::TextDisabled("Emplacement : %s", SlotLabelFr(def->slot));
+							const engine::items::StatBonus& b = def->bonus;
+							if (b.hp)          ImGui::Text("PV +%d", b.hp);
+							if (b.resource)    ImGui::Text("Ressource +%d", b.resource);
+							if (b.damage)      ImGui::Text("Degats +%d", b.damage);
+							if (b.accuracy)    ImGui::Text("Precision +%d", b.accuracy);
+							if (b.range != 0.0f)       ImGui::Text("Portee +%.1f m", b.range);
+							if (b.critRate != 0.0f)    ImGui::Text("Crit +%.1f%%", b.critRate);
+							if (b.critMult != 0.0f)    ImGui::Text("Mult. crit +%.2f", b.critMult);
+							if (b.speedWalk != 0.0f)   ImGui::Text("Vitesse marche +%.2f", b.speedWalk);
+							if (b.speedRun != 0.0f)    ImGui::Text("Vitesse course +%.2f", b.speedRun);
+							if (b.speedSprint != 0.0f) ImGui::Text("Vitesse sprint +%.2f", b.speedSprint);
+							if (b.stamina)     ImGui::Text("Endurance +%d", b.stamina);
+							if (b.perception)  ImGui::Text("Perception +%d", b.perception);
+							if (b.stealth)     ImGui::Text("Discretion +%d", b.stealth);
+							if (equippable)
+							{
+								ImGui::Separator();
+								ImGui::TextDisabled("Clic : equiper");
+							}
+						}
 						ImGui::EndTooltip();
+					}
+					// Clic gauche sur un objet équipable => intention d'équipement (drainée
+					// par Engine). Le serveur revalide (possession + slot).
+					if (equippable && ImGui::IsMouseHoveringRect(mn, mx)
+						&& ImGui::IsMouseClicked(ImGuiMouseButton_Left))
+					{
+						m_pendingEquip = PendingEquipAction{
+							PendingEquipAction::Kind::Equip, s.itemId, 0u};
 					}
 				}
 				// Réserve toute la zone grille pour pousser la bourse en bas.

--- a/src/client/render/CharacterWindowImGuiRenderer.h
+++ b/src/client/render/CharacterWindowImGuiRenderer.h
@@ -10,6 +10,7 @@ namespace engine::core { class Config; }
 namespace engine::client { class UIModelBinding; class InventoryUiPresenter; class SkillIconCache; struct UIModel; }
 namespace engine::render { class SkillBookImGuiRenderer; class GrimoireImGuiRenderer; class ClassSkillTreeImGuiRenderer; }
 namespace engine::render::race { class RacePreviewViewport; }
+namespace engine::items { class ItemCatalog; }
 
 namespace engine::render
 {
@@ -27,6 +28,28 @@ namespace engine::render
 			engine::render::SkillBookImGuiRenderer* skillBook,
 			engine::render::GrimoireImGuiRenderer* grimoire,
 			engine::render::ClassSkillTreeImGuiRenderer* classTree);
+
+		/// Chantier 2 SP-A — catalogue d'objets client (résolution itemId → nom/slot/
+		/// bonus pour le panneau équipement et les tooltips enrichis). Nul -> noms bruts.
+		void SetItemCatalog(const engine::items::ItemCatalog* catalog) { m_itemCatalog = catalog; }
+
+		/// Chantier 2 SP-A — action d'équipement demandée par l'utilisateur au clic,
+		/// drainée par Engine après Render() pour l'envoyer au serveur (le renderer
+		/// n'a pas accès au socket).
+		struct PendingEquipAction
+		{
+			enum class Kind { None, Equip, Unequip } kind = Kind::None;
+			uint32_t itemId = 0; ///< pour Equip (objet du sac cliqué)
+			uint8_t slot = 0;    ///< pour Unequip (slot cliqué, 1..10)
+		};
+		/// Récupère et efface l'action en attente. Retourne false si aucune.
+		bool ConsumeEquipAction(PendingEquipAction& out)
+		{
+			if (m_pendingEquip.kind == PendingEquipAction::Kind::None) return false;
+			out = m_pendingEquip;
+			m_pendingEquip = PendingEquipAction{};
+			return true;
+		}
 
 		/// Viewport 3D du perso (optionnel ; Task 4). Nul -> placeholder dessiné.
 		void SetRaceViewport(engine::render::race::RacePreviewViewport* vp) { m_raceViewport = vp; }
@@ -53,6 +76,8 @@ namespace engine::render
 		const engine::core::Config* m_cfg = nullptr;
 		const engine::client::UIModelBinding* m_uiBinding = nullptr;
 		const engine::client::InventoryUiPresenter* m_inv = nullptr;
+		const engine::items::ItemCatalog* m_itemCatalog = nullptr; ///< Chantier 2 SP-A
+		PendingEquipAction m_pendingEquip{};                       ///< Chantier 2 SP-A
 		engine::client::SkillIconCache* m_icons = nullptr;
 		engine::render::SkillBookImGuiRenderer* m_skillBook = nullptr;
 		engine::render::GrimoireImGuiRenderer* m_grimoire = nullptr;

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -567,6 +567,8 @@ namespace engine::client
 			return ApplyZoneChange(packet);
 		case engine::server::MessageKind::InventoryDelta:
 			return ApplyInventoryDelta(packet);
+		case engine::server::MessageKind::EquipmentUpdate:
+			return ApplyEquipmentUpdate(packet);
 		case engine::server::MessageKind::QuestDelta:
 			return ApplyQuestDelta(packet);
 		case engine::server::MessageKind::QuestGiverList:
@@ -1285,6 +1287,22 @@ namespace engine::client
 		LOG_INFO(Net, "[UIModelBinding] InventoryDelta applied (client_id={}, items={})",
 			m_inventoryMessage.clientId,
 			m_model.inventory.size());
+		return true;
+	}
+
+	bool UIModelBinding::ApplyEquipmentUpdate(std::span<const std::byte> packet)
+	{
+		if (!engine::server::DecodeEquipmentUpdate(packet, m_equipmentMessage, m_equipmentScratch))
+		{
+			LOG_WARN(Net, "[UIModelBinding] EquipmentUpdate FAILED: decode error");
+			return false;
+		}
+
+		m_model.equipment = m_equipmentScratch;
+		NotifyObservers(UIModelChangeEquipment);
+		LOG_INFO(Net, "[UIModelBinding] EquipmentUpdate applied (client_id={}, worn={})",
+			m_equipmentMessage.clientId,
+			m_model.equipment.size());
 		return true;
 	}
 

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -44,7 +44,9 @@ namespace engine::client
 		/// M36.1 — harvest cast bar progress (start, fill, cancel/complete).
 		UIModelChangeHarvest   = 1u << 14,
 		/// M36.2 — crafting panel state (professions, recipe list, cast bar).
-		UIModelChangeCrafting  = 1u << 15
+		UIModelChangeCrafting  = 1u << 15,
+		/// Chantier 2 SP-A — équipement porté (snapshot EquipmentUpdate).
+		UIModelChangeEquipment = 1u << 16
 	};
 
 	/// M35.2 — one vendor offer row mirrored from \ref engine::server::ShopOfferWire.
@@ -442,6 +444,10 @@ namespace engine::client
 		UIPlayerStats playerStats{};
 		UITargetStats targetStats{};
 		std::vector<engine::server::ItemStack> inventory;
+		/// Chantier 2 SP-A — équipement porté (slots occupés uniquement, miroir du
+		/// wire EquipmentUpdate). slot = valeur d'EquipmentSlot (1..10), itemId résolu
+		/// via le catalogue client pour l'affichage.
+		std::vector<engine::server::EquipmentEntry> equipment;
 		std::vector<UIQuestEntry> quests;
 		/// SP2 — liste de quêtes offer/turn-in du PNJ ciblé (Talk), voir \ref UIQuestGiverList.
 		UIQuestGiverList giverList;
@@ -651,6 +657,10 @@ namespace engine::client
 		/// Apply one decoded inventory delta to the inventory section of the UI model.
 		bool ApplyInventoryDelta(std::span<const std::byte> packet);
 
+		/// Chantier 2 SP-A — applique un snapshot d'équipement (EquipmentUpdate) à la
+		/// section équipement du modèle (remplacement complet, idempotent).
+		bool ApplyEquipmentUpdate(std::span<const std::byte> packet);
+
 		/// Apply one decoded quest delta to the quest section of the UI model.
 		bool ApplyQuestDelta(std::span<const std::byte> packet);
 
@@ -755,6 +765,9 @@ namespace engine::client
 		engine::server::LootNotifyMessage m_lootNotifyMessage{};
 		engine::server::ZoneChangeMessage m_zoneChangeMessage{};
 		engine::server::InventoryDeltaMessage m_inventoryMessage{};
+		/// Chantier 2 SP-A — scratch du snapshot d'équipement (réutilisé par paquet).
+		engine::server::EquipmentUpdateMessage m_equipmentMessage{};
+		std::vector<engine::server::EquipmentEntry> m_equipmentScratch;
 		engine::server::QuestDeltaMessage m_questMessage{};
 		/// SP2 — scratch du message QuestGiverList (réutilisé par paquet).
 		engine::server::QuestGiverListMessage m_questGiverListMessage{};

--- a/src/shardd/gameplay/character/CharacterPersistence.cpp
+++ b/src/shardd/gameplay/character/CharacterPersistence.cpp
@@ -137,6 +137,15 @@ namespace engine::server
 			outState.inventory.push_back(item);
 		}
 
+		// Chantier 2 SP-A — équipement porté : clé plate equipment.<slot>.item_id.
+		// Slots absents => 0 (rien d'équipé). Robuste aux fichiers legacy (pré-SP-A).
+		outState.equipment.fill(0u);
+		for (std::size_t slot = 1; slot < outState.equipment.size(); ++slot)
+		{
+			outState.equipment[slot] = static_cast<uint32_t>(
+				persisted.GetInt("equipment." + std::to_string(slot) + ".item_id", 0));
+		}
+
 		const uint32_t questCount = static_cast<uint32_t>(persisted.GetInt("quests.count", 0));
 		for (uint32_t questIndex = 0; questIndex < questCount; ++questIndex)
 		{
@@ -282,6 +291,14 @@ namespace engine::server
 		{
 			output << "inventory." << index << ".item_id=" << state.inventory[index].itemId << "\n";
 			output << "inventory." << index << ".quantity=" << state.inventory[index].quantity << "\n";
+		}
+		// Chantier 2 SP-A — équipement porté (n'écrit que les slots occupés).
+		for (std::size_t slot = 1; slot < state.equipment.size(); ++slot)
+		{
+			if (state.equipment[slot] != 0u)
+			{
+				output << "equipment." << slot << ".item_id=" << state.equipment[slot] << "\n";
+			}
 		}
 		// SP1 — format_version=1 : quests.*.status écrit l'enum QuestStatus direct (0..4).
 		// EXT-2 — format_version=2 : ajoute quests.<i>.completed_at (ms UTC de la dernière

--- a/src/shardd/gameplay/character/CharacterPersistence.h
+++ b/src/shardd/gameplay/character/CharacterPersistence.h
@@ -4,6 +4,7 @@
 #include "src/shardd/gameplay/crafting/CraftingSystem.h"
 #include "src/shardd/gameplay/quest/QuestRuntime.h"
 #include "src/shared/network/ReplicationTypes.h"
+#include "src/shared/items/ItemDefinition.h"
 
 #include <array>
 #include <cstdint>
@@ -32,6 +33,9 @@ namespace engine::server
 		uint32_t premiumCurrency = 0;
 		StatsComponent stats{};
 		std::vector<ItemStack> inventory;
+		/// Chantier 2 SP-A — équipement porté (indexé par la valeur de
+		/// engine::items::EquipmentSlot, 1..kEquipSlotCount ; index 0 inutilisé).
+		std::array<uint32_t, engine::items::kEquipSlotCount + 1> equipment{};
 		std::vector<QuestState> questStates;
 		/// M29.2: persisted `/ignore` targets (display names, e.g. P12).
 		std::vector<std::string> chatIgnoredDisplayNames;

--- a/src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp
+++ b/src/shardd/gameplay/character/CharacterPersistenceQuestCompatTests.cpp
@@ -174,6 +174,57 @@ int main()
               "EXT-2 format_version=2 écrit");
     }
 
+    // Chantier 2 SP-A — round-trip de l'équipement porté : les slots occupés
+    // survivent à Save/Load ; les slots vides restent à 0.
+    {
+        engine::core::Config config = MakeConfigWithSchema();
+        CharacterPersistenceStore store(config);
+        Check(store.Init(), "SP-A store Init OK (équipement)");
+
+        PersistedCharacterState saved{};
+        saved.characterKey = 555ULL;
+        saved.equipment[1] = 2001u; // Head
+        saved.equipment[2] = 2002u; // Chest
+        saved.equipment[6] = 2004u; // MainHand
+        Check(store.SaveCharacter(saved), "SP-A SaveCharacter (équipement) OK");
+
+        PersistedCharacterState loaded{};
+        Check(store.LoadCharacter(saved.characterKey, loaded), "SP-A LoadCharacter (équipement) OK");
+        Check(loaded.equipment[1] == 2001u, "SP-A slot Head round-trip");
+        Check(loaded.equipment[2] == 2002u, "SP-A slot Chest round-trip");
+        Check(loaded.equipment[6] == 2004u, "SP-A slot MainHand round-trip");
+        Check(loaded.equipment[3] == 0u, "SP-A slot vide reste 0");
+        Check(loaded.equipment[0] == 0u, "SP-A slot 0 (None) inutilisé");
+    }
+
+    // Chantier 2 SP-A — compat legacy : un fichier sans clés equipment.* charge
+    // avec tous les slots à 0 (pas de régression pour les persos pré-SP-A).
+    {
+        engine::core::Config config = MakeConfigWithSchema();
+        CharacterPersistenceStore store(config);
+        Check(store.Init(), "SP-A store Init OK (legacy sans équipement)");
+
+        const uint64_t key = 556ULL;
+        const std::string rel =
+            "persistence/characters/character_" + std::to_string(key) + ".ini";
+        const std::string legacyBlob =
+            "character.zone_id=1\n"
+            "inventory.count=0\n"
+            "quests.format_version=2\n"
+            "quests.count=0\n";
+        Check(engine::platform::FileSystem::WriteAllTextContent(config, rel, legacyBlob),
+              "SP-A écriture blob legacy");
+
+        PersistedCharacterState loaded{};
+        Check(store.LoadCharacter(key, loaded), "SP-A LoadCharacter legacy OK");
+        bool allZero = true;
+        for (std::size_t s = 0; s < loaded.equipment.size(); ++s)
+        {
+            if (loaded.equipment[s] != 0u) { allZero = false; break; }
+        }
+        Check(allZero, "SP-A legacy → équipement tout à 0");
+    }
+
     if (g_failures) { std::cerr << g_failures << " échec(s)\n"; return 1; }
     std::cout << "OK\n";
     return 0;

--- a/src/shared/items/ItemCatalog.cpp
+++ b/src/shared/items/ItemCatalog.cpp
@@ -1,0 +1,158 @@
+#include "src/shared/items/ItemCatalog.h"
+
+#include "src/shared/core/Config.h"
+
+#include <algorithm>
+#include <cctype>
+#include <format>
+#include <fstream>
+#include <sstream>
+
+namespace engine::items
+{
+	namespace
+	{
+		// Minuscules ASCII (comparaison de tokens de type/slot insensible à la casse).
+		std::string ToLowerAscii(std::string s)
+		{
+			std::transform(s.begin(), s.end(), s.begin(),
+				[](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+			return s;
+		}
+
+		// Lit le bloc "bonus" d'un objet (préfixe = "items[i].bonus"). Chaque champ
+		// est optionnel ; absent => 0. Les floats passent par GetDouble.
+		StatBonus ReadBonus(const engine::core::Config& cfg, const std::string& p)
+		{
+			StatBonus b;
+			b.hp          = static_cast<std::int32_t>(cfg.GetInt(p + ".hp", 0));
+			b.resource    = static_cast<std::int32_t>(cfg.GetInt(p + ".resource", 0));
+			b.damage      = static_cast<std::int32_t>(cfg.GetInt(p + ".damage", 0));
+			b.accuracy    = static_cast<std::int32_t>(cfg.GetInt(p + ".accuracy", 0));
+			b.range       = static_cast<float>(cfg.GetDouble(p + ".range", 0.0));
+			b.critRate    = static_cast<float>(cfg.GetDouble(p + ".critRate", 0.0));
+			b.critMult    = static_cast<float>(cfg.GetDouble(p + ".critMult", 0.0));
+			b.speedWalk   = static_cast<float>(cfg.GetDouble(p + ".speedWalk", 0.0));
+			b.speedRun    = static_cast<float>(cfg.GetDouble(p + ".speedRun", 0.0));
+			b.speedSprint = static_cast<float>(cfg.GetDouble(p + ".speedSprint", 0.0));
+			b.stamina     = static_cast<std::int32_t>(cfg.GetInt(p + ".stamina", 0));
+			b.perception  = static_cast<std::int32_t>(cfg.GetInt(p + ".perception", 0));
+			b.stealth     = static_cast<std::int32_t>(cfg.GetInt(p + ".stealth", 0));
+			return b;
+		}
+	}
+
+	bool ItemCatalog::LoadFromJson(const std::string& jsonText)
+	{
+		engine::core::Config cfg;
+		if (!cfg.LoadFromString(jsonText))
+			return false;
+
+		// Config aplatit les tableaux JSON en notation crochets : items[0].id, etc.
+		// On itère tant que "items[i].id" existe.
+		for (std::size_t i = 0;; ++i)
+		{
+			const std::string p = std::format("items[{}]", i);
+			if (!cfg.Has(p + ".id"))
+				break;
+
+			ItemDefinition def;
+			def.id          = static_cast<std::uint32_t>(cfg.GetInt(p + ".id", 0));
+			if (def.id == 0)
+				continue; // id 0 réservé (= vide) : on ignore l'entrée invalide.
+			def.name        = cfg.GetString(p + ".name", "");
+			def.description = cfg.GetString(p + ".description", "");
+			def.iconPath    = cfg.GetString(p + ".icon", "");
+			def.type        = ItemTypeFromString(ToLowerAscii(cfg.GetString(p + ".type", "misc")));
+			def.slot        = EquipmentSlotFromString(ToLowerAscii(cfg.GetString(p + ".slot", "none")));
+			def.visualMesh  = cfg.GetString(p + ".visualMesh", "");
+			if (cfg.Has(p + ".bonus.hp") || cfg.Has(p + ".bonus.damage") ||
+				cfg.Has(p + ".bonus.resource") || cfg.Has(p + ".bonus.accuracy") ||
+				cfg.Has(p + ".bonus.range") || cfg.Has(p + ".bonus.critRate") ||
+				cfg.Has(p + ".bonus.critMult") || cfg.Has(p + ".bonus.speedWalk") ||
+				cfg.Has(p + ".bonus.speedRun") || cfg.Has(p + ".bonus.speedSprint") ||
+				cfg.Has(p + ".bonus.stamina") || cfg.Has(p + ".bonus.perception") ||
+				cfg.Has(p + ".bonus.stealth"))
+			{
+				def.bonus = ReadBonus(cfg, p + ".bonus");
+			}
+
+			m_byId[def.id] = std::move(def);
+		}
+		return true;
+	}
+
+	bool ItemCatalog::LoadFromFile(const std::string& filePath)
+	{
+		std::ifstream in(filePath, std::ios::binary);
+		if (!in)
+			return false;
+		std::ostringstream ss;
+		ss << in.rdbuf();
+		return LoadFromJson(ss.str());
+	}
+
+	const ItemDefinition* ItemCatalog::Find(std::uint32_t id) const
+	{
+		const auto it = m_byId.find(id);
+		return it == m_byId.end() ? nullptr : &it->second;
+	}
+
+	// ---- Conversions chaîne <-> enum (déclarées dans ItemDefinition.h) ----
+
+	EquipmentSlot EquipmentSlotFromString(const std::string& s)
+	{
+		if (s == "head")     return EquipmentSlot::Head;
+		if (s == "chest")    return EquipmentSlot::Chest;
+		if (s == "legs")     return EquipmentSlot::Legs;
+		if (s == "feet")     return EquipmentSlot::Feet;
+		if (s == "hands")    return EquipmentSlot::Hands;
+		if (s == "mainhand") return EquipmentSlot::MainHand;
+		if (s == "offhand")  return EquipmentSlot::OffHand;
+		if (s == "amulet")   return EquipmentSlot::Amulet;
+		if (s == "ring1")    return EquipmentSlot::Ring1;
+		if (s == "ring2")    return EquipmentSlot::Ring2;
+		return EquipmentSlot::None;
+	}
+
+	ItemType ItemTypeFromString(const std::string& s)
+	{
+		if (s == "weapon")     return ItemType::Weapon;
+		if (s == "armor")      return ItemType::Armor;
+		if (s == "accessory")  return ItemType::Accessory;
+		if (s == "consumable") return ItemType::Consumable;
+		if (s == "quest")      return ItemType::Quest;
+		return ItemType::Misc;
+	}
+
+	const char* ToString(EquipmentSlot slot)
+	{
+		switch (slot)
+		{
+		case EquipmentSlot::Head:     return "head";
+		case EquipmentSlot::Chest:    return "chest";
+		case EquipmentSlot::Legs:     return "legs";
+		case EquipmentSlot::Feet:     return "feet";
+		case EquipmentSlot::Hands:    return "hands";
+		case EquipmentSlot::MainHand: return "mainhand";
+		case EquipmentSlot::OffHand:  return "offhand";
+		case EquipmentSlot::Amulet:   return "amulet";
+		case EquipmentSlot::Ring1:    return "ring1";
+		case EquipmentSlot::Ring2:    return "ring2";
+		default:                      return "none";
+		}
+	}
+
+	const char* ToString(ItemType type)
+	{
+		switch (type)
+		{
+		case ItemType::Weapon:     return "weapon";
+		case ItemType::Armor:      return "armor";
+		case ItemType::Accessory:  return "accessory";
+		case ItemType::Consumable: return "consumable";
+		case ItemType::Quest:      return "quest";
+		default:                   return "misc";
+		}
+	}
+}

--- a/src/shared/items/ItemCatalog.h
+++ b/src/shared/items/ItemCatalog.h
@@ -1,0 +1,44 @@
+#pragma once
+
+// Catalogue d'objets chargé depuis game/data/items/items.json (Chantier 2 SP-A).
+// Partagé client/serveur : le CLIENT s'en sert pour l'affichage (icônes, tooltips,
+// noms) ; le SERVEUR (shardd) s'en sert comme SOURCE AUTORITAIRE (slot + bonus
+// réels d'un objet équipé — jamais les valeurs envoyées par le client).
+//
+// Parsing : réutilise engine::core::Config (aplatit le JSON en clés pointées,
+// ex. "items.0.id"). Pas de dépendance JSON supplémentaire.
+
+#include "src/shared/items/ItemDefinition.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace engine::items
+{
+	class ItemCatalog
+	{
+	public:
+		// Charge/fusionne les définitions depuis un texte JSON (schéma cf. items.json).
+		// Retourne false si le JSON est illisible ; les entrées valides déjà chargées
+		// sont conservées. Un id dupliqué écrase la définition précédente (dernier gagne).
+		bool LoadFromJson(const std::string& jsonText);
+
+		// Charge depuis un fichier disque (chemin résolu par l'appelant). Retourne
+		// false si le fichier est absent/illisible.
+		bool LoadFromFile(const std::string& filePath);
+
+		// Renvoie la définition d'un id, ou nullptr si absente.
+		const ItemDefinition* Find(std::uint32_t id) const;
+
+		// Nombre d'objets chargés.
+		std::size_t Count() const { return m_byId.size(); }
+
+		// Accès en lecture à toutes les définitions (ordre d'insertion non garanti).
+		const std::unordered_map<std::uint32_t, ItemDefinition>& All() const { return m_byId; }
+
+	private:
+		std::unordered_map<std::uint32_t, ItemDefinition> m_byId;
+	};
+}

--- a/src/shared/items/ItemCatalogTests.cpp
+++ b/src/shared/items/ItemCatalogTests.cpp
@@ -1,0 +1,111 @@
+#include "src/shared/items/ItemCatalog.h"
+
+#include <cstdio>
+#include <string>
+
+using engine::items::EquipmentSlot;
+using engine::items::ItemCatalog;
+using engine::items::ItemDefinition;
+using engine::items::ItemType;
+using engine::items::StatBonus;
+
+namespace
+{
+	int g_failed = 0;
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { std::fprintf(stderr, "[FAIL] %s:%d %s\n", __FILE__, __LINE__, #cond); ++g_failed; } \
+	} while (0)
+
+	// Catalogue minimal en dur : 1 arme (mainhand, bonus dégât) + 1 consommable
+	// (non équipable). Couvre parsing type/slot/bonus + IsEquippable.
+	const char* kJson = R"JSON(
+	{
+	  "items": [
+	    {
+	      "id": 2004,
+	      "name": "Epee courte",
+	      "description": "Une lame courte.",
+	      "icon": "items/epee.png",
+	      "type": "weapon",
+	      "slot": "mainhand",
+	      "bonus": { "damage": 12, "accuracy": 3, "critRate": 0.02 }
+	    },
+	    {
+	      "id": 3001,
+	      "name": "Pomme",
+	      "type": "consumable",
+	      "slot": "none"
+	    }
+	  ]
+	}
+	)JSON";
+
+	void Test_LoadAndFind()
+	{
+		ItemCatalog cat;
+		REQUIRE(cat.LoadFromJson(kJson));
+		REQUIRE(cat.Count() == 2);
+
+		const ItemDefinition* epee = cat.Find(2004);
+		REQUIRE(epee != nullptr);
+		if (epee)
+		{
+			REQUIRE(epee->name == "Epee courte");
+			REQUIRE(epee->type == ItemType::Weapon);
+			REQUIRE(epee->slot == EquipmentSlot::MainHand);
+			REQUIRE(epee->IsEquippable());
+			REQUIRE(epee->bonus.damage == 12);
+			REQUIRE(epee->bonus.accuracy == 3);
+			REQUIRE(epee->bonus.critRate > 0.019f && epee->bonus.critRate < 0.021f);
+			REQUIRE(epee->bonus.hp == 0); // champ absent => 0
+		}
+	}
+
+	void Test_NonEquippable()
+	{
+		ItemCatalog cat;
+		REQUIRE(cat.LoadFromJson(kJson));
+		const ItemDefinition* pomme = cat.Find(3001);
+		REQUIRE(pomme != nullptr);
+		if (pomme)
+		{
+			REQUIRE(pomme->type == ItemType::Consumable);
+			REQUIRE(pomme->slot == EquipmentSlot::None);
+			REQUIRE(!pomme->IsEquippable());
+		}
+	}
+
+	void Test_MissingIdReturnsNull()
+	{
+		ItemCatalog cat;
+		REQUIRE(cat.LoadFromJson(kJson));
+		REQUIRE(cat.Find(9999) == nullptr);
+	}
+
+	void Test_BonusAccumulation()
+	{
+		StatBonus a; a.hp = 15; a.damage = 5;
+		StatBonus b; b.hp = 30; b.speedWalk = 0.2f;
+		a += b;
+		REQUIRE(a.hp == 45);
+		REQUIRE(a.damage == 5);
+		REQUIRE(a.speedWalk > 0.19f && a.speedWalk < 0.21f);
+	}
+
+	void Test_InvalidJson()
+	{
+		ItemCatalog cat;
+		REQUIRE(!cat.LoadFromJson("{ ceci n'est pas du json"));
+		REQUIRE(cat.Count() == 0);
+	}
+}
+
+int main()
+{
+	Test_LoadAndFind();
+	Test_NonEquippable();
+	Test_MissingIdReturnsNull();
+	Test_BonusAccumulation();
+	Test_InvalidJson();
+	return g_failed == 0 ? 0 : 1;
+}

--- a/src/shared/items/ItemDefinition.h
+++ b/src/shared/items/ItemDefinition.h
@@ -1,0 +1,102 @@
+#pragma once
+
+// Catalogue d'objets — modèle de données partagé client/serveur (Chantier 2 SP-A).
+// Décrit l'identité d'un objet : type, slot d'équipement, bonus de stats,
+// apparence. Aucune logique lourde ici (POD + petites fonctions utilitaires).
+// Le serveur (shardd) est autoritaire : il lit CE modèle depuis sa propre copie
+// de game/data/items/items.json et n'accepte jamais slot/bonus fournis par le
+// client (anti-triche).
+
+#include <cstdint>
+#include <string>
+
+namespace engine::items
+{
+	// Slot d'équipement gameplay. None (0) = objet non équipable (consommable,
+	// quête, divers). 7 slots visuels (portés sur l'avatar) + 3 non visuels
+	// (accessoires : amulette, 2 anneaux). L'ordre est FIGÉ (persisté en DB et
+	// transmis sur le réseau) : ne jamais réordonner, seulement ajouter à la fin.
+	enum class EquipmentSlot : std::uint8_t
+	{
+		None = 0,
+		Head,      // 1
+		Chest,     // 2
+		Legs,      // 3
+		Feet,      // 4
+		Hands,     // 5
+		MainHand,  // 6  (arme principale)
+		OffHand,   // 7  (bouclier / 2ᵈᵉ main)
+		Amulet,    // 8  (non visuel)
+		Ring1,     // 9  (non visuel)
+		Ring2,     // 10 (non visuel)
+		Count      // 11 borne
+	};
+
+	// Nombre de slots réellement équipables (hors None). Utile pour dimensionner
+	// les tableaux d'équipement (indices 1..kEquipSlotCount).
+	inline constexpr std::size_t kEquipSlotCount =
+		static_cast<std::size_t>(EquipmentSlot::Count) - 1u;
+
+	// Catégorie d'objet (tri / affichage). Pas de logique gameplay en SP-A.
+	enum class ItemType : std::uint8_t
+	{
+		Misc = 0,
+		Weapon,
+		Armor,
+		Accessory,
+		Consumable,
+		Quest
+	};
+
+	// Bonus additif appliqué aux stats dérivées quand l'objet est équipé.
+	// Miroir des champs numériques de shardd DerivedStats : chaque champ non nul
+	// s'ADDITIONNE à la stat calculée (interpolation classe/race/sexe), clampée ≥ 0.
+	struct StatBonus
+	{
+		std::int32_t hp = 0;
+		std::int32_t resource = 0;
+		std::int32_t damage = 0;
+		std::int32_t accuracy = 0;
+		float        range = 0.0f;
+		float        critRate = 0.0f;
+		float        critMult = 0.0f;
+		float        speedWalk = 0.0f;
+		float        speedRun = 0.0f;
+		float        speedSprint = 0.0f;
+		std::int32_t stamina = 0;
+		std::int32_t perception = 0;
+		std::int32_t stealth = 0;
+
+		// Additionne un autre bonus (utilisé pour sommer l'équipement complet).
+		StatBonus& operator+=(const StatBonus& o)
+		{
+			hp += o.hp; resource += o.resource; damage += o.damage;
+			accuracy += o.accuracy; range += o.range; critRate += o.critRate;
+			critMult += o.critMult; speedWalk += o.speedWalk; speedRun += o.speedRun;
+			speedSprint += o.speedSprint; stamina += o.stamina;
+			perception += o.perception; stealth += o.stealth;
+			return *this;
+		}
+	};
+
+	// Définition complète d'un objet du catalogue.
+	struct ItemDefinition
+	{
+		std::uint32_t id = 0;
+		std::string   name;
+		std::string   description;
+		std::string   iconPath;
+		ItemType      type = ItemType::Misc;
+		EquipmentSlot slot = EquipmentSlot::None; // None => non équipable
+		StatBonus     bonus;                      // additif quand équipé
+		std::string   visualMesh;                 // apparence modulaire (SP-D) ; vide en SP-A
+
+		bool IsEquippable() const { return slot != EquipmentSlot::None; }
+	};
+
+	// Conversions chaîne <-> enum (parsing JSON et diagnostics).
+	EquipmentSlot EquipmentSlotFromString(const std::string& s); // défaut None si inconnu
+	ItemType      ItemTypeFromString(const std::string& s);      // défaut Misc si inconnu
+	const char*   ToString(EquipmentSlot slot);
+	const char*   ToString(ItemType type);
+}

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -1146,6 +1146,91 @@ namespace engine::server
 		return true;
 	}
 
+	// ---- Chantier 2 SP-A : équipement ----
+
+	std::vector<std::byte> EncodeEquipRequest(const EquipRequestMessage& message)
+	{
+		// Payload fixe : clientId (4) + itemId (4) = 8 octets (miroir du décodeur).
+		std::vector<std::byte> packet = BeginPacket(MessageKind::EquipRequest, 8);
+		WriteU32(packet, message.clientId);
+		WriteU32(packet, message.itemId);
+		return packet;
+	}
+
+	bool DecodeEquipRequest(std::span<const std::byte> packet, EquipRequestMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::EquipRequest, payload) || payload.size() != 8)
+		{
+			return false;
+		}
+		outMessage.clientId = ReadU32(payload, 0);
+		outMessage.itemId = ReadU32(payload, 4);
+		return true;
+	}
+
+	std::vector<std::byte> EncodeUnequipRequest(const UnequipRequestMessage& message)
+	{
+		// Payload fixe : clientId (4) + slot (1) = 5 octets.
+		std::vector<std::byte> packet = BeginPacket(MessageKind::UnequipRequest, 5);
+		WriteU32(packet, message.clientId);
+		WriteU8(packet, message.slot);
+		return packet;
+	}
+
+	bool DecodeUnequipRequest(std::span<const std::byte> packet, UnequipRequestMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::UnequipRequest, payload) || payload.size() != 5)
+		{
+			return false;
+		}
+		outMessage.clientId = ReadU32(payload, 0);
+		outMessage.slot = ReadU8(payload, 4);
+		return true;
+	}
+
+	std::vector<std::byte> EncodeEquipmentUpdate(const EquipmentUpdateMessage& message, std::span<const EquipmentEntry> entries)
+	{
+		// Payload : clientId (4) + count (2) + count × [slot (1) + itemId (4)].
+		std::vector<std::byte> packet = BeginPacket(MessageKind::EquipmentUpdate, 6 + (entries.size() * 5));
+		WriteU32(packet, message.clientId);
+		WriteU16(packet, static_cast<uint16_t>(entries.size()));
+		for (const EquipmentEntry& entry : entries)
+		{
+			WriteU8(packet, entry.slot);
+			WriteU32(packet, entry.itemId);
+		}
+		return packet;
+	}
+
+	bool DecodeEquipmentUpdate(std::span<const std::byte> packet, EquipmentUpdateMessage& outMessage, std::vector<EquipmentEntry>& outEntries)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::EquipmentUpdate, payload) || payload.size() < 6)
+		{
+			return false;
+		}
+		outMessage.clientId = ReadU32(payload, 0);
+		const size_t count = static_cast<size_t>(ReadU16(payload, 4));
+		const size_t expectedPayloadSize = 6 + (count * 5);
+		if (payload.size() != expectedPayloadSize)
+		{
+			return false;
+		}
+		outEntries.clear();
+		outEntries.resize(count);
+		size_t offset = 6;
+		for (size_t index = 0; index < count; ++index)
+		{
+			EquipmentEntry& entry = outEntries[index];
+			entry.slot = ReadU8(payload, offset + 0);
+			entry.itemId = ReadU32(payload, offset + 1);
+			offset += 5;
+		}
+		return true;
+	}
+
 	std::vector<std::byte> EncodeQuestDelta(const QuestDeltaMessage& message)
 	{
 		size_t payloadSize = 4 + 1 + 2 + message.questId.size() + 4 + 4 + 1 + 2;

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -59,7 +59,11 @@ namespace engine::server
 	/// 4 → 5). Les kinds ForcePosition (86) et LootNotify (87) ajoutés pendant
 	/// la fenêtre v12 restaient rétro-additifs ; ce changement-ci modifie un
 	/// payload existant → wire-breaking : lock-step master + shardd + client.
-	inline constexpr uint16_t kProtocolVersion = 14;
+	/// Chantier 2 SP-A — bump 14 → 15 : opcodes équipement EquipRequest (96),
+	/// UnequipRequest (97), EquipmentUpdate (98). Nouveaux opcodes client→serveur
+	/// (equip/unequip) : un vieux serveur les ignorerait → bump pour rejeter les
+	/// paires client/serveur incompatibles. Lock-step master + shardd + client.
+	inline constexpr uint16_t kProtocolVersion = 15;
 
 	/// Message kinds exchanged by the server skeleton.
 	enum class MessageKind : uint16_t
@@ -293,7 +297,18 @@ namespace engine::server
 		/// XP dans le niveau courant, XP requise pour le suivant. Poussé à l'enter-world
 		/// ET à chaque gain d'XP (level-up ou non). Rétro-additif (vieux clients
 		/// l'ignorent) : PAS de bump de kProtocolVersion.
-		PlayerXpUpdate = 95
+		PlayerXpUpdate = 95,
+
+		/// Chantier 2 SP-A — équipement d'objets. Wire-breaking (bump 14→15).
+		/// EquipRequest (client→serveur) : équiper l'objet `itemId` depuis le sac ;
+		/// le SERVEUR détermine le slot depuis SON catalogue (anti-triche).
+		EquipRequest = 96,
+		/// UnequipRequest (client→serveur) : retirer l'objet du slot `slot` (renvoyé
+		/// au sac).
+		UnequipRequest = 97,
+		/// EquipmentUpdate (serveur→client) : snapshot complet de l'équipement porté
+		/// (liste des slots occupés → itemId). Idempotent, comme InventoryDelta.
+		EquipmentUpdate = 98
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -564,6 +579,38 @@ namespace engine::server
 		uint32_t clientId = 0;
 	};
 
+	/// Chantier 2 SP-A — requête d'équipement (client→serveur). Le client demande
+	/// à équiper `itemId` (présent dans son sac). Le slot est déterminé par le
+	/// serveur depuis SON catalogue (jamais fourni par le client).
+	struct EquipRequestMessage
+	{
+		uint32_t clientId = 0;
+		uint32_t itemId = 0;
+	};
+
+	/// Chantier 2 SP-A — requête de retrait d'équipement (client→serveur).
+	/// `slot` = valeur de engine::items::EquipmentSlot (1..10).
+	struct UnequipRequestMessage
+	{
+		uint32_t clientId = 0;
+		uint8_t slot = 0;
+	};
+
+	/// Une entrée d'équipement portée : slot occupé → itemId. Slot = valeur de
+	/// engine::items::EquipmentSlot (1..10).
+	struct EquipmentEntry
+	{
+		uint8_t slot = 0;
+		uint32_t itemId = 0;
+	};
+
+	/// Chantier 2 SP-A — snapshot d'équipement (serveur→client). Contient les
+	/// slots occupés uniquement ; le client vide puis applique (idempotent).
+	struct EquipmentUpdateMessage
+	{
+		uint32_t clientId = 0;
+	};
+
 	/// Client request asking the authoritative server to validate one quest talk target.
 	struct TalkRequestMessage
 	{
@@ -790,6 +837,19 @@ namespace engine::server
 
 	/// Decode an inventory delta packet and reuse the provided item buffer for the payload items.
 	bool DecodeInventoryDelta(std::span<const std::byte> packet, InventoryDeltaMessage& outMessage, std::vector<ItemStack>& outItems);
+
+	/// Chantier 2 SP-A — encode/décode d'une requête d'équipement (payload fixe 8 o).
+	std::vector<std::byte> EncodeEquipRequest(const EquipRequestMessage& message);
+	bool DecodeEquipRequest(std::span<const std::byte> packet, EquipRequestMessage& outMessage);
+
+	/// Chantier 2 SP-A — encode/décode d'une requête de retrait (payload fixe 5 o).
+	std::vector<std::byte> EncodeUnequipRequest(const UnequipRequestMessage& message);
+	bool DecodeUnequipRequest(std::span<const std::byte> packet, UnequipRequestMessage& outMessage);
+
+	/// Chantier 2 SP-A — encode/décode d'un snapshot d'équipement.
+	/// Payload : clientId (4) + count (2) + count × [slot (1) + itemId (4)].
+	std::vector<std::byte> EncodeEquipmentUpdate(const EquipmentUpdateMessage& message, std::span<const EquipmentEntry> entries);
+	bool DecodeEquipmentUpdate(std::span<const std::byte> packet, EquipmentUpdateMessage& outMessage, std::vector<EquipmentEntry>& outEntries);
 
 	/// Decode a talk request packet and validate the protocol header.
 	bool DecodeTalkRequest(std::span<const std::byte> packet, TalkRequestMessage& outMessage);

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -753,6 +753,76 @@ namespace
 		std::puts("[OK] TestQuestGiverListRoundTrip");
 	}
 
+	// Chantier 2 SP-A — équipement.
+	void TestEquipRequestRoundTrip()
+	{
+		engine::server::EquipRequestMessage msg{};
+		msg.clientId = 7u;
+		msg.itemId = 2004u;
+		std::vector<std::byte> packet = engine::server::EncodeEquipRequest(msg);
+
+		engine::server::EquipRequestMessage out{};
+		assert(engine::server::DecodeEquipRequest(packet, out));
+		assert(out.clientId == 7u);
+		assert(out.itemId == 2004u);
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 1u);
+		assert(!engine::server::DecodeEquipRequest(truncated, out));
+		std::puts("[OK] TestEquipRequestRoundTrip");
+	}
+
+	void TestUnequipRequestRoundTrip()
+	{
+		engine::server::UnequipRequestMessage msg{};
+		msg.clientId = 12u;
+		msg.slot = 6u; // MainHand
+		std::vector<std::byte> packet = engine::server::EncodeUnequipRequest(msg);
+
+		engine::server::UnequipRequestMessage out{};
+		assert(engine::server::DecodeUnequipRequest(packet, out));
+		assert(out.clientId == 12u);
+		assert(out.slot == 6u);
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 1u);
+		assert(!engine::server::DecodeUnequipRequest(truncated, out));
+		std::puts("[OK] TestUnequipRequestRoundTrip");
+	}
+
+	void TestEquipmentUpdateRoundTrip()
+	{
+		engine::server::EquipmentUpdateMessage msg{};
+		msg.clientId = 42u;
+		std::vector<engine::server::EquipmentEntry> entries = {
+			{1u, 2001u}, // Head
+			{2u, 2002u}, // Chest
+			{6u, 2004u}, // MainHand
+		};
+		std::vector<std::byte> packet = engine::server::EncodeEquipmentUpdate(msg, entries);
+
+		engine::server::EquipmentUpdateMessage out{};
+		std::vector<engine::server::EquipmentEntry> outEntries;
+		assert(engine::server::DecodeEquipmentUpdate(packet, out, outEntries));
+		assert(out.clientId == 42u);
+		assert(outEntries.size() == 3u);
+		assert(outEntries[0].slot == 1u && outEntries[0].itemId == 2001u);
+		assert(outEntries[1].slot == 2u && outEntries[1].itemId == 2002u);
+		assert(outEntries[2].slot == 6u && outEntries[2].itemId == 2004u);
+
+		// Snapshot vide (tout déséquipé) : valide, 0 entrée.
+		engine::server::EquipmentUpdateMessage empty{};
+		empty.clientId = 5u;
+		assert(engine::server::DecodeEquipmentUpdate(
+			engine::server::EncodeEquipmentUpdate(empty, {}), out, outEntries));
+		assert(outEntries.empty());
+
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 1u);
+		assert(!engine::server::DecodeEquipmentUpdate(truncated, out, outEntries));
+		std::puts("[OK] TestEquipmentUpdateRoundTrip");
+	}
+
 int main()
 {
 	TestInputRoundTrip();
@@ -781,6 +851,9 @@ int main()
 	TestQuestAcceptRequestRoundTrip();
 	TestQuestTurnInRequestRoundTrip();
 	TestQuestGiverListRoundTrip();
+	TestEquipRequestRoundTrip();
+	TestUnequipRequestRoundTrip();
+	TestEquipmentUpdateRoundTrip();
 	std::puts("All ServerProtocol tests passed");
 	return 0;
 }

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -471,6 +471,25 @@ namespace engine::server
 		}
 		m_vendorStock.ResetFromCatalog(m_vendorCatalog.GetVendors());
 
+		// Chantier 2 SP-A — catalogue d'objets (autoritaire pour slot/bonus). Non
+		// fatal : un catalogue absent désactive simplement l'équipement (pas de
+		// régression sur le reste du gameplay), à l'image de m_statsTables.
+		{
+			const std::string itemsPath = m_config.GetString("server.items_catalog_path", "items/items.json");
+			const std::string itemsText = engine::platform::FileSystem::ReadAllTextContent(m_config, itemsPath);
+			if (itemsText.empty() || !m_itemCatalog.LoadFromJson(itemsText))
+			{
+				LOG_WARN(Core,
+					"[ServerApp] catalogue d'objets absent/illisible (path={}) — équipement désactivé",
+					itemsPath);
+			}
+			else
+			{
+				m_itemCatalogLoaded = true;
+				LOG_INFO(Core, "[ServerApp] catalogue d'objets chargé : {} objet(s)", m_itemCatalog.Count());
+			}
+		}
+
 		m_characterAutosaveIntervalTicks = ResolveCharacterAutosaveIntervalTicks();
 		m_nextCharacterAutosaveTick = m_characterAutosaveIntervalTicks;
 
@@ -867,6 +886,21 @@ namespace engine::server
 		if (DecodePickupRequest(packetBytes, pickupRequest))
 		{
 			HandlePickupRequest(datagram.endpoint, pickupRequest.clientId, pickupRequest.lootBagEntityId);
+			return;
+		}
+
+		// Chantier 2 SP-A — équiper / déséquiper un objet.
+		EquipRequestMessage equipRequest{};
+		if (DecodeEquipRequest(packetBytes, equipRequest))
+		{
+			HandleEquipRequest(datagram.endpoint, equipRequest.clientId, equipRequest.itemId);
+			return;
+		}
+
+		UnequipRequestMessage unequipRequest{};
+		if (DecodeUnequipRequest(packetBytes, unequipRequest))
+		{
+			HandleUnequipRequest(datagram.endpoint, unequipRequest.clientId, unequipRequest.slot);
 			return;
 		}
 
@@ -1360,6 +1394,7 @@ namespace engine::server
 			acceptedClient.premiumCurrency = persistedState.premiumCurrency;
 			acceptedClient.stats = persistedState.stats;
 			acceptedClient.inventory = persistedState.inventory;
+			acceptedClient.equipment = persistedState.equipment; // Chantier 2 SP-A
 			acceptedClient.questStates = persistedState.questStates;
 		acceptedClient.chatIgnoredDisplayNames = std::move(persistedState.chatIgnoredDisplayNames);
 		acceptedClient.chatModeratorRole = persistedState.chatModeratorRole;
@@ -1490,6 +1525,18 @@ namespace engine::server
 			{
 				acceptedClient.stats.maxHealth = sh.maxHealth;
 				acceptedClient.stats.currentHealth = sh.currentHealth;
+				// Chantier 2 SP-A — le bonus PV d'équipement élargit le pool de PV max
+				// (les PV courants persistés restent clampés dessous).
+				const int32_t hpBonus = SumEquipmentBonus(acceptedClient).hp;
+				if (hpBonus != 0)
+				{
+					const int64_t widened = static_cast<int64_t>(acceptedClient.stats.maxHealth) + hpBonus;
+					acceptedClient.stats.maxHealth = widened < 0 ? 0u : static_cast<uint32_t>(widened);
+					if (acceptedClient.stats.currentHealth > acceptedClient.stats.maxHealth)
+					{
+						acceptedClient.stats.currentHealth = acceptedClient.stats.maxHealth;
+					}
+				}
 				LOG_INFO(Net,
 					"[ServerApp] R1-A enter-world stats (client_id={}, faction={}, class={}, level={}) -> maxHealth={}, currentHealth={}",
 					acceptedClient.clientId,
@@ -1503,11 +1550,13 @@ namespace engine::server
 			// portée, précision, critique) dans le composant combat, à la place
 			// des constantes MVP. Faction/classe vides → ComputeStats nullopt →
 			// le composant MVP est conservé (pas de régression mode no-DB).
-			const auto derived = engine::server::gameplay::ComputeStats(
+			auto derived = engine::server::gameplay::ComputeStats(
 				*m_statsTables, acceptedClient.factionId, acceptedClient.classId,
 				sex, acceptedClient.level);
 			if (derived)
 			{
+				// Chantier 2 SP-A — bonus d'equipement dans le combat/ressource au spawn.
+				ApplyEquipmentBonus(acceptedClient, *derived);
 				ApplyDerivedCombatStats(acceptedClient, *derived);
 				// Combat SP3 — profil de classe (kit de sorts) + ressource runtime.
 				const auto factionIt = m_statsTables->factions.find(acceptedClient.factionId);
@@ -2110,6 +2159,7 @@ namespace engine::server
 		state.premiumCurrency = client.premiumCurrency;
 		state.stats = client.stats;
 		state.inventory = client.inventory;
+		state.equipment = client.equipment; // Chantier 2 SP-A
 		state.questStates = client.questStates;
 		state.chatIgnoredDisplayNames = client.chatIgnoredDisplayNames;
 		state.chatModeratorRole = client.chatModeratorRole;
@@ -3398,6 +3448,229 @@ namespace engine::server
 		}
 		SaveConnectedClient(*client, "pickup");
 		(void)SendInventoryDelta(*client, pickedItems);
+	}
+
+	// ------------------------------------------------------------------------
+	// Chantier 2 SP-A — équipement d'objets (serveur autoritaire)
+	// ------------------------------------------------------------------------
+
+	engine::items::StatBonus ServerApp::SumEquipmentBonus(const ConnectedClient& client) const
+	{
+		engine::items::StatBonus total{};
+		if (!m_itemCatalogLoaded)
+		{
+			return total;
+		}
+		for (std::size_t slot = 1; slot < client.equipment.size(); ++slot)
+		{
+			const uint32_t itemId = client.equipment[slot];
+			if (itemId == 0u)
+			{
+				continue;
+			}
+			if (const engine::items::ItemDefinition* def = m_itemCatalog.Find(itemId))
+			{
+				total += def->bonus;
+			}
+		}
+		return total;
+	}
+
+	void ServerApp::ApplyEquipmentBonus(const ConnectedClient& client, engine::server::gameplay::DerivedStats& d) const
+	{
+		const engine::items::StatBonus b = SumEquipmentBonus(client);
+		// Champs uint32 : additionne en int64 puis clamp ≥ 0 (bonus négatif possible).
+		const auto addU = [](uint32_t base, int32_t delta) -> uint32_t {
+			const int64_t v = static_cast<int64_t>(base) + static_cast<int64_t>(delta);
+			return v < 0 ? 0u : static_cast<uint32_t>(v);
+		};
+		d.hp          = addU(d.hp, b.hp);
+		d.resource    = addU(d.resource, b.resource);
+		d.damage      = addU(d.damage, b.damage);
+		d.stamina     = addU(d.stamina, b.stamina);
+		d.accuracy    = std::max(0.0f, d.accuracy + static_cast<float>(b.accuracy));
+		d.range       = std::max(0.0f, d.range + b.range);
+		d.critRate    = std::max(0.0f, d.critRate + b.critRate);
+		d.critMult    = std::max(0.0f, d.critMult + b.critMult);
+		d.speedWalk   = std::max(0.0f, d.speedWalk + b.speedWalk);
+		d.speedRun    = std::max(0.0f, d.speedRun + b.speedRun);
+		d.speedSprint = std::max(0.0f, d.speedSprint + b.speedSprint);
+		d.perception  = std::max(0.0f, d.perception + static_cast<float>(b.perception));
+		d.stealth     = std::max(0.0f, d.stealth + static_cast<float>(b.stealth));
+	}
+
+	void ServerApp::RefreshLiveDerivedStats(ConnectedClient& client)
+	{
+		if (!m_statsTables) return;
+		if (client.factionId.empty() || client.classId.empty()) return;
+		const engine::server::gameplay::Sex sex =
+			(client.gender == "female") ? engine::server::gameplay::Sex::Female
+			                            : engine::server::gameplay::Sex::Male;
+		auto d = engine::server::gameplay::ComputeStats(
+			*m_statsTables, client.factionId, client.classId, sex, client.level);
+		if (!d) return;
+		ApplyEquipmentBonus(client, *d);
+
+		ApplyDerivedCombatStats(client, *d);
+		client.maxResource = d->resource;
+		if (client.currentResource > client.maxResource)
+		{
+			client.currentResource = client.maxResource;
+		}
+		// PV max = hp dérivé (bonus inclus) ; on préserve les PV courants (pas de
+		// soin en équipant), seulement clampés sur le nouveau max.
+		client.stats.maxHealth = d->hp;
+		if (client.stats.currentHealth > client.stats.maxHealth)
+		{
+			client.stats.currentHealth = client.stats.maxHealth;
+		}
+	}
+
+	bool ServerApp::SendEquipmentUpdate(const ConnectedClient& receiver)
+	{
+		EquipmentUpdateMessage message{};
+		message.clientId = receiver.clientId;
+		std::vector<EquipmentEntry> entries;
+		for (std::size_t slot = 1; slot < receiver.equipment.size(); ++slot)
+		{
+			if (receiver.equipment[slot] != 0u)
+			{
+				entries.push_back(EquipmentEntry{static_cast<uint8_t>(slot), receiver.equipment[slot]});
+			}
+		}
+		const std::vector<std::byte> packet = EncodeEquipmentUpdate(message, entries);
+		if (!m_transport.Send(receiver.endpoint, packet))
+		{
+			LOG_WARN(Net, "[ServerApp] EquipmentUpdate send failed (client_id={})", receiver.clientId);
+			return false;
+		}
+		LOG_INFO(Net, "[ServerApp] EquipmentUpdate sent (client_id={}, worn={})",
+			receiver.clientId, entries.size());
+		return true;
+	}
+
+	void ServerApp::HandleEquipRequest(const Endpoint& endpoint, uint32_t clientId, uint32_t itemId)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] EquipRequest ignored from unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+		if (client->clientId != clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] EquipRequest ignored: client_id mismatch (expected={}, got={})",
+				client->clientId, clientId);
+			return;
+		}
+		if (!m_itemCatalogLoaded)
+		{
+			LOG_WARN(Net, "[ServerApp] EquipRequest rejeté: catalogue d'objets non chargé (client_id={})", clientId);
+			return;
+		}
+
+		// Slot ET bonus proviennent du catalogue serveur (jamais du client) : anti-triche.
+		const engine::items::ItemDefinition* def = m_itemCatalog.Find(itemId);
+		if (def == nullptr || !def->IsEquippable())
+		{
+			LOG_WARN(Net, "[ServerApp] EquipRequest rejeté: objet inconnu/non équipable (client_id={}, item_id={})",
+				clientId, itemId);
+			return;
+		}
+		const std::size_t slot = static_cast<std::size_t>(def->slot);
+		if (slot == 0u || slot >= client->equipment.size())
+		{
+			LOG_WARN(Net, "[ServerApp] EquipRequest rejeté: slot hors borne (client_id={}, item_id={}, slot={})",
+				clientId, itemId, slot);
+			return;
+		}
+
+		// L'objet doit être présent dans le sac (anti-triche : on ne peut équiper
+		// que ce qu'on possède).
+		bool owned = false;
+		for (const ItemStack& stack : client->inventory)
+		{
+			if (stack.itemId == itemId && stack.quantity >= 1u)
+			{
+				owned = true;
+				break;
+			}
+		}
+		if (!owned)
+		{
+			LOG_WARN(Net, "[ServerApp] EquipRequest rejeté: objet absent du sac (client_id={}, item_id={})",
+				clientId, itemId);
+			return;
+		}
+
+		std::string error;
+		if (!RemoveStackFromInventory(*client, itemId, 1u, error))
+		{
+			LOG_WARN(Net, "[ServerApp] EquipRequest échec retrait sac (client_id={}, item_id={}, err={})",
+				clientId, itemId, error);
+			return;
+		}
+
+		// Renvoie au sac l'objet déjà porté sur ce slot (échange).
+		const uint32_t previous = client->equipment[slot];
+		if (previous != 0u)
+		{
+			AddItemToInventory(*client, ItemStack{previous, 1u});
+		}
+		client->equipment[slot] = itemId;
+
+		LOG_INFO(Net, "[ServerApp] Équipement (client_id={}, item_id={}, slot={}, remplacé={})",
+			clientId, itemId, slot, previous);
+
+		SaveConnectedClient(*client, "equip");
+		RefreshLiveDerivedStats(*client); // combat/PV/ressource refletent le nouvel equipement
+		(void)SendInventoryDelta(*client, client->inventory); // snapshot complet
+		(void)SendEquipmentUpdate(*client);
+		(void)SendPlayerStats(*client);
+	}
+
+	void ServerApp::HandleUnequipRequest(const Endpoint& endpoint, uint32_t clientId, uint8_t slot)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] UnequipRequest ignored from unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+		if (client->clientId != clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] UnequipRequest ignored: client_id mismatch (expected={}, got={})",
+				client->clientId, clientId);
+			return;
+		}
+		const std::size_t slotIndex = static_cast<std::size_t>(slot);
+		if (slotIndex == 0u || slotIndex >= client->equipment.size())
+		{
+			LOG_WARN(Net, "[ServerApp] UnequipRequest rejeté: slot hors borne (client_id={}, slot={})",
+				clientId, slotIndex);
+			return;
+		}
+		const uint32_t itemId = client->equipment[slotIndex];
+		if (itemId == 0u)
+		{
+			LOG_WARN(Net, "[ServerApp] UnequipRequest ignoré: slot déjà vide (client_id={}, slot={})",
+				clientId, slotIndex);
+			return;
+		}
+
+		AddItemToInventory(*client, ItemStack{itemId, 1u});
+		client->equipment[slotIndex] = 0u;
+
+		LOG_INFO(Net, "[ServerApp] Déséquipement (client_id={}, item_id={}, slot={})",
+			clientId, itemId, slotIndex);
+
+		SaveConnectedClient(*client, "unequip");
+		RefreshLiveDerivedStats(*client); // combat/PV/ressource refletent le nouvel equipement
+		(void)SendInventoryDelta(*client, client->inventory); // snapshot complet
+		(void)SendEquipmentUpdate(*client);
+		(void)SendPlayerStats(*client);
 	}
 
 	void ServerApp::HandleTalkRequest(const Endpoint& endpoint, uint32_t clientId, std::string_view targetId)
@@ -6359,9 +6632,11 @@ namespace engine::server
 		const engine::server::gameplay::Sex sex =
 			(client.gender == "female") ? engine::server::gameplay::Sex::Female
 			                            : engine::server::gameplay::Sex::Male;
-		const auto d = engine::server::gameplay::ComputeStats(
+		auto d = engine::server::gameplay::ComputeStats(
 			*m_statsTables, client.factionId, client.classId, sex, client.level);
 		if (!d) return false;
+		// Chantier 2 SP-A — bonus d'équipement (source autoritaire : catalogue serveur).
+		ApplyEquipmentBonus(client, *d);
 
 		PlayerStatsMessage msg{};
 		msg.clientId    = client.clientId;

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -18,6 +18,7 @@
 #include "src/shardd/gameplay/creature/CreatureArchetypeLibrary.h"
 #include "src/shardd/gameplay/spell/SpellKitLibrary.h"
 #include "src/shardd/gameplay/spell/ClassSkillLibrary.h"
+#include "src/shared/items/ItemCatalog.h"
 #include "src/shared/core/Config.h"
 #include "src/shared/net/ChatSystem.h"
 #include "src/shardd/gameplay/chat/ChatCommandParser.h"
@@ -210,6 +211,10 @@ namespace engine::server
 		std::vector<EntityId> interestEntityIds;
 		std::vector<EntityId> replicatedEntityIds;
 		std::vector<ItemStack> inventory;
+		/// Chantier 2 SP-A — équipement porté. Indexé par la valeur de
+		/// engine::items::EquipmentSlot (1..kEquipSlotCount) ; index 0 (None) inutilisé.
+		/// 0 = slot vide, sinon itemId. Persisté + poussé au client via EquipmentUpdate.
+		std::array<uint32_t, engine::items::kEquipSlotCount + 1> equipment{};
 		std::vector<QuestState> questStates;
 		/// M29.2: ignored chat senders (display names, persisted).
 		std::vector<std::string> chatIgnoredDisplayNames;
@@ -559,6 +564,34 @@ namespace engine::server
 
 		/// Validate one pickup request, update the inventory and despawn the bag.
 		void HandlePickupRequest(const Endpoint& endpoint, uint32_t clientId, EntityId lootBagEntityId);
+
+		/// Chantier 2 SP-A — équipe l'objet `itemId` (présent au sac) du client. Le
+		/// slot et le bonus sont résolus depuis m_itemCatalog (autoritaire). Retire un
+		/// exemplaire du sac, replace l'éventuel objet déjà porté dans le sac, met à
+		/// jour equipment[slot], persiste, puis pousse EquipmentUpdate + PlayerStats.
+		void HandleEquipRequest(const Endpoint& endpoint, uint32_t clientId, uint32_t itemId);
+
+		/// Chantier 2 SP-A — retire l'objet du slot `slot` (1..kEquipSlotCount) et le
+		/// renvoie au sac. Persiste puis pousse EquipmentUpdate + PlayerStats.
+		void HandleUnequipRequest(const Endpoint& endpoint, uint32_t clientId, uint8_t slot);
+
+		/// Chantier 2 SP-A — pousse au client le snapshot complet de son équipement porté.
+		bool SendEquipmentUpdate(const ConnectedClient& receiver);
+
+		/// Chantier 2 SP-A — somme des StatBonus de tout l'équipement porté (résolus
+		/// via m_itemCatalog). Additionnée aux DerivedStats avant émission (anti-triche).
+		engine::items::StatBonus SumEquipmentBonus(const ConnectedClient& client) const;
+
+		/// Chantier 2 SP-A — additionne le bonus d'équipement du client aux stats
+		/// dérivées `d` (clamp ≥ 0 ; les champs uint32 passent par int64 pour éviter
+		/// tout underflow avec un bonus négatif). Ne lit jamais de valeur client.
+		void ApplyEquipmentBonus(const ConnectedClient& client, engine::server::gameplay::DerivedStats& d) const;
+
+		/// Chantier 2 SP-A — recalcule les stats runtime vivantes (combat, ressource
+		/// max, PV max) d'un client déjà en monde en tenant compte de l'équipement,
+		/// puis clamp les valeurs courantes sur les nouveaux max. Appelée après un
+		/// equip/unequip. Sans effet si les tables de stats ou l'identité RPG manquent.
+		void RefreshLiveDerivedStats(ConnectedClient& client);
 
 		/// Validate one talk request and forward it to the quest runtime.
 		void HandleTalkRequest(const Endpoint& endpoint, uint32_t clientId, std::string_view targetId);
@@ -1084,6 +1117,11 @@ namespace engine::server
 		/// M35.2 — vendor definitions (`config/vendors.json`) + finite stock book.
 		VendorCatalog m_vendorCatalog{};
 		VendorStockBook m_vendorStock{};
+		/// Chantier 2 SP-A — catalogue d'objets (game/data/items/items.json).
+		/// SOURCE AUTORITAIRE : slot + bonus d'un objet équipé sont lus ici, jamais
+		/// fournis par le client. Chargé une fois à l'Init (m_itemCatalogLoaded).
+		engine::items::ItemCatalog m_itemCatalog{};
+		bool m_itemCatalogLoaded = false;
 		EventRuntime m_eventRuntime;
 		QuestRuntime m_questRuntime;
 		SpawnerRuntime m_spawnerRuntime;


### PR DESCRIPTION
## Chantier 2 SP-A — PR2 (client)

Deuxième et dernière PR du système d'équipement. **Stackée sur PR1** (#965) — la base de cette PR est la branche de PR1, donc le diff ne montre que le client. À merger **après** PR1.

### Contenu
- **Réception** : `UIModel.equipment` (miroir wire) + `ApplyEquipmentUpdate` (décode `EquipmentUpdate` kind 98, remplacement complet) branché dans le dispatch.
- **Émission** : `GameplayUdpClient::SendEquipRequest(itemId)` / `SendUnequipRequest(slot)`.
- **Catalogue client** : `Engine` charge `game/data/items/items.json` (noms/slots/bonus pour l'affichage — le serveur reste autoritaire) et le passe au renderer.
- **Fenêtre Personnage (onglet Personnage)** : le placeholder « Equipement — Chantier 2 » devient une grille de 10 slots (libellés FR) montrant l'objet porté ; **clic sur un slot → déséquiper**, **clic sur un objet équipable de l'inventaire → équiper**. Tooltips inventaire enrichis (emplacement + bonus de stats). Canal d'action drainé par `Engine` (le renderer n'a pas le socket).

### Anti-triche
Le client n'envoie qu'un `itemId` (equip) ou un `slot` (unequip) ; le serveur décide du slot/bonus et revalide la possession.

### Déploiement
> **Déploiement** : ⚠️ **client + serveur en LOCK-STEP** (protocole 15). Cette PR est le versant client de PR1 : les deux doivent être mergées et déployées ensemble (master + shardd + client). Un client neuf ne parle pas à un serveur ancien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)