### PR TITLE
ci(windows): jobs parallèles par composant (client / éditeur+carte / serveur)

### DIFF
--- a/.github/scripts/package-windows.ps1
+++ b/.github/scripts/package-windows.ps1
@@ -1,0 +1,108 @@
+# Helpers de packaging pour build-windows.yml (jobs parallèles client/editor/server).
+# Factorise la collecte des artefacts, appelé via `. package-windows.ps1` puis
+# les fonctions ci-dessous. Chaque job ne package que ce dont il a besoin.
+#
+# Principe : CMake déploie déjà les DLL runtime (glfw3, vulkan-1, libssl/libcrypto)
+# À CÔTÉ de chaque exe (steps « deploying dependencies »). On copie donc l'exe + les
+# DLL de son dossier, puis on ajoute les redistribuables MSVC + ucrt (que CMake ne
+# déploie pas), et enfin les données/config selon le composant.
+
+$ErrorActionPreference = "Stop"
+$Artifacts = Join-Path $env:GITHUB_WORKSPACE "artifacts"
+
+function Initialize-Artifacts {
+    New-Item -ItemType Directory -Force -Path $Artifacts | Out-Null
+}
+
+# Copie les exécutables nommés (trouvés sous build/, hors vcpkg/Debug/tests) +
+# les DLL déjà déployées par CMake dans le dossier de chaque exe.
+function Copy-ArtifactExes {
+    param([Parameter(Mandatory = $true)][string[]]$Names)
+    Initialize-Artifacts
+    foreach ($name in $Names) {
+        $exe = Get-ChildItem -Recurse -Path "$env:GITHUB_WORKSPACE\build" -Filter $name -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -notlike "*\vcpkg\*" -and $_.FullName -notlike "*\Debug\*" -and $_.FullName -notlike "*\debug\*" } |
+            Select-Object -First 1
+        if (-not $exe) { throw "[package] Exécutable introuvable : $name" }
+        Copy-Item $exe.FullName -Destination $Artifacts -Force
+        # DLL runtime déployées par CMake à côté de l'exe.
+        Get-ChildItem -Path $exe.DirectoryName -Filter *.dll -ErrorAction SilentlyContinue |
+            Copy-Item -Destination $Artifacts -Force
+        Write-Host "[package] exe : $($exe.FullName)"
+    }
+}
+
+# Redistribuables MSVC + ucrt (non déployés par CMake) + filet de sécurité pour
+# les DLL vcpkg (ssl/crypto/glfw/vulkan) au cas où un exe n'aurait rien à côté.
+# Le switch -IncludeGraphics est accepté pour lisibilité mais les DLL graphiques
+# sont copiées de toute façon (inoffensif pour le serveur).
+function Copy-RuntimeDlls {
+    param([switch]$IncludeGraphics)
+    Initialize-Artifacts
+
+    # MSVC redist (Release, x64).
+    $vcRedistBase = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC"
+    foreach ($dll in @("MSVCP140.dll", "VCRUNTIME140.dll", "VCRUNTIME140_1.dll")) {
+        $found = Get-ChildItem -Recurse -Path $vcRedistBase -Filter $dll -ErrorAction SilentlyContinue |
+            Where-Object { $_.FullName -like "*x64*" -and $_.FullName -notlike "*debug_nonredist*" -and $_.FullName -notlike "*onecore*" } |
+            Select-Object -First 1
+        if ($found) { Copy-Item $found.FullName -Destination $Artifacts -Force }
+    }
+
+    # ucrtbase (System32).
+    $ucrt = "C:\Windows\System32\ucrtbase.dll"
+    if (Test-Path $ucrt) { Copy-Item $ucrt -Destination $Artifacts -Force }
+
+    # Filet de sécurité : DLL vcpkg (si absentes à côté de l'exe).
+    $vcpkgBinCandidates = @(
+        (Join-Path $env:VCPKG_ROOT "installed\$env:VCPKG_DEFAULT_TRIPLET\bin"),
+        (Join-Path $env:GITHUB_WORKSPACE "build\vs2022-x64\vcpkg_installed\$env:VCPKG_DEFAULT_TRIPLET\bin"),
+        (Join-Path $env:GITHUB_WORKSPACE "build\vs2022-x64\vcpkg_installed\x64-windows\bin")
+    )
+    $vcpkgDlls = @("libssl-3-x64.dll", "libcrypto-3-x64.dll", "glfw3.dll", "vulkan-1.dll")
+    foreach ($bin in $vcpkgBinCandidates) {
+        if (-not (Test-Path $bin)) { continue }
+        foreach ($dll in $vcpkgDlls) {
+            $src = Join-Path $bin $dll
+            if ((Test-Path $src) -and -not (Test-Path (Join-Path $Artifacts $dll))) {
+                Copy-Item $src -Destination $Artifacts -Force
+            }
+        }
+    }
+}
+
+# game/data (assets, shaders SPIR-V, icônes LFS) -> artifacts/game/data.
+function Copy-GameData {
+    Initialize-Artifacts
+    $src = Join-Path $env:GITHUB_WORKSPACE "game\data"
+    if (Test-Path $src) {
+        Copy-Item -Recurse -Path $src -Destination (Join-Path $Artifacts "game\data") -Force
+    }
+}
+
+# Config côté client/éditeur : config.json racine + config/server.ini + build_hlod.bat.
+function Copy-ClientConfig {
+    Initialize-Artifacts
+    $config = Join-Path $env:GITHUB_WORKSPACE "config.json"
+    if (Test-Path $config) { Copy-Item $config -Destination $Artifacts -Force }
+    Copy-ServerIni
+    $buildHlod = Join-Path $env:GITHUB_WORKSPACE "build_hlod.bat"
+    if (Test-Path $buildHlod) { Copy-Item $buildHlod -Destination $Artifacts -Force }
+}
+
+# Config côté serveur : config.json + config/server.ini.
+function Copy-ServerConfig {
+    Initialize-Artifacts
+    $config = Join-Path $env:GITHUB_WORKSPACE "config.json"
+    if (Test-Path $config) { Copy-Item $config -Destination $Artifacts -Force }
+    Copy-ServerIni
+}
+
+# config/server.ini (endpoints master runtime) -> artifacts/config/.
+function Copy-ServerIni {
+    $serverIni = Join-Path $env:GITHUB_WORKSPACE "config\server.ini"
+    if (Test-Path $serverIni) {
+        New-Item -ItemType Directory -Force -Path (Join-Path $Artifacts "config") | Out-Null
+        Copy-Item $serverIni -Destination (Join-Path $Artifacts "config") -Force
+    }
+}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,79 +1,83 @@
-# Build engine (Windows, CMake + vcpkg + Ninja)
+# Build engine (Windows, CMake + vcpkg + MSBuild)
+#
+# Découpé en JOBS PARALLÈLES par composant (retour utilisateur 2026-07-11) :
+#   - client        : le jeu (engine_app -> lcdlln.exe)
+#   - editor        : l'éditeur de monde + le constructeur de carte
+#                     (world_editor_app -> lcdlln_world_editor.exe, zone_builder)
+#   - server-tools  : le serveur + les outils (server_app + migration/hlod/…)
+#
+# Pourquoi c'est plus rapide que l'ancien job unique : chaque job ne compile
+# QUE sa cible (pas les ~100 exécutables de test, qui sont validés par ctest
+# dans build-linux). Les jobs tournent en parallèle -> temps « au mur » réduit.
+#
+# Cache : on persiste le dépôt d'ARCHIVES BINAIRES de vcpkg
+# (%LOCALAPPDATA%\vcpkg\archives). C'est le cache natif de vcpkg, clé par ABI :
+# OpenSSL/Vulkan/glfw ne sont recompilés qu'au 1er run (~8 min), puis restaurés
+# (~1 min) pour tous les jobs et tous les runs suivants. Le SDK Vulkan
+# (glslangValidator) est aussi caché.
+#
+# Contrepartie assumée : `engine_core` (bibliothèque partagée) est reconstruit
+# dans chaque job -> plus de minutes facturées, mais chaque job reste plus court
+# que l'ancien build monolithique.
 name: Build Windows
 on:
   push:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+
+env:
+  VCPKG_DEFAULT_TRIPLET: x64-windows-release
+
 jobs:
-  build-windows:
-    # Epingle sur windows-2022 (= Visual Studio 2022 / v17). L'image `windows-latest`
-    # a derive vers Visual Studio 18, que le generateur CMake "Visual Studio 17 2022"
-    # (CMakePresets.json, preset vs2022-x64) ne trouve pas -> echec a la configuration.
+  # ---------------------------------------------------------------------------
+  # CLIENT (jeu)
+  # ---------------------------------------------------------------------------
+  client:
+    name: Client (jeu)
     runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          # Récupère les fichiers Git LFS (icônes de compétences
-          # game/data/icons/skills/**/*.png) pour qu'ils soient empaquetés dans
-          # l'artefact client. Sans ça, seuls les pointeurs LFS seraient copiés et
-          # le rendu retomberait sur le texte.
+          # LFS : icônes de compétences (game/data/icons/skills/**/*.png)
+          # empaquetées dans l'artefact ; sinon seuls les pointeurs LFS seraient copiés.
           lfs: true
 
-      - name: Clone vcpkg
-        shell: pwsh
-        run: git clone https://github.com/Microsoft/vcpkg.git "$env:GITHUB_WORKSPACE\vcpkg"
+      # Cache natif de vcpkg (archives binaires ABI-keyed). Partagé entre jobs/runs.
+      - name: Cache vcpkg binary archives
+        uses: actions/cache@v5
+        with:
+          path: ~\AppData\Local\vcpkg\archives
+          key: vcpkg-archives-windows-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-archives-windows-
 
-      - name: Bootstrap vcpkg
+      - name: Clone + bootstrap vcpkg
         shell: pwsh
         run: |
+          git clone https://github.com/Microsoft/vcpkg.git "$env:GITHUB_WORKSPACE\vcpkg"
           & "$env:GITHUB_WORKSPACE\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
 
       - name: Configure
         shell: pwsh
         env:
           VCPKG_ROOT: ${{ github.workspace }}\vcpkg
-          VCPKG_DEFAULT_TRIPLET: x64-windows-release
-        run: |
-          cmake --preset vs2022-x64
+        run: cmake --preset vs2022-x64
 
-      - name: Build (Release)
+      - name: Build (client uniquement — engine_app)
         shell: pwsh
         env:
           VCPKG_ROOT: ${{ github.workspace }}\vcpkg
-        run: |
-          cmake --build --preset vs2022-x64-release
+        run: cmake --build --preset vs2022-x64-release --target engine_app
 
-      # Lot H : garde explicite que le World Editor compile au même titre que le jeu.
-      # Si une régression casse uniquement la cible world_editor_app, ce step échoue alors que
-      # le step précédent (qui construit toutes les cibles) pourrait masquer le diagnostic.
-      - name: Build explicite — cible world_editor_app
-        shell: pwsh
-        env:
-          VCPKG_ROOT: ${{ github.workspace }}\vcpkg
-        run: |
-          cmake --build --preset vs2022-x64-release --target world_editor_app
-
-      - name: Vérifie présence des deux exécutables (jeu + éditeur)
+      - name: Vérifie présence de l'exécutable jeu
         shell: pwsh
         run: |
-          $errors = @()
-          $engineExe = Get-ChildItem -Recurse -Path "$env:GITHUB_WORKSPACE\build" -Filter "lcdlln*.exe" `
-            -ErrorAction SilentlyContinue | Where-Object { $_.Name -ne "lcdlln_world_editor.exe" } | Select-Object -First 1
-          $editorExe = Get-ChildItem -Recurse -Path "$env:GITHUB_WORKSPACE\build" -Filter "lcdlln_world_editor.exe" `
-            -ErrorAction SilentlyContinue | Select-Object -First 1
-          if (-not $engineExe) { $errors += "Game executable (lcdlln*.exe non-editor) introuvable" }
-          if (-not $editorExe) { $errors += "Editor executable (lcdlln_world_editor.exe) introuvable" }
-          if ($errors.Count -gt 0) {
-            Write-Host "[FAIL] Build verification failed:"
-            $errors | ForEach-Object { Write-Host "  - $_" }
-            exit 1
-          }
-          Write-Host "[OK] Game exe   : $($engineExe.FullName)"
-          Write-Host "[OK] Editor exe : $($editorExe.FullName)"
+          $exe = Get-ChildItem -Recurse -Path "$env:GITHUB_WORKSPACE\build" -Filter "lcdlln.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $exe) { Write-Host "[FAIL] lcdlln.exe introuvable"; exit 1 }
+          Write-Host "[OK] Game exe : $($exe.FullName)"
 
-      # Les .spv ne sont pas versionnés (sources GLSL seulement) ; le moteur charge uniquement le SPIR-V depuis game/data/shaders/.
       - name: Cache Vulkan SDK (glslangValidator)
         id: vk-sdk-cache
         uses: actions/cache@v5
@@ -91,13 +95,11 @@ jobs:
           New-Item -ItemType Directory -Force -Path "C:\VulkanSDK" | Out-Null
           $url = "https://sdk.lunarg.com/sdk/download/$sdkVer/windows/VulkanSDK-$sdkVer-Installer.exe"
           $inst = Join-Path $env:TEMP "VulkanSDK-$sdkVer-Installer.exe"
-          Write-Host "Downloading $url"
           Invoke-WebRequest -Uri $url -OutFile $inst -UseBasicParsing
-          Write-Host "Installing Vulkan SDK to $root ..."
           $p = Start-Process -FilePath $inst -ArgumentList @("--root", $root, "--accept-licenses", "--default-answer", "--confirm-command", "install") -Wait -PassThru -NoNewWindow
           if ($p.ExitCode -ne 0) { throw "Vulkan SDK installer exit code $($p.ExitCode)" }
 
-      - name: Compile GLSL to SPIR-V (game/data/shaders)
+      - name: Compile GLSL to SPIR-V
         shell: pwsh
         env:
           VULKAN_SDK: C:\VulkanSDK\1.3.296.0
@@ -107,128 +109,189 @@ jobs:
           if (-not (Test-Path -LiteralPath $glsl)) { throw "Missing $glsl" }
           & "${{ github.workspace }}\tools\compile_game_shaders.ps1" -ShaderDir "${{ github.workspace }}\game\data\shaders"
 
-      - name: Collect artifacts
+      - name: Package (jeu)
         shell: pwsh
         env:
           VCPKG_ROOT: ${{ github.workspace }}\vcpkg
-          VCPKG_DEFAULT_TRIPLET: x64-windows-release
         run: |
-          New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\artifacts"
+          . "${{ github.workspace }}\.github\scripts\package-windows.ps1"
+          Copy-ArtifactExes -Names @("lcdlln.exe")
+          Copy-RuntimeDlls -IncludeGraphics
+          Copy-GameData
+          Copy-ClientConfig
 
-          # Copie les binaires produits (hors vcpkg et hors debug) "*.exe" "*.dll" "*.pdb" 
-          # Filtres successifs :
-          #  - vcpkg, debug : sources externes ou builds debug, pas du release
-          #  - *_tests.exe : test executables (tournent en ctest, pas a shipper)
-          #  - CompilerId*.exe : fichiers cmake pour detection compilo
-          #  - VmaSample* : sample du Vulkan Memory Allocator (dependance externe)
-          #  - client_flow_app.exe : test d'integration headless, pas outil utilisateur
-          # Ce qui reste : lcdlln.exe, lcdlln_world_editor.exe, lcdlln_server.exe,
-          # zone_builder.exe, hlod_builder.exe, migration_checksum.exe,
-          # gen_terrain_placeholders.exe, load_tester.exe + DLLs.
-          Get-ChildItem -Recurse -Path "$env:GITHUB_WORKSPACE" `
-            -Include "*.exe","*.dll" |
-            Where-Object {
-              $_.FullName -notlike "*\vcpkg\*" -and
-              $_.FullName -notlike "*\debug\*" -and
-              $_.FullName -notlike "*\Debug\*" -and
-              $_.Name -notlike "*_tests.exe" -and
-              $_.Name -notlike "CompilerId*.exe" -and
-              $_.Name -notlike "VmaSample*" -and
-              $_.Name -ne "client_flow_app.exe"
-            } |
-            Copy-Item -Destination "$env:GITHUB_WORKSPACE\artifacts" -Force
-
-          # NB : ex-step "assets/" supprime suite a la migration des 2 JSONs
-          # (surface_table, layer_palette) vers game/data/. Le top-level
-          # assets/ n'existe plus. game/data/ est copie plus bas et inclut
-          # desormais ces fichiers.
-
-          # Copie les DLLs MSVC Release depuis VS Redist
-          $vcRedistBase = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Redist\MSVC"
-          $dlls = @("MSVCP140.dll", "VCRUNTIME140.dll", "VCRUNTIME140_1.dll", "LIBCRYPTO-3-X64.dll", "LIBSSL-3-X64.dll")
-          foreach ($dll in $dlls) {
-            $found = Get-ChildItem -Recurse -Path $vcRedistBase -Filter $dll `
-              -ErrorAction SilentlyContinue |
-              Where-Object {
-                $_.FullName -like "*x64*" -and
-                $_.FullName -notlike "*debug_nonredist*" -and
-                $_.FullName -notlike "*onecore*"
-              } |
-              Select-Object -First 1
-            if ($found) {
-              Copy-Item $found.FullName -Destination "$env:GITHUB_WORKSPACE\artifacts" -Force
-            }
-          }
-
-          # Copie ucrtbase.dll depuis System32
-          $ucrt = "C:\Windows\System32\ucrtbase.dll"
-          if (Test-Path $ucrt) {
-            Copy-Item $ucrt -Destination "$env:GITHUB_WORKSPACE\artifacts" -Force
-          }
-
-          # OpenSSL (vcpkg, lien dynamique) — même principe que les redist MSVC
-          $osslDlls = @("libssl-3-x64.dll", "libcrypto-3-x64.dll")
-          # vcpkg peut placer les binaires soit sous $VCPKG_ROOT/installed, soit sous le dossier vcpkg intégré au build.
-          $osslBinCandidates = @(
-            (Join-Path $env:VCPKG_ROOT "installed\$env:VCPKG_DEFAULT_TRIPLET\bin"),
-            (Join-Path $env:GITHUB_WORKSPACE "build\vs2022-x64\vcpkg_installed\$env:VCPKG_DEFAULT_TRIPLET\bin"),
-            (Join-Path $env:GITHUB_WORKSPACE "build\vs2022-x64\vcpkg_installed\x64-windows\bin")
-          )
-
-          $copiedAny = $false
-          foreach ($osslBin in $osslBinCandidates) {
-            if (-not (Test-Path $osslBin)) { continue }
-            foreach ($dll in $osslDlls) {
-              $src = Join-Path $osslBin $dll
-              if (Test-Path $src) {
-                Copy-Item $src -Destination "$env:GITHUB_WORKSPACE\artifacts" -Force
-                $copiedAny = $true
-              }
-            }
-          }
-
-          foreach ($dll in $osslDlls) {
-            $dst = Join-Path $env:GITHUB_WORKSPACE\artifacts $dll
-            if (Test-Path $dst) {
-              Write-Host "[OpenSSL] Copied $dll to artifacts/"
-            } else {
-              Write-Host "[OpenSSL] MISSING $dll in artifacts/"
-            }
-          }
-
-          # game/data
-          $gameDataSource = "$env:GITHUB_WORKSPACE\game\data"
-          if (Test-Path $gameDataSource) {
-            Copy-Item -Recurse -Path $gameDataSource `
-              -Destination "$env:GITHUB_WORKSPACE\artifacts\game\data" -Force
-          }
-          
-          # config.json à la racine (si présent)
-          $config = "$env:GITHUB_WORKSPACE\config.json"
-          if (Test-Path $config) {
-            Copy-Item $config -Destination "$env:GITHUB_WORKSPACE\artifacts" -Force
-          }
-
-          # config/server.ini : source runtime des endpoints master (host TCP/HTTPS,
-          # origine HTTP embarquee, sonde /status, portail). Charge a cote de l'exe par
-          # Config.cpp ; auto-recree avec les defauts s'il est absent (ServerEndpoints).
-          # En le packageant ici, l'environnement se change en editant ce seul fichier.
-          $serverIni = "$env:GITHUB_WORKSPACE\config\server.ini"
-          if (Test-Path $serverIni) {
-            New-Item -ItemType Directory -Force -Path "$env:GITHUB_WORKSPACE\artifacts\config" | Out-Null
-            Copy-Item $serverIni -Destination "$env:GITHUB_WORKSPACE\artifacts\config" -Force
-          }
-
-          # build_hlod.bat à la racine du package de livraison (si présent)
-          $buildHlod = "$env:GITHUB_WORKSPACE\build_hlod.bat"
-          if (Test-Path $buildHlod) {
-            Copy-Item $buildHlod -Destination "$env:GITHUB_WORKSPACE\artifacts" -Force
-          }
-
-      - name: Upload artifacts
+      - name: Upload artifact (jeu)
         uses: actions/upload-artifact@v6
         with:
-          name: windows-release-${{ github.sha }}
+          name: windows-client-${{ github.sha }}
+          path: artifacts/
+          if-no-files-found: error
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # ÉDITEUR DE MONDE + CONSTRUCTEUR DE CARTE
+  # ---------------------------------------------------------------------------
+  editor:
+    name: Editeur + carte
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Cache vcpkg binary archives
+        uses: actions/cache@v5
+        with:
+          path: ~\AppData\Local\vcpkg\archives
+          key: vcpkg-archives-windows-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-archives-windows-
+
+      - name: Clone + bootstrap vcpkg
+        shell: pwsh
+        run: |
+          git clone https://github.com/Microsoft/vcpkg.git "$env:GITHUB_WORKSPACE\vcpkg"
+          & "$env:GITHUB_WORKSPACE\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
+
+      - name: Configure
+        shell: pwsh
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+        run: cmake --preset vs2022-x64
+
+      - name: Build (éditeur + carte — world_editor_app, zone_builder)
+        shell: pwsh
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+        run: |
+          cmake --build --preset vs2022-x64-release --target world_editor_app
+          cmake --build --preset vs2022-x64-release --target zone_builder
+
+      - name: Vérifie présence des exécutables (éditeur + carte)
+        shell: pwsh
+        run: |
+          $ed = Get-ChildItem -Recurse -Path "$env:GITHUB_WORKSPACE\build" -Filter "lcdlln_world_editor.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          $zb = Get-ChildItem -Recurse -Path "$env:GITHUB_WORKSPACE\build" -Filter "zone_builder.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $ed) { Write-Host "[FAIL] lcdlln_world_editor.exe introuvable"; exit 1 }
+          if (-not $zb) { Write-Host "[FAIL] zone_builder.exe introuvable"; exit 1 }
+          Write-Host "[OK] Editor : $($ed.FullName)"
+          Write-Host "[OK] Carte  : $($zb.FullName)"
+
+      - name: Cache Vulkan SDK (glslangValidator)
+        id: vk-sdk-cache
+        uses: actions/cache@v5
+        with:
+          path: C:\VulkanSDK\1.3.296.0
+          key: lunarg-vulkan-sdk-1.3.296.0-windows-x64-glslang
+
+      - name: Install Vulkan SDK (prebuilt, silent)
+        if: steps.vk-sdk-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $sdkVer = "1.3.296.0"
+          $root = "C:\VulkanSDK\$sdkVer"
+          New-Item -ItemType Directory -Force -Path "C:\VulkanSDK" | Out-Null
+          $url = "https://sdk.lunarg.com/sdk/download/$sdkVer/windows/VulkanSDK-$sdkVer-Installer.exe"
+          $inst = Join-Path $env:TEMP "VulkanSDK-$sdkVer-Installer.exe"
+          Invoke-WebRequest -Uri $url -OutFile $inst -UseBasicParsing
+          $p = Start-Process -FilePath $inst -ArgumentList @("--root", $root, "--accept-licenses", "--default-answer", "--confirm-command", "install") -Wait -PassThru -NoNewWindow
+          if ($p.ExitCode -ne 0) { throw "Vulkan SDK installer exit code $($p.ExitCode)" }
+
+      - name: Compile GLSL to SPIR-V
+        shell: pwsh
+        env:
+          VULKAN_SDK: C:\VulkanSDK\1.3.296.0
+        run: |
+          $ErrorActionPreference = "Stop"
+          $glsl = Join-Path $env:VULKAN_SDK "Bin\glslangValidator.exe"
+          if (-not (Test-Path -LiteralPath $glsl)) { throw "Missing $glsl" }
+          & "${{ github.workspace }}\tools\compile_game_shaders.ps1" -ShaderDir "${{ github.workspace }}\game\data\shaders"
+
+      - name: Package (éditeur + carte)
+        shell: pwsh
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+        run: |
+          . "${{ github.workspace }}\.github\scripts\package-windows.ps1"
+          Copy-ArtifactExes -Names @("lcdlln_world_editor.exe", "zone_builder.exe")
+          Copy-RuntimeDlls -IncludeGraphics
+          Copy-GameData
+          Copy-ClientConfig
+
+      - name: Upload artifact (éditeur + carte)
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-editor-${{ github.sha }}
+          path: artifacts/
+          if-no-files-found: error
+          retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # SERVEUR + OUTILS
+  # ---------------------------------------------------------------------------
+  server-tools:
+    name: Serveur + outils
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          lfs: false # le serveur/outils n'ont pas besoin des assets LFS
+
+      - name: Cache vcpkg binary archives
+        uses: actions/cache@v5
+        with:
+          path: ~\AppData\Local\vcpkg\archives
+          key: vcpkg-archives-windows-${{ hashFiles('vcpkg.json') }}
+          restore-keys: |
+            vcpkg-archives-windows-
+
+      - name: Clone + bootstrap vcpkg
+        shell: pwsh
+        run: |
+          git clone https://github.com/Microsoft/vcpkg.git "$env:GITHUB_WORKSPACE\vcpkg"
+          & "$env:GITHUB_WORKSPACE\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
+
+      - name: Configure
+        shell: pwsh
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+        run: cmake --preset vs2022-x64
+
+      - name: Build (serveur + outils)
+        shell: pwsh
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+        run: |
+          cmake --build --preset vs2022-x64-release --target server_app
+          cmake --build --preset vs2022-x64-release --target migration_checksum
+          cmake --build --preset vs2022-x64-release --target hlod_builder
+          cmake --build --preset vs2022-x64-release --target gen_terrain_placeholders
+          cmake --build --preset vs2022-x64-release --target load_tester
+
+      - name: Vérifie présence de l'exécutable serveur
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem -Recurse -Path "$env:GITHUB_WORKSPACE\build" -Filter "lcdlln_server.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+          if (-not $exe) { Write-Host "[FAIL] lcdlln_server.exe introuvable"; exit 1 }
+          Write-Host "[OK] Server : $($exe.FullName)"
+
+      - name: Package (serveur + outils)
+        shell: pwsh
+        env:
+          VCPKG_ROOT: ${{ github.workspace }}\vcpkg
+        run: |
+          . "${{ github.workspace }}\.github\scripts\package-windows.ps1"
+          Copy-ArtifactExes -Names @("lcdlln_server.exe", "migration_checksum.exe", "hlod_builder.exe", "gen_terrain_placeholders.exe", "load_tester.exe")
+          Copy-RuntimeDlls
+          Copy-ServerConfig
+
+      - name: Upload artifact (serveur + outils)
+        uses: actions/upload-artifact@v6
+        with:
+          name: windows-server-${{ github.sha }}
           path: artifacts/
           if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
## Découpage du build Windows en jobs parallèles

Suite à ta demande : le job unique `build-windows` devient **3 jobs parallèles** par composant, dans le même fichier.

| Job | Cible(s) CMake | Artefact |
|---|---|---|
| **client** | `engine_app` → `lcdlln.exe` (+ shaders + game/data) | `windows-client-<sha>` |
| **editor** | `world_editor_app` + `zone_builder` (éditeur + **constructeur de carte**) | `windows-editor-<sha>` |
| **server-tools** | `server_app` + `migration_checksum`/`hlod_builder`/… | `windows-server-<sha>` |

### Pourquoi c'est plus rapide
- **Chaque job ne compile que sa cible** — plus les ~100 exécutables de test. C'est ce qui, additionné au parallélisme, réduit le temps « au mur » (~33 min → **~18-20 min** attendus).
- **Cache binaire natif de vcpkg** (`%LOCALAPPDATA%\vcpkg\archives`, clé par ABI) partagé entre jobs et runs : OpenSSL/Vulkan/glfw compilés **une seule fois** (~8 min) puis restaurés (~1 min). SDK Vulkan toujours caché.
- **Packaging factorisé** dans `.github/scripts/package-windows.ps1` (fini les ~110 lignes dupliquées).

### Compromis (assumés, à valider ensemble)
- `engine_core` (lib partagée) est reconstruit dans chaque job → **plus de minutes facturées** (le prix du parallélisme quand le code est partagé).
- Les **tests ne sont plus compilés sur Windows** ; ils restent **exécutés par `ctest` dans `build-linux`** (donc mieux couverts qu'avant, où Windows compilait sans exécuter). Perte marginale : erreurs de compilation de tests *spécifiques* à Windows.
- **1er run lent** (cache vcpkg froid), rapide ensuite.

`build-linux.yml` est **inchangé**.

### Validation
Cette PR modifie le workflow → **sa propre CI exécute la nouvelle version** (3 jobs Windows + Linux). Si un job casse, seule la PR est rouge ; `main` garde l'ancien workflow jusqu'au merge. Le 1er run servira aussi à **chauffer le cache vcpkg**.

> **Déploiement** : ✅ CI/infra uniquement, aucun impact runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)