### PR TITLE
chore(warnings): round 2 — élimine les warnings restants

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -7095,7 +7095,7 @@ namespace engine
 																break;
 															}
 															LOG_INFO(Render,
-																"[CopyPresent] auth fond: blit {}x{} → {}x{} fit={} (log unique; blit chaque frame)",
+																"[CopyPresent] auth fond: blit {}x{} -> {}x{} fit={} (log unique; blit chaque frame)",
 																bgTex->width,
 																bgTex->height,
 																ext.width,

--- a/src/client/auth/AuthUiPresenterCore.cpp
+++ b/src/client/auth/AuthUiPresenterCore.cpp
@@ -844,7 +844,14 @@ namespace engine::client
 		std::string_view CountryCodeAt(int idx)
 		{
 			const int n = static_cast<int>(kCountryCodes.size());
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4127) // n derive d une table de taille compile-time (garde defensive)
+#endif
 			if (n == 0) return "FR";
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 			return kCountryCodes[static_cast<size_t>(((idx % n) + n) % n)];
 		}
 

--- a/src/client/auth/screens/AuthScreenRegister.cpp
+++ b/src/client/auth/screens/AuthScreenRegister.cpp
@@ -80,10 +80,17 @@ namespace
 	std::string_view CountryCodeAt(int idx)
 	{
 		const int n = static_cast<int>(kCountryCodes.size());
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4127) // n derive d une table de taille compile-time (garde defensive)
+#endif
 		if (n == 0)
 		{
 			return "FR";
 		}
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 		return kCountryCodes[static_cast<size_t>(((idx % n) + n) % n)];
 	}
 

--- a/src/client/localization/LocalizationService.cpp
+++ b/src/client/localization/LocalizationService.cpp
@@ -7,6 +7,9 @@
 #include <cctype>
 #include <cstdlib>
 #include <filesystem>
+#if defined(_MSC_VER)
+#pragma warning(disable : 4996) // getenv (lecture var env, sur) ; deprecation CRT MSVC
+#endif
 
 #if defined(_WIN32)
 #	define WIN32_LEAN_AND_MEAN

--- a/src/client/render/ShaderCompiler.cpp
+++ b/src/client/render/ShaderCompiler.cpp
@@ -5,6 +5,9 @@
 #include <cstdlib>
 #include <fstream>
 #include <filesystem>
+#if defined(_MSC_VER)
+#pragma warning(disable : 4996) // getenv (lecture var env, sur) ; deprecation CRT MSVC
+#endif
 
 namespace engine::render
 {

--- a/src/shared/auth/Argon2Hash.cpp
+++ b/src/shared/auth/Argon2Hash.cpp
@@ -5,6 +5,9 @@
 #include <openssl/sha.h>
 #include <cstring>
 #include <string>
+#if defined(_MSC_VER)
+#pragma warning(disable : 4996) // OpenSSL SHA256_* (deprecation OpenSSL 3.0, API retenue deliberement ; migration EVP = chantier separe)
+#endif
 
 namespace engine::auth
 {

--- a/src/shared/security/SecurityAuditLog.cpp
+++ b/src/shared/security/SecurityAuditLog.cpp
@@ -21,7 +21,15 @@ namespace engine::server
 		auto now = std::chrono::system_clock::now();
 		auto t = std::chrono::system_clock::to_time_t(now);
 		char buf[32];
-		std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&t));
+		// gmtime_s/gmtime_r : variante THREAD-SAFE (std::gmtime renvoie un buffer
+		// statique partagé — course de données ; d'où le C4996 sous MSVC).
+		std::tm tmUtc{};
+#if defined(_WIN32)
+		gmtime_s(&tmUtc, &t);
+#else
+		gmtime_r(&t, &tmUtc);
+#endif
+		std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tmUtc);
 		return std::string(buf);
 	}
 

--- a/src/shared/security/SharedSecretPolicy.cpp
+++ b/src/shared/security/SharedSecretPolicy.cpp
@@ -3,6 +3,9 @@
 #include <array>
 #include <cstdlib>
 #include <string_view>
+#if defined(_MSC_VER)
+#pragma warning(disable : 4996) // getenv (lecture var env, sur) ; deprecation CRT MSVC
+#endif
 
 namespace engine::security
 {

--- a/src/world_editor/routine/RoutineNodeInspector.cpp
+++ b/src/world_editor/routine/RoutineNodeInspector.cpp
@@ -6,6 +6,9 @@
 #include "src/world_editor/routine/RoutineGraphCommands.h"
 #include "src/world_editor/routine/RoutineGraphDocument.h"
 #include "src/shared/routine/RoutineNodeSchema.h"
+#if defined(_MSC_VER)
+#pragma warning(disable : 4996) // strncpy borne + termine manuellement (usage correct) ; deprecation CRT MSVC
+#endif
 
 #if defined(_WIN32)
 #	include "imgui.h"

--- a/src/world_editor/tests/ExportZoneTests.cpp
+++ b/src/world_editor/tests/ExportZoneTests.cpp
@@ -88,7 +88,7 @@ namespace
 		};
 		// Triangle (0,0)-(10,0)-(0,10) : contient id 1, pas 2 (au-dessus de
 		// l'hypoténuse x+z<=10 ? 2+8=10 → sur la limite, exclu), pas 3.
-		std::vector<std::pair<float, float>> poly = { {0,0}, {10,0}, {0,10} };
+		std::vector<std::pair<float, float>> poly = { {0.f,0.f}, {10.f,0.f}, {0.f,10.f} };
 		auto sel = SelectInLasso(pts, poly);
 		bool has1 = false, has3 = false;
 		for (uint32_t id : sel) { if (id == 1) has1 = true; if (id == 3) has3 = true; }
@@ -96,7 +96,7 @@ namespace
 		REQUIRE(!has3);
 
 		// Polygone dégénéré (< 3 sommets) → rien.
-		std::vector<std::pair<float, float>> deg = { {0,0}, {1,1} };
+		std::vector<std::pair<float, float>> deg = { {0.f,0.f}, {1.f,1.f} };
 		REQUIRE(SelectInLasso(pts, deg).empty());
 	}
 

--- a/tools/impostor_builder/GltfMeshLoader.cpp
+++ b/tools/impostor_builder/GltfMeshLoader.cpp
@@ -3,10 +3,22 @@
 /// .cpp (unique TU pour chaque bibliothèque header-only).
 
 #define CGLTF_IMPLEMENTATION
+#if defined(_MSC_VER)
+#pragma warning(push, 0) // en-tete tiers : silence les warnings
+#endif
 #include "cgltf.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #define STB_IMAGE_IMPLEMENTATION
+#if defined(_MSC_VER)
+#pragma warning(push, 0) // en-tete tiers : silence les warnings
+#endif
 #include "stb_image.h"
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #include "GltfMeshLoader.h"
 

--- a/tools/migration_checksum/main.cpp
+++ b/tools/migration_checksum/main.cpp
@@ -13,6 +13,9 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#if defined(_MSC_VER)
+#pragma warning(disable : 4996) // OpenSSL SHA256_* (deprecation OpenSSL 3.0 ; outil de checksum de migration)
+#endif
 
 namespace fs = std::filesystem;
 


### PR DESCRIPTION
## Nettoyage warnings — round 2 (suite de #969)

Traite les **~47 warnings restants** sur `main` après #969.

### Corrections de fond
- **`C4244` (18) — les conversions « taille » qui restaient** : `ExportZoneTests` initialisait des `std::pair<float,float>` avec des **littéraux entiers** (`{0,0}`, `{10,0}`…) → conversion `int→float`. Corrigé en littéraux flottants (`{0.f,0.f}`…), ce qui supprime l'instanciation `std::pair<float,float>(int,int)` à l'origine des 18 warnings.
- **`C4996` `gmtime` (SecurityAuditLog) — 🔒 vrai fix thread-safety** : `std::gmtime` renvoie un buffer statique partagé (course de données). Remplacé par `gmtime_s` (Windows) / `gmtime_r` (POSIX).
- **`C4566` (Engine)** : flèche Unicode `→` dans un log narrow → `->` ASCII.

### Suppressions locales documentées (APIs délibérées)
- **`C4996` restants** (`strncpy` borné+terminé correctement, `getenv` lecture d'env, OpenSSL `SHA256_*`) : `#pragma warning(disable:4996)` local et **commenté par fichier**. La migration OpenSSL `SHA256_*` → EVP est un **chantier séparé** (crypto — pas fait en aveugle).
- **`C4127` (2)** : gardes défensives `if (n == 0)` sur une table de taille compile-time → `#pragma warning(push/disable:4127/pop)` gardé `_MSC_VER`.

### Résultat attendu
Build **quasi sans warning** (139 → ~0 sur les deux rounds). Restera éventuellement quelques warnings tiers non couverts, à vérifier sur la CI.

### Déploiement
> **Déploiement** : ✅ neutre — comportement inchangé (`gmtime` : même sortie, juste thread-safe). Aucun changement protocole/gameplay/schéma, pas de redéploiement fonctionnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)