### PR TITLE
fix(inventory): InventoryDelta envoie l'inventaire complet (butin cumulé non affiché)

### DIFF
--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -5925,22 +5925,32 @@ namespace engine::server
 			eventCount);
 	}
 
-	bool ServerApp::SendInventoryDelta(const ConnectedClient& receiver, std::span<const ItemStack> items)
+	bool ServerApp::SendInventoryDelta(const ConnectedClient& receiver, std::span<const ItemStack> changedItems)
 	{
+		// IMPORTANT — le client applique InventoryDelta comme un SNAPSHOT COMPLET
+		// (UIModelBinding::ApplyInventoryDelta fait `m_model.inventory = delta`, un
+		// remplacement total). On envoie donc TOUJOURS l'inventaire complet du joueur,
+		// jamais la seule liste des objets qui viennent de changer : sinon l'affichage
+		// est écrasé par le dernier delta partiel. Symptôme (bug corrigé ici) : le butin
+		// auto-loot de N sangliers n'affichait que le dernier kill (1 épée + 3 potions)
+		// au lieu du cumul (ex. 12 + 36), alors que l'inventaire serveur était correct.
+		// `changedItems` ne sert plus qu'au log (nombre d'objets modifiés).
 		InventoryDeltaMessage message{};
 		message.clientId = receiver.clientId;
-		const std::vector<std::byte> packet = EncodeInventoryDelta(message, items);
+		const std::vector<std::byte> packet = EncodeInventoryDelta(message, receiver.inventory);
 		if (!m_transport.Send(receiver.endpoint, packet))
 		{
-			LOG_WARN(Net, "[ServerApp] InventoryDelta send failed (client_id={}, item_count={})",
+			LOG_WARN(Net, "[ServerApp] InventoryDelta send failed (client_id={}, changed={}, total={})",
 				receiver.clientId,
-				items.size());
+				changedItems.size(),
+				receiver.inventory.size());
 			return false;
 		}
 
-		LOG_INFO(Net, "[ServerApp] InventoryDelta sent (client_id={}, item_count={})",
+		LOG_INFO(Net, "[ServerApp] InventoryDelta sent (client_id={}, changed={}, total={})",
 			receiver.clientId,
-			items.size());
+			changedItems.size(),
+			receiver.inventory.size());
 		return true;
 	}
 


### PR DESCRIPTION
## Anomalie : le butin cumulé ne s'affiche pas dans l'inventaire

Constaté en jeu : après avoir tué ~12 sangliers (chacun lâche 1 Rusty Sword + 3 Minor Potions en auto-loot), l'inventaire n'affichait que **1 + 3** (le dernier kill) au lieu de **12 + 36**. La fenêtre « Butin » annonçait pourtant bien les bons totaux.

### Ce n'est PAS une récompense de quête
Vérifié dans `quest_definitions.json` : les quêtes récompensent XP/or + 1 « Quest Relic » (3001) — jamais Rusty Sword/Minor Potion. Ces objets viennent du **butin de kill** (table `loot_tables.txt` : mob 100 → `2001 x1` + `2002 x3` par sanglier).

### Cause racine
Le client applique `InventoryDelta` comme un **snapshot complet** :
```cpp
// UIModelBinding::ApplyInventoryDelta
m_model.inventory = m_inventoryScratch; // remplacement TOTAL
```
Mais la plupart des chemins serveur (`AutoLootMobToKiller`, `HandlePickupRequest`, `GrantQuestReward`, récompenses d'événement, commerce…) n'envoyaient que **les objets qui venaient de changer**. Chaque delta partiel **écrasait** donc l'inventaire affiché → seul le dernier kill restait visible. L'inventaire **serveur** était correct (`AddItemToInventory` empile bien) ; seul l'affichage client était faux.

### Correctif
`SendInventoryDelta` encode désormais **toujours `receiver.inventory`** (l'inventaire complet) au lieu de la liste partielle reçue. Comme c'est le **seul point d'encodage** d'`InventoryDelta`, ça corrige **tous** les appelants d'un coup (auto-loot, pickup, quêtes, événements, commerce, équipement).

- **Wire inchangé** (le client remplaçait déjà tout) → pas de bump protocole.
- Payload marginalement plus gros (inventaire complet vs delta), négligeable.

### Déploiement
> **Déploiement** : ⚠️ **redéploiement shard requis** (le shard émet le payload corrigé). **Client inchangé.** Après déploiement, l'inventaire affiche le cumul réel ; un relog l'aurait d'ailleurs déjà montré (la donnée serveur/persistée était correcte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)