### PR TITLE
chore(warnings): nettoyage warnings build (~125 traités, dont 1 vrai bug)

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10139,7 +10139,7 @@ namespace engine
 		{
 			// Ne pas lier souris et clavier : un InputText actif mettait WantCaptureKeyboard à true et bloquait
 			// aussi la souris (orientation), ce qui figeait la caméra dans l’éditeur.
-			const bool capMouse = m_worldEditorImGui->WantsCaptureMouse();
+			[[maybe_unused]] const bool capMouse = m_worldEditorImGui->WantsCaptureMouse();
 			const bool capKb = m_worldEditorImGui->WantsCaptureKeyboard();
 			// Convention UX standard (Unity/Unreal/Blender) : la rotation de la
 			// caméra free-fly de l'éditeur n'est active QUE pendant que le clic

--- a/src/client/audio/MaMenuMusic.cpp
+++ b/src/client/audio/MaMenuMusic.cpp
@@ -6,7 +6,13 @@
 #include <cstring>
 
 #define MINIAUDIO_IMPLEMENTATION
+#if defined(_MSC_VER)
+#pragma warning(push, 0) // en-tete tiers : silence les warnings
+#endif
 #include "miniaudio.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 namespace engine::audio
 {

--- a/src/client/gameplay/CharacterController.cpp
+++ b/src/client/gameplay/CharacterController.cpp
@@ -405,7 +405,7 @@ namespace engine::gameplay
 		return true;
 	}
 
-	bool CharacterController::TryStepUp(const MoveInput& input, float dt, float timeRemaining,
+	bool CharacterController::TryStepUp(const MoveInput& input, float dt, [[maybe_unused]] float timeRemaining,
 		const IWorldCollider& world,
 		const engine::math::Vec3& startPos,
 		const engine::math::Vec3& horizontalDisp,

--- a/src/client/gameplay/SkillSystem.cpp
+++ b/src/client/gameplay/SkillSystem.cpp
@@ -1871,7 +1871,7 @@ namespace engine::gameplay
 		const uint64_t castTicks = SecondsToTicks(def->castTimeSeconds);
 		if (castTicks == 0)
 		{
-			const float gcdSeconds = static_cast<float>(m_config.GetDouble("skills.gcd_seconds", 1.5));
+			[[maybe_unused]] const float gcdSeconds = static_cast<float>(m_config.GetDouble("skills.gcd_seconds", 1.5));
 			m_gcdEndTicks[playerId] = nowTicks + ResolveGcdTicks();
 
 			LOG_INFO(Gameplay, "[SkillSystem] Cast triggered instant (player_id={}, skill={}, target_id={}, gcd_s={:.2f})",

--- a/src/client/render/AuthGlyphPass.cpp
+++ b/src/client/render/AuthGlyphPass.cpp
@@ -493,7 +493,7 @@ namespace engine::render
 		}
 	}
 
-	bool AuthGlyphPass::CreateFontPipeline(VkDevice device, VkPhysicalDevice physicalDevice, VkFormat colorFormat,
+	bool AuthGlyphPass::CreateFontPipeline(VkDevice device, [[maybe_unused]] VkPhysicalDevice physicalDevice, VkFormat colorFormat,
 		const uint32_t* vertSpirv, size_t vertWordCount,
 		const uint32_t* fragTtfSpirv, size_t fragTtfWordCount,
 		VkPipelineCache pipelineCache)
@@ -1432,7 +1432,7 @@ namespace engine::render
 		return TextPixelWidth(text, scale);
 	}
 
-	void AuthGlyphPass::Record(VkDevice device, VkCommandBuffer cmd, VkExtent2D extent,
+	void AuthGlyphPass::Record([[maybe_unused]] VkDevice device, VkCommandBuffer cmd, VkExtent2D extent,
 		std::string_view text,
 		int32_t originX, int32_t originY,
 		int32_t maxWidthPx)
@@ -1490,7 +1490,7 @@ namespace engine::render
 		vkCmdDraw(cmd, static_cast<uint32_t>(vertices.size()), 1, 0, 0);
 	}
 
-	void AuthGlyphPass::RecordModel(VkDevice device, VkCommandBuffer cmd, VkExtent2D extent,
+	void AuthGlyphPass::RecordModel([[maybe_unused]] VkDevice device, VkCommandBuffer cmd, VkExtent2D extent,
 		const engine::client::AuthUiPresenter::VisualState& state,
 		const engine::client::AuthUiPresenter::RenderModel& model,
 		const AuthUiTheme& theme)
@@ -1614,7 +1614,7 @@ namespace engine::render
 				}
 				const auto& card = model.languageFirstRunCards[static_cast<size_t>(ci)];
 				const int32_t cax = layout.languageCardX[ci];
-				const int32_t cay = layout.languageCardY[ci];
+				[[maybe_unused]] const int32_t cay = layout.languageCardY[ci];
 				const int32_t caw = layout.languageCardW[ci];
 				const int32_t nameY = layout.languageFlagCenterY[ci] + layout.languageFlagHalfExtentPx[ci] + 8;
 				appendCenteredText(card.nameAllCaps, cax, nameY, caw, smallScale,
@@ -1671,7 +1671,7 @@ namespace engine::render
 		if (!state.submitting && !model.errorText.empty())
 		{
 			const int32_t boxTop = panelY + layout.authErrorBoxTopFromPanelTopPx;
-			const int32_t boxH = std::max(48, layout.authErrorBoxHeightPx);
+			[[maybe_unused]] const int32_t boxH = std::max(48, layout.authErrorBoxHeightPx);
 			const int32_t msgY = boxTop + 18;
 			AppendText(vertices, model.errorText, contentX + 18, msgY, contentW - 36, bodyScale, titleColor);
 			const int32_t footerTop = panelY + layout.authErrorFooterTopFromPanelTopPx;
@@ -2005,7 +2005,7 @@ namespace engine::render
 				for (int32_t row = 0; row < 2; ++row)
 				{
 					const int32_t rowY = (row == 0) ? loginTwoRow.secondaryRowY : loginTwoRow.primaryRowY;
-					int32_t colX = contentX;
+					[[maybe_unused]] int32_t colX = contentX;
 					for (int32_t col = 0; col < 2; ++col)
 					{
 						const int32_t i = row * 2 + col;

--- a/src/client/render/ChatImGuiRenderer.cpp
+++ b/src/client/render/ChatImGuiRenderer.cpp
@@ -60,7 +60,7 @@ namespace engine::render
 		m_cfg = cfg;
 	}
 
-	void ChatImGuiRenderer::Render(float viewportW, float viewportH, bool inWorldShard)
+	void ChatImGuiRenderer::Render([[maybe_unused]] float viewportW, float viewportH, bool inWorldShard)
 	{
 		if (m_chat == nullptr || !m_chat->IsInitialized())
 			return;
@@ -240,9 +240,9 @@ namespace engine::render
 				ImGui::Text("> ");
 				ImGui::SameLine(0.f, 4.f);
 				ImGui::SetNextItemWidth(-FLT_MIN); // remplit la ligne restante
-				const ImGuiInputTextFlags flags = ImGuiInputTextFlags_EnterReturnsTrue
+				const ImGuiInputTextFlags inputFlags = ImGuiInputTextFlags_EnterReturnsTrue
 					| ImGuiInputTextFlags_AutoSelectAll;
-				if (ImGui::InputText("##ln_chat_input", m_inputBuf, sizeof(m_inputBuf), flags))
+				if (ImGui::InputText("##ln_chat_input", m_inputBuf, sizeof(m_inputBuf), inputFlags))
 				{
 					m_chat->SetInputLine(m_inputBuf);
 					m_chat->SubmitFromUi();

--- a/src/client/render/DecalPass.cpp
+++ b/src/client/render/DecalPass.cpp
@@ -83,7 +83,7 @@ namespace engine::render
 			std::array<VkDescriptorSetLayoutBinding, 2> bindings{};
 			for (size_t i = 0; i < bindings.size(); ++i)
 			{
-				bindings[i].binding = i;
+				bindings[i].binding = static_cast<uint32_t>(i);
 				bindings[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 				bindings[i].descriptorCount = 1;
 				bindings[i].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
@@ -385,7 +385,7 @@ namespace engine::render
 			{
 				writes[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
 				writes[i].dstSet = ds;
-				writes[i].dstBinding = i;
+				writes[i].dstBinding = static_cast<uint32_t>(i);
 				writes[i].descriptorCount = 1;
 				writes[i].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
 				writes[i].pImageInfo = &imageInfos[i];

--- a/src/client/render/FrameGraph.cpp
+++ b/src/client/render/FrameGraph.cpp
@@ -3,7 +3,13 @@
 #include "src/shared/core/Profiler.h"
 
 #include <vulkan/vulkan.h>
+#if defined(_MSC_VER)
+#pragma warning(push, 0) // en-tete tiers : silence les warnings
+#endif
 #include <vk_mem_alloc.h>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #include <algorithm>
 #include <cstdio>
@@ -758,7 +764,7 @@ namespace engine::render
 		}
 	}
 
-	void FrameGraph::ensureBufferResources(VkDevice device, void* vmaAllocator,
+	void FrameGraph::ensureBufferResources([[maybe_unused]] VkDevice device, void* vmaAllocator,
 		uint32_t frameIndex, uint32_t framesInFlight)
 	{
 		if (vmaAllocator == nullptr) return;

--- a/src/client/render/LootRollImGuiRenderer.cpp
+++ b/src/client/render/LootRollImGuiRenderer.cpp
@@ -64,7 +64,7 @@ namespace engine::render
 		const float panelW = 460.f;
 		const float panelH = 520.f;
 		const float margin = 24.f;
-		const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
+		[[maybe_unused]] const float vpW = (m_viewportW > 0) ? static_cast<float>(m_viewportW) : 1280.f;
 		const float vpH = (m_viewportH > 0) ? static_cast<float>(m_viewportH) : 720.f;
 		const float posX = std::max(0.f, margin);
 		const float posY = std::max(0.f, (vpH - panelH) * 0.5f);

--- a/src/client/render/auth/AuthUiRendererCore.cpp
+++ b/src/client/render/auth/AuthUiRendererCore.cpp
@@ -461,7 +461,7 @@ namespace engine::render
 		const int32_t contentX = layout.contentX;
 		const int32_t contentW = layout.contentW;
 		const int32_t artW = layout.artW;
-		const bool largeContent = layout.largeContent;
+		[[maybe_unused]] const bool largeContent = layout.largeContent;
 
 		auto addRect = [&layers](int32_t x, int32_t y, int32_t rw, int32_t rh, float r, float g, float b, float a)
 		{
@@ -952,7 +952,7 @@ namespace engine::render
 			for (int32_t row = 0; row < 2; ++row)
 			{
 				const int32_t rowY = (row == 0) ? loginTwoRow.secondaryRowY : loginTwoRow.primaryRowY;
-				int32_t colX = contentX;
+				[[maybe_unused]] int32_t colX = contentX;
 				for (int32_t col = 0; col < 2; ++col)
 				{
 					const int32_t i = row * 2 + col;

--- a/src/client/render/auth/screens/AuthImGuiOptions.cpp
+++ b/src/client/render/auth/screens/AuthImGuiOptions.cpp
@@ -403,7 +403,10 @@ namespace engine::render
 		if (m_optionsTab == 0)
 		{
 			sectionTitle("options.imgui.section.display");
-			const char* resItems = "1280x720\01600x900\01920x1080\02560x1440\03840x2160\0\0";
+			// Liste ImGui séparée par des NUL. Chaque item est un littéral distinct :
+			// sinon "\0" suivi d'un chiffre est lu comme échappement OCTAL (ex. "\016")
+			// et corrompt les séparateurs (bug C4125). La juxtaposition force un vrai NUL.
+			const char* resItems = "1280x720\0" "1600x900\0" "1920x1080\0" "2560x1440\0" "3840x2160\0";
 			const std::string resLab = tr("options.imgui.resolution");
 			if (ImGui::Combo(resLab.c_str(), &m_optResIdx, resItems))
 			{

--- a/src/client/render/skinned/SkinnedMeshLoader.cpp
+++ b/src/client/render/skinned/SkinnedMeshLoader.cpp
@@ -9,7 +9,13 @@
 // être défini que dans UN seul .cpp du projet ; aucune autre TU n'inclut
 // cgltf actuellement (vérifié à la création de Task 10).
 #define CGLTF_IMPLEMENTATION
+#if defined(_MSC_VER)
+#pragma warning(push, 0) // en-tete tiers : silence les warnings
+#endif
 #include "cgltf.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #include "src/shared/math/Quat.h"
 

--- a/src/client/render/static_mesh/StaticMeshLoader.cpp
+++ b/src/client/render/static_mesh/StaticMeshLoader.cpp
@@ -2,7 +2,13 @@
 
 // cgltf est défini (CGLTF_IMPLEMENTATION) une seule fois dans le projet, dans
 // SkinnedMeshLoader.cpp. Ici on n'inclut que les déclarations.
+#if defined(_MSC_VER)
+#pragma warning(push, 0) // en-tete tiers : silence les warnings
+#endif
 #include "cgltf.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #include "src/shared/core/Log.h"
 

--- a/src/client/render/terrain/TerrainRenderer.cpp
+++ b/src/client/render/terrain/TerrainRenderer.cpp
@@ -1755,8 +1755,8 @@ namespace engine::render::terrain
                 if (cliff.vertexBuffer == VK_NULL_HANDLE || cliff.indexBuffer == VK_NULL_HANDLE)
                     continue;
 
-                VkDeviceSize vbOffset = 0;
-                vkCmdBindVertexBuffers(cmd, 0, 1, &cliff.vertexBuffer, &vbOffset);
+                VkDeviceSize cliffVbOffset = 0;
+                vkCmdBindVertexBuffers(cmd, 0, 1, &cliff.vertexBuffer, &cliffVbOffset);
                 vkCmdBindIndexBuffer(cmd, cliff.indexBuffer, 0, VK_INDEX_TYPE_UINT16);
                 vkCmdDrawIndexed(cmd, cliff.indexCount, 1, 0, 0, 0);
             }

--- a/src/client/render/tests/WaterPassTests.cpp
+++ b/src/client/render/tests/WaterPassTests.cpp
@@ -3,6 +3,9 @@
 
 #include <cstddef>
 #include <cstdio>
+#if defined(_MSC_VER)
+#pragma warning(disable : 4127) // REQUIRE() sur expressions constantes (sizeof/offsetof) dans les tests
+#endif
 
 namespace
 {

--- a/src/client/render/vk/VkSwapchain.cpp
+++ b/src/client/render/vk/VkSwapchain.cpp
@@ -349,7 +349,7 @@ namespace engine::render
 		return desiredExtent.width != m_extent.width || desiredExtent.height != m_extent.height;
 	}
 
-	bool VkSwapchain::HasDegenerateSurfaceExtent(uint32_t requestedWidth, uint32_t requestedHeight) const
+	bool VkSwapchain::HasDegenerateSurfaceExtent([[maybe_unused]] uint32_t requestedWidth, uint32_t requestedHeight) const
 	{
 		if (m_physicalDevice == VK_NULL_HANDLE || m_surface == VK_NULL_HANDLE || m_swapchain == VK_NULL_HANDLE)
 		{

--- a/src/client/render/vk/VmaAllocator.cpp
+++ b/src/client/render/vk/VmaAllocator.cpp
@@ -2,4 +2,10 @@
 // Include path to vk_mem_alloc.h must be provided by CMake (VMA_SOURCE_DIR/include).
 #include <cstdio>
 
+#if defined(_MSC_VER)
+#pragma warning(push, 0) // en-tete tiers : silence les warnings
+#endif
 #include "vk_mem_alloc.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif

--- a/src/client/world/surface/tests/SurfaceTypeTests.cpp
+++ b/src/client/world/surface/tests/SurfaceTypeTests.cpp
@@ -3,6 +3,9 @@
 
 #include <cstdio>
 #include <cstring>
+#if defined(_MSC_VER)
+#pragma warning(disable : 4127) // REQUIRE() sur expressions constantes (sizeof/offsetof) dans les tests
+#endif
 
 namespace
 {

--- a/src/shardd/gameplay/trade/TradeSystem.cpp
+++ b/src/shardd/gameplay/trade/TradeSystem.cpp
@@ -334,7 +334,7 @@ namespace engine::server
 			outError = "not in a trade";
 			return TradeOpResult::NotInTrade;
 		}
-		RemoveSession(idx, "cancel");
+		RemoveSession(static_cast<uint32_t>(idx), "cancel");
 		return TradeOpResult::Ok;
 	}
 

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -8880,7 +8880,7 @@ namespace engine::server
 		return true;
 	}
 
-	void ServerApp::HandleTradeAccept(const Endpoint& endpoint, const TradeAcceptMessage& message)
+	void ServerApp::HandleTradeAccept(const Endpoint& endpoint, [[maybe_unused]] const TradeAcceptMessage& message)
 	{
 		ConnectedClient* acceptor = FindClient(endpoint);
 		if (acceptor == nullptr)
@@ -8905,7 +8905,7 @@ namespace engine::server
 		         acceptor->clientId, partnerClientId);
 	}
 
-	void ServerApp::HandleTradeDecline(const Endpoint& endpoint, const TradeDeclineMessage& message)
+	void ServerApp::HandleTradeDecline(const Endpoint& endpoint, [[maybe_unused]] const TradeDeclineMessage& message)
 	{
 		ConnectedClient* decliner = FindClient(endpoint);
 		if (decliner == nullptr)
@@ -8980,7 +8980,7 @@ namespace engine::server
 		BroadcastTradeWindowUpdate(caller->clientId, partnerClientId);
 	}
 
-	void ServerApp::HandleTradeLock(const Endpoint& endpoint, const TradeLockMessage& message)
+	void ServerApp::HandleTradeLock(const Endpoint& endpoint, [[maybe_unused]] const TradeLockMessage& message)
 	{
 		ConnectedClient* caller = FindClient(endpoint);
 		if (caller == nullptr)
@@ -9003,7 +9003,7 @@ namespace engine::server
 		BroadcastTradeWindowUpdate(caller->clientId, partnerClientId);
 	}
 
-	void ServerApp::HandleTradeConfirm(const Endpoint& endpoint, const TradeConfirmMessage& message)
+	void ServerApp::HandleTradeConfirm(const Endpoint& endpoint, [[maybe_unused]] const TradeConfirmMessage& message)
 	{
 		ConnectedClient* caller = FindClient(endpoint);
 		if (caller == nullptr)
@@ -9069,7 +9069,7 @@ namespace engine::server
 		}
 	}
 
-	void ServerApp::HandleTradeCancelPacket(const Endpoint& endpoint, const TradeCancelMessage& message)
+	void ServerApp::HandleTradeCancelPacket(const Endpoint& endpoint, [[maybe_unused]] const TradeCancelMessage& message)
 	{
 		ConnectedClient* caller = FindClient(endpoint);
 		if (caller == nullptr)
@@ -9248,7 +9248,7 @@ namespace engine::server
 		}
 	}
 
-	void ServerApp::HandleHarvestCancelRequest(const Endpoint& endpoint, const HarvestCancelRequestMessage& message)
+	void ServerApp::HandleHarvestCancelRequest(const Endpoint& endpoint, [[maybe_unused]] const HarvestCancelRequestMessage& message)
 	{
 		ConnectedClient* client = FindClient(endpoint);
 		if (client == nullptr)
@@ -9498,7 +9498,7 @@ namespace engine::server
 		}
 	}
 
-	void ServerApp::HandleCraftCancelRequest(const Endpoint& endpoint, const CraftCancelRequestMessage& message)
+	void ServerApp::HandleCraftCancelRequest(const Endpoint& endpoint, [[maybe_unused]] const CraftCancelRequestMessage& message)
 	{
 		ConnectedClient* client = FindClient(endpoint);
 		if (client == nullptr)


### PR DESCRIPTION
## Nettoyage des warnings de build

Suite au constat de nombreux warnings dans le build. Traite **~125 des 139** warnings.

### Corrections de fond (correctness / sécurité)
- **Troncatures `size_t → uint32_t` (`C4267`, perte de données possible)** — la préoccupation soulevée : `DecalPass` (`binding`/`dstBinding`) + `TradeSystem` (`RemoveSession`) → `static_cast<uint32_t>` explicite (indices petits, sûrs).
- **🐛 VRAI BUG (`C4125`)** — la liste de résolutions ImGui `"1280x720\01600x900\0…"` : un `\0` suivi d'un chiffre était interprété comme **échappement octal** (`\016` = caractère 14), **corrompant les séparateurs** de la combo (résolutions mal découpées). Corrigé en littéraux juxtaposés (`"…\0" "…\0"`), chaque `\0` étant alors un vrai NUL.
- **Noms locaux masqués (`C4456`)** — `TerrainRenderer` (`vbOffset`→`cliffVbOffset`), `ChatImGuiRenderer` (`flags`→`inputFlags`).

### Réduction de bruit
- **En-têtes tiers (~75 warnings)** — `vk_mem_alloc.h`, `cgltf.h`, `miniaudio.h` enveloppés dans `#pragma warning(push, 0)/pop` (gardé `_MSC_VER`), **sans éditer le code vendored**.
- **Params/variables inutilisés (`C4100`/`C4189`, ~22)** — attribut `[[maybe_unused]]` (non destructif, aucun changement de comportement).
- **`C4127` dans les tests de layout** (`REQUIRE` sur `sizeof`/`offsetof` = expressions constantes) — `#pragma warning(disable:4127)` en tête des fichiers de test concernés.

### Volontairement NON traité (chantier séparé)
- **`C4996` (~13)** — API dépréciées (OpenSSL `SHA256_*`, CRT). **Migration prudente requise** (crypto/CRT sensibles) — à faire dans une PR dédiée, pas en aveugle.
- 2 `C4127` hors tests + 1 `C4566` — mineurs.

### Comportement / déploiement
Aucun changement de comportement (les casts formalisent une conversion déjà implicite ; les attributs/pragmas n'affectent pas la génération de code). Fichiers serveur touchés (`ServerApp`/`TradeSystem`) mais **neutres**.
> **Déploiement** : ✅ neutre — pas de redéploiement serveur fonctionnel requis (aucun changement de protocole, gameplay ou schéma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)