### PR TITLE
feat(editor): PR1 - registre d'actions + menus reorganises + barre de statut

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,9 @@ add_library(engine_core
   # editor.world.enabled. Pas référencé par engine/server/.
   src/world_editor/core/WorldEditorShell.cpp
   src/world_editor/core/CommandStack.cpp
+  # Réorganisation UI 2026-07-17 — registre central des actions (menus,
+  # barre d'actions, palette de commandes, fenêtre raccourcis).
+  src/world_editor/actions/EditorActionRegistry.cpp
   # M101.4 / M101.5 — editeur de routines nodal (panel + commandes + palette/inspecteur).
   src/world_editor/routine/RoutineGraphCommands.cpp
   src/world_editor/routine/RoutineGraphPanel.cpp
@@ -1720,6 +1723,21 @@ if(WIN32)
   endif()
   add_test(NAME editor_toolbar_tests COMMAND editor_toolbar_tests)
 endif()
+
+# Réorganisation UI 2026-07-17 — Tests unitaires CPU du registre d'actions
+# de l'éditeur monde (unicité des ids, prédicats enabled/checked, ordre
+# d'insertion) + sériel de mutations du CommandStack (dirty-tracking « non
+# sauvegardé »). Aucune dépendance ImGui/GPU : NON gaté WIN32 pour que
+# build-linux (le seul workflow à lancer ctest) l'exécute réellement.
+add_executable(editor_action_registry_tests src/world_editor/tests/EditorActionRegistryTests.cpp)
+target_include_directories(editor_action_registry_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(editor_action_registry_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(editor_action_registry_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+else()
+  target_compile_options(editor_action_registry_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+add_test(NAME editor_action_registry_tests COMMAND editor_action_registry_tests)
 
 # M100.36 — Tests unitaires CPU pour le watershed D8 + flow accumulation +
 # Douglas-Peucker + OceanSettings + RiverNetworkCommand + water.bin v1/v2

--- a/docs/superpowers/plans/2026-07-17-editor-menus-toolbar-reorg.md
+++ b/docs/superpowers/plans/2026-07-17-editor-menus-toolbar-reorg.md
@@ -1,0 +1,361 @@
+# Réorganisation menus / barre d'actions / palette d'outils — Plan d'implémentation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal :** Réorganiser l'UI de l'éditeur monde sur les conventions UE : registre
+d'actions central, menus Fichier/Édition/Vue/Fenêtre/Outils/Aide, barre
+d'actions en haut, palette d'outils à gauche, statut enrichi, palette de
+commandes Ctrl+P, fenêtre raccourcis. Spec :
+`docs/superpowers/specs/2026-07-17-editor-menus-toolbar-reorg-design.md`.
+
+**Architecture :** Un `EditorActionRegistry` (pure data + std::function) vit
+dans `WorldEditorShell` ; le shell y enregistre ses actions autonomes
+(undo/redo, toggles panneaux, outils), `WorldEditorImGui` y ajoute les actions
+session (save/load/export/import/quit). Menus, barre d'actions, palette Ctrl+P
+et fenêtre raccourcis consomment le registre. La logique testable (registre,
+groupes palette, filtre, récents) est séparée d'ImGui pour tourner sous ctest
+Linux.
+
+**Tech stack :** C++20, ImGui docking, CMake, tests maison REQUIRE + main
+(pattern `EditorToolbarTests.cpp`).
+
+## Global Constraints
+
+- Commentaires en **français** ; toute fonction ajoutée/modifiée dans
+  `src/world_editor/` documentée en `///` (rôle, params non évidents, effets
+  de bord, contraintes thread) — règle stricte CLAUDE.md.
+- **PascalCase** pour nouveaux fichiers/classes ; membres `m_camelCase`,
+  constantes `kPascalCase`.
+- **Pas de toolchain locale** : aucune compilation locale possible. Le cycle
+  TDD est : écrire test + impl → push → CI (build-windows compile,
+  build-linux compile + ctest). Ne jamais prétendre « tests passés » avant CI
+  verte.
+- Nouveaux tests **non gatés WIN32** quand ils n'incluent pas
+  `WorldEditorShell.h`/ImGui (sinon ils ne tournent jamais : build-windows
+  n'exécute pas ctest). Enregistrer les cibles test dans le
+  **CMakeLists.txt racine** (vérifier aussi `src/CMakeLists.txt` — piège
+  doublon CMP0002).
+- `git add` **ciblé uniquement** (jamais `-A` : le worktree contient des .fbx
+  modifiés et `dev/` non suivis qui ne sont pas à nous).
+- Ne pas toucher `legacy/`.
+- 3 PRs empilées : PR1 = branche courante
+  `claude/unreal-engine-editor-comparison-d5280e` → main ; PR2 =
+  `claude/editor-ui-reorg-pr2` (base PR1) ; PR3 =
+  `claude/editor-ui-reorg-pr3` (base PR2). Indiquer l'ordre de merge.
+- Déploiement : ✅ client/éditeur uniquement (à rappeler dans chaque PR).
+
+---
+
+## PR 1 — Registre d'actions + menus + statut
+
+### Task 1 : `EditorAction` + `EditorActionRegistry` + tests
+
+**Files:**
+- Create: `src/world_editor/actions/EditorAction.h`
+- Create: `src/world_editor/actions/EditorActionRegistry.h`
+- Create: `src/world_editor/actions/EditorActionRegistry.cpp`
+- Test: `src/world_editor/tests/EditorActionRegistryTests.cpp`
+- Modify: `CMakeLists.txt` (bloc tests, après `editor_toolbar_tests`)
+
+**Interfaces (produit) :**
+
+```cpp
+// EditorAction.h — AUCUN include ImGui/Shell (testable Linux).
+namespace engine::editor::world::actions
+{
+	/// Catégorie d'une action — pilote le groupement dans les menus, la
+	/// palette de commandes et la fenêtre raccourcis.
+	enum class ActionCategory : uint8_t
+	{ Fichier = 0, Edition, Vue, Fenetre, Outils, Aide };
+
+	/// Déclaration unique d'une action de l'éditeur (menu, barre d'actions,
+	/// palette Ctrl+P, fenêtre raccourcis consomment la même entrée).
+	struct EditorAction
+	{
+		std::string id;            ///< stable, kebab-case, ex. "file.save"
+		std::string label;         ///< libellé FR affiché
+		ActionCategory category = ActionCategory::Fichier;
+		std::string section;       ///< en-tête de section optionnel (ex. "Import")
+		std::string shortcutText;  ///< texte affiché ("Ctrl+S") ; exécution ailleurs
+		std::function<bool()> enabled;  ///< nul => toujours actif
+		std::function<bool()> checked;  ///< nul => pas un toggle
+		std::function<void()> execute;  ///< nul => item inerte (interdit hors tests)
+	};
+
+	class EditorActionRegistry
+	{
+	public:
+		/// Enregistre une action. \return false (et log) si id dupliqué/vide.
+		bool Register(EditorAction action);
+		const std::vector<EditorAction>& Actions() const;
+		/// nullptr si absent.
+		const EditorAction* Find(std::string_view id) const;
+		bool IsEnabled(const EditorAction& a) const;  // a.enabled ? a.enabled() : true
+		size_t Size() const;
+		void Clear();  ///< tests uniquement
+	};
+}
+```
+
+- [ ] **Step 1 : test échouant** — `EditorActionRegistryTests.cpp` (pattern
+  REQUIRE + main) : Register ok, id dupliqué refusé, id vide refusé, Find,
+  IsEnabled avec/sans prédicat, checked toggle, ordre d'insertion préservé.
+- [ ] **Step 2 : impl minimale** (`std::vector` + lookup linéaire — <100
+  actions, pas de map nécessaire).
+- [ ] **Step 3 : CMake** — cible `editor_action_registry_tests` NON gatée
+  WIN32 (le module n'inclut ni ImGui ni le shell), lien `engine_core`,
+  `add_test`. Vérifier absence de doublon dans `src/CMakeLists.txt`.
+- [ ] **Step 4 : commit** `feat(editor): registre d'actions central (PR1 1/6)`.
+
+### Task 2 : `CommandStack::Serial()` + dirty-depuis-save du shell
+
+**Files:**
+- Modify: `src/world_editor/core/CommandStack.h/.cpp` — membre
+  `uint64_t m_serial = 0;` incrémenté dans `Push` (même en cas de merge),
+  `Undo`, `Redo`, `Clear` ; accesseur `uint64_t Serial() const`.
+- Modify: `src/world_editor/core/WorldEditorShell.h` —
+  `void NoteSaved()` (m_savedSerial = serial courant ; m_dirty = false) ;
+  `bool IsDirtySinceSave() const` (serial != m_savedSerial || m_dirty).
+- Test: étendre `EditorActionRegistryTests.cpp`… **non** : CommandStack.h est
+  inclus sans ImGui → test dans le même binaire
+  `editor_action_registry_tests` (section dédiée) pour éviter une cible de
+  plus : Push/Undo/Redo/Clear incrémentent, NoteSaved/IsDirtySinceSave via un
+  `WorldEditorShell`… **le shell tire tout l'éditeur** → tester
+  NoteSaved/IsDirtySinceSave dans `editor_toolbar_tests` (déjà gaté WIN32,
+  linke le shell). Serial() testé côté Linux avec une commande stub.
+- [ ] Steps : test serial (stub ICommand) → impl → test shell dirty dans
+  EditorToolbarTests → commit
+  `feat(editor): serial CommandStack + dirty-depuis-save (PR1 2/6)`.
+
+### Task 3 : cartes récentes dans `UserPrefs`
+
+**Files:**
+- Modify: `src/world_editor/prefs/UserPrefs.h` —
+  `std::vector<std::string> recentMapIds;` (+ doc).
+- Modify: `src/world_editor/prefs/UserPrefsStore.h/.cpp` —
+  `void PushRecentMap(const std::string& zoneId)` : dédoublonne, insère en
+  tête, tronque à `kMaxRecentMaps = 8`, persiste ;
+  `const std::vector<std::string>& GetRecentMaps() const`.
+  Sérialisation JSON symétrique (champ `recentMapIds`, lecture tolérante).
+- Test: `src/world_editor/tests/UserPrefsRecentMapsTests.cpp` (non gaté si
+  UserPrefsStore compile hors WIN32 — il n'inclut qu'EditorMode + filesystem ;
+  sinon suivre le gating du fichier existant). Cap 8, dédoublonnage remonte
+  en tête, ordre, round-trip disque via répertoire temporaire +
+  `ResetForTesting`.
+- [ ] Steps : test → impl → CMake → commit
+  `feat(editor): cartes recentes persistees (PR1 3/6)`.
+
+### Task 4 : réorganisation des menus dans `WorldEditorImGui::BuildUi`
+
+**Files:**
+- Modify: `src/world_editor/ui/WorldEditorImGui.h` : membres
+  `bool m_showPreferencesWindow = false; bool m_showAboutWindow = false;
+  bool m_quitConfirmOpen = false; bool m_actionsRegistered = false;
+  std::function<void()> m_onQuitRequested;` + setter
+  `void SetQuitCallback(std::function<void()> cb)` + méthodes privées
+  `RegisterEditorActions(); RenderMenuBarFr(); RenderPreferencesWindow();
+  RenderAboutWindow(); RenderQuitConfirmModal(); MenuItemForAction(const char* id);`
+- Modify: `src/world_editor/ui/WorldEditorImGui.cpp` : le bloc
+  `BeginMainMenuBar` (~849-1120) est remplacé par `RenderMenuBarFr()`.
+- Modify: `src/world_editor/core/WorldEditorShell.h/.cpp` :
+  `actions::EditorActionRegistry& MutableActionRegistry()` (membre
+  `m_actions`) ; le shell enregistre à `Init` : `edit.undo`, `edit.redo`,
+  `edit.history` (SetVisible(true) du panneau History), `window.panel.<name>`
+  pour chaque panneau (checked = IsVisible), `window.layout.reset`.
+- `WorldEditorImGui::RegisterEditorActions()` (1er BuildUi, garde
+  `m_actionsRegistered`) ajoute : `file.new-zone-wizard`, `file.zone-preset`,
+  `file.save` (Ctrl+S ; après succès `m_shell->NoteSaved()` +
+  `UserPrefsStore::PushRecentMap`), `file.load.<n>` n'est PAS une action (le
+  sous-menu Charger reste itératif), `file.import.texture`,
+  `file.import.audio`, `zone.validate`, `zone.export` (enabled = gating
+  validation existant), `file.quit` (voir modale), `view.grid` (checked),
+  `view.camera-help`, `view.atmosphere`, `window.texture-library`,
+  `window.validation-panel`, `edit.preferences`, `help.diagnostic`,
+  `help.about`, `edit.select.delete` (enabled = sélection non vide ; pousse
+  la `DeleteCommand` existante — reprendre le call-site actuel de suppression
+  de l'OutlinerPanel/SelectionTool), et les 15 outils
+  `tool.<kebab>` (execute = SetActiveTool, checked = GetActiveTool()==t,
+  shortcutText = raccourci Ctrl+Shift existant, section = famille).
+- Structure des menus (ordre exact, `ImGui::SeparatorText` pour les
+  en-têtes) :
+
+```text
+Fichier : [NOUVEAU] file.new-zone-wizard, file.zone-preset
+          [OUVRIR] Charger une carte ▸ (itératif : ActionLoadMapByZoneId +
+                   PushRecentMap + Rafraîchir) ; Cartes récentes ▸
+                   (GetRecentMaps ; item grisé si plus dans AvailableMapIds)
+          [ENREGISTRER] file.save
+          [IMPORT] file.import.texture, file.import.audio
+          [EXPORT] zone.validate, zone.export (tooltip blocage conservé)
+          ── file.quit
+Édition : edit.undo, edit.redo, edit.history ── edit.select.delete
+          ── edit.preferences, (PR3: edit.shortcuts)
+Vue     : view.grid, view.camera-help, view.atmosphere
+Fenêtre : window.panel.* (boucle panneaux, skip "Scene"),
+          window.texture-library, window.validation-panel
+          ── window.layout.reset (comportement DockBuilderRemoveNode actuel)
+Outils  : sous-menus Terrain ▸ / Eau ▸ / Macro ▸ / Structures ▸
+          (itère registre catégorie Outils groupé par section)
+Aide    : help.diagnostic, (PR3: help.shortcuts), help.about
+```
+
+- `MenuItemForAction(id)` : lookup ; `ImGui::MenuItem(label, shortcut,
+  checkedVal, enabled)` ; toggle → execute inverse le flag via checked ;
+  conserve l'enregistrement `m_widgetTargets` pour `menubar.file.export_runtime`
+  et `toolbar.button.validate` (guidance overlay).
+- Disparaissent : items top-level Sauvegarder/Charger, statut dans la barre,
+  menu Options (fusionné dans Préférences), slider vitesse caméra et astuces
+  du menu Vue (déplacés Préférences/tooltips).
+- `RenderPreferencesWindow()` : fenêtre « Préférences » (toggle) — layout
+  clavier QWERTY/AZERTY (logique actuelle
+  `TryPersistMovementLayoutToUserSettings` conservée), slider
+  `controls.editor_camera_speed_multiplier` (0.25–5.0 + texte d'aide), mode
+  éditeur Simple/Avancé (EditorModeRegistry).
+- `RenderQuitConfirmModal()` : `file.quit` → si
+  `m_shell && m_shell->IsDirtySinceSave()` ouvre popup modale « Quitter
+  l'éditeur » (3 boutons : Sauvegarder et quitter / Quitter sans sauvegarder /
+  Annuler) sinon appelle direct `m_onQuitRequested`.
+- `RenderAboutWindow()` : version (constante `kWorldEditorVersionLabel`
+  = "LCDLLN World Editor — build dev"), chemin spec/manuel.
+- Modify: `src/client/app/Engine.cpp` : au câblage worldEditorExe existant
+  (`SetWorldEditorShell` / `SetEditorContext`), ajouter
+  `m_worldEditorImGui.SetQuitCallback([this]{ OnQuit(); });`
+- [ ] Steps : impl (pas de test ImGui possible — la logique testable est déjà
+  couverte Tasks 1-3) → relecture manuelle du diff → commit
+  `feat(editor): menus reorganises Fichier/Edition/Vue/Fenetre/Outils/Aide (PR1 4/6)`.
+
+### Task 5 : barre de statut enrichie
+
+**Files:**
+- Modify: `WorldEditorImGui.cpp` fenêtre `"Statut"` (~1962) : gauche =
+  `Status()` ; ` | Carte : <zoneId ou aucune>` ; ` | Outil : <libellé FR>` ;
+  droite (SameLine + alignement à `GetContentRegionAvail`) =
+  « Tout enregistré » (gris) ou « ● Non sauvegardé » (ambre) selon
+  `m_shell->IsDirtySinceSave()`. Libellé outil : réutilise
+  `ToolbarIconAtlas::Get(tool).tooltipFr`.
+- [ ] Steps : impl → commit `feat(editor): barre de statut enrichie (PR1 5/6)`.
+
+### Task 6 : dégraissage barre anglaise fantôme + PR
+
+**Files:**
+- Modify: `src/world_editor/core/WorldEditorShell.cpp` `RenderMenuBar` :
+  supprimer menu File (stubs no-op), menu Tools (vide), menu Window (4
+  layouts aliasés) ; garder Edit/View/Help minimal comme fallback du mode
+  shell-sans-UI-française (le binaire éditeur la supprime déjà via
+  `SetMenuBarSuppressed`). Mettre à jour la doc `///`.
+- [ ] Step : commit `chore(editor): degraisse la barre M100.1 fantome (PR1 6/6)`.
+- [ ] **PR 1** : push branche courante ; `gh pr create` base main. Corps :
+  résumé + « **Déploiement** : ✅ client uniquement ». Vérifier CI.
+
+## PR 2 — Barre d'actions + palette d'outils (branche `claude/editor-ui-reorg-pr2`)
+
+### Task 7 : extraction `ActiveTool` + modèle de palette pur + tests
+
+**Files:**
+- Create: `src/world_editor/core/ActiveTool.h` (déplacement verbatim de
+  l'enum depuis `WorldEditorShell.h`, qui l'inclut désormais — aucun autre
+  call-site à toucher).
+- Create: `src/world_editor/ui/ToolPaletteModel.h/.cpp` :
+
+```cpp
+/// Groupe d'outils affiché par la palette (pure data, testable sans ImGui).
+struct ToolPaletteGroup { const char* titleFr; std::vector<ActiveTool> tools; };
+/// Les 4 familles (Terrain / Eau / Macro / Structures) couvrant exactement
+/// les 15 outils, ordre d'affichage stable.
+const std::vector<ToolPaletteGroup>& GetToolPaletteGroups();
+/// Libellé FR court d'un outil (source unique pour palette/menu/statut).
+const char* ToolLabelFr(ActiveTool t);
+```
+
+- Test: `src/world_editor/tests/ToolPaletteModelTests.cpp` NON gaté WIN32 :
+  chaque valeur 1..15 de l'enum apparaît exactement une fois, groupes non
+  vides, labels non vides et uniques, `ToolLabelFr(None)` défini.
+- [ ] Steps : test → impl → CMake → commit.
+
+### Task 8 : `EditorToolbar` reconverti en barre d'actions
+
+**Files:**
+- Modify: `src/world_editor/ui/EditorToolbar.h/.cpp` :
+  `ToolbarButtonRect.tool` remplacé par `std::string actionId;` ; la liste
+  ordonnée devient `{"file.save","edit.undo","edit.redo","zone.validate",
+  "zone.export"}` ; séparateur visuel entre groupes (gap double) ;
+  `HandleClick` → `registry.Find(id)->execute()` si enabled ; bouton grisé
+  sinon ; tooltip = `label (shortcutText)`. Le constructeur prend
+  `WorldEditorShell&` (inchangé) et lit `shell.MutableActionRegistry()`.
+- Modify: `src/world_editor/ui/ToolbarIconAtlas.h/.cpp` : ajoute
+  `static ToolIconStyle GetForAction(std::string_view actionId);` (lettres
+  S/Z/Y/V/E, couleurs distinctes, tooltip FR).
+- Test: `EditorToolbarTests.cpp` réécrit : invariant géométrique conservé
+  (aucun bouton sous la bande), clic exécute l'action (action stub registrée
+  dans le test qui flippe un bool), clic sur action disabled = no-op, action
+  inconnue = bouton absent (layout l'omet).
+- [ ] Steps : test → impl → commit.
+
+### Task 9 : `ToolPalettePanel` + disposition + nettoyage
+
+**Files:**
+- Create: `src/world_editor/panels/ToolPalettePanel.h/.cpp` : IPanel, nom
+  fenêtre `"Palette d'outils"` ; en tête bouton « Aucun outil » ; par groupe
+  `CollapsingHeader(DefaultOpen)` + un bouton par outil (`Selectable` avec
+  pastille couleur atlas + `ToolLabelFr`), surligné si actif, tooltip
+  raccourci ; clic → `m_shell.SetActiveTool`.
+- Modify: `WorldEditorShell.cpp Init` : append du panneau en FIN de
+  `m_panels` (les indices F1..F12 restent stables).
+- Modify: `WorldEditorImGui.cpp` bloc DockBuilder : `DockBuilderDockWindow
+  ("Palette d'outils", idLeft)` ; texte du panneau « Outils » mis à jour
+  (« Sélection d'outil : palette à gauche, menu Outils ou Ctrl+Shift+… »).
+- [ ] Steps : impl → commit → **PR 2** (base PR1, corps + déploiement ✅,
+  ordre de merge 1→2→3).
+
+## PR 3 — Palette de commandes + fenêtre raccourcis (branche `claude/editor-ui-reorg-pr3`)
+
+### Task 10 : filtre pur + tests
+
+**Files:**
+- Create: `src/world_editor/ui/CommandPaletteModel.h/.cpp` :
+
+```cpp
+/// Entrée candidate (id + libellé + catégorie déjà résolus en texte).
+struct PaletteEntry { std::string id, label, categoryFr, shortcutText; bool enabled; };
+/// Filtre insensible casse/accents ; préfixe de mot > sous-chaîne ; requête
+/// vide => tout dans l'ordre d'origine. Retourne les indices ordonnés.
+std::vector<size_t> FilterPaletteEntries(std::string_view query,
+	const std::vector<PaletteEntry>& entries);
+/// Normalisation : minuscules ASCII + translittération accents FR courants.
+std::string NormalizeForSearch(std::string_view text);
+```
+
+- Test: `CommandPaletteModelTests.cpp` NON gaté : accents (é→e), casse,
+  préfixe classé avant sous-chaîne, requête vide, aucun match, stabilité.
+- [ ] Steps : test → impl → CMake → commit.
+
+### Task 11 : fenêtre palette Ctrl+P + fenêtre Raccourcis
+
+**Files:**
+- Modify: `WorldEditorImGui.h/.cpp` : `m_showCommandPalette`,
+  `m_showShortcutsWindow`, `m_paletteQuery[128]`, `m_paletteSelected` ;
+  détection `ImGui::IsKeyChordPressed(ImGuiMod_Ctrl | ImGuiKey_P)` dans
+  BuildUi (hors capture texte) ; fenêtre centrée : InputText auto-focus,
+  liste filtrée (`FilterPaletteEntries` sur le registre), ↑/↓/Entrée/Échap ;
+  action disabled grisée non exécutable ; exécution ferme la palette.
+- Fenêtre « Raccourcis clavier » : table 2 colonnes groupée par catégorie
+  (actions à shortcutText non vide) + table statique documentée (WASD/ZQSD,
+  Shift course, molette zoom, Numpad 1/3/7 caméra, F1..F12 panneaux, Suppr,
+  Ctrl+P) ; entrées de menu `edit.shortcuts` (Édition) et `help.shortcuts`
+  (Aide) enregistrées au registre.
+- [ ] Steps : impl → commit → **PR 3** (base PR2) → CI des 3 PRs, rapport
+  final avec ordre de merge.
+
+## Self-review (fait à la rédaction)
+
+- Couverture spec : §3 registre=T1 ; §4 menus=T4+T6 (récents=T3, dirty=T2) ;
+  §5 barre actions=T8 ; §6 palette=T7+T9 ; §7 statut=T5 ; §8 palette
+  Ctrl+P + raccourcis=T10+T11 ; §9 tests=T1/T2/T3/T7/T8/T10 ; §10 PRs=T6/T9/T11.
+- Déviation assumée vs spec §4 : la barre anglaise M100.1 n'est pas
+  **supprimée** mais **dégraissée** (fallback minimal Edit/View/Help pour le
+  mode shell in-game sans UI française) — documentée Task 6 + PR.
+- Types cohérents : `EditorActionRegistry` produit en T1, consommé T4/T8/T11
+  via `WorldEditorShell::MutableActionRegistry()` (introduit T4).
+  `ToolLabelFr` produit T7, consommé T5 ? — non : T5 (PR1) utilise
+  `ToolbarIconAtlas::Get(tool).tooltipFr` qui existe déjà ; `ToolLabelFr`
+  n'est consommé qu'en PR2+. OK.

--- a/docs/superpowers/specs/2026-07-17-editor-menus-toolbar-reorg-design.md
+++ b/docs/superpowers/specs/2026-07-17-editor-menus-toolbar-reorg-design.md
@@ -1,0 +1,227 @@
+# Réorganisation des menus, barre d'actions et palette d'outils de l'éditeur monde
+
+Date : 2026-07-17
+Statut : validé (design approuvé en séance)
+Périmètre : 100 % client/éditeur — aucun redéploiement serveur.
+
+## 1. Contexte et objectif
+
+L'utilisateur a comparé notre éditeur monde (`lcdlln_world_editor.exe`) à
+Unreal Engine 5.8 et souhaite en rapprocher l'**organisation des menus, des
+barres d'outils et des raccourcis** (pas les fonctionnalités : notre éditeur
+reste spécialisé pour LCDLLN).
+
+Problèmes constatés dans l'existant :
+
+- **Menu « Vue » fourre-tout** (`src/world_editor/ui/WorldEditorImGui.cpp`,
+  `BuildUi`, ~ligne 849) : mélange toggles de panneaux (rôle d'un menu
+  Fenêtre), options viewport (grille, aide caméra), un slider de vitesse
+  caméra (rôle de Préférences), des lignes d'astuce et la gestion de
+  disposition.
+- **Menu « Edition » quasi vide** : Annuler/Rétablir seulement, alors que
+  `DeleteCommand`, `HistoryPanel` et `EditorModeRegistry` existent.
+- **« Sauvegarder » et « Charger une carte » comme items de premier niveau**
+  de la barre de menu (boutons déguisés en menus) + **texte de statut dans la
+  barre de menu** (disparaît, bouge).
+- **« Quitter » grisé** (stub no-op) dans Fichier.
+- **Barre anglaise fantôme** : `WorldEditorShell::RenderMenuBar` (M100.1,
+  File/Edit/View/Tools/Window/Help + layouts Sculpting/Painting/Placement
+  aliasés sur Default) est supprimée au runtime par `SetMenuBarSuppressed(true)`
+  → code mort qui diverge du menu français.
+- **Barre d'outils = 15 boutons d'outils terrain sans aucune action**
+  (`src/world_editor/ui/EditorToolbar.{h,cpp}`) : pas de Sauvegarder, pas
+  d'Annuler/Rétablir, pas de Valider/Exporter. UE fait l'inverse : actions en
+  haut, outils dans une palette latérale.
+- **Raccourcis** dispersés (F1..F12, Ctrl+Shift+lettre, Ctrl+Z/Y) dans
+  `WorldEditorShell::HandleShortcut`, affichés inégalement, aucune vue
+  d'ensemble.
+
+## 2. Décisions validées avec l'utilisateur
+
+| Question | Décision |
+|---|---|
+| Organisation toolbar | **Actions en haut + palette d'outils verticale à gauche** (style UE Modes) |
+| Palette de commandes (recherche d'actions) | **Incluse dans ce chantier** (PR 3) |
+| Raccourcis clavier | **Fenêtre récapitulative en lecture seule** (pas de rebinding) |
+| Approche technique | **Registre d'actions central** (option B), pas de duplication par surface |
+
+## 3. Architecture : registre d'actions central
+
+Nouveau module `src/world_editor/actions/` (PascalCase, doc `///` en français
+— règle stricte de l'éditeur monde) :
+
+- `EditorAction.h` — struct pure data :
+  - `Id` : identifiant stable kebab-case (ex. `file.save`, `tool.terrain-sculpt`,
+    `panel.outliner`) ;
+  - `Label` : libellé FR affiché ;
+  - `Category` : enum (Fichier, Edition, Vue, Fenetre, Outils, Aide) — sert au
+    groupement dans la palette Ctrl+P et la fenêtre raccourcis ;
+  - `Section` : sous-groupe optionnel (ex. « Import », « Export ») pour les
+    en-têtes `SeparatorText` des menus ;
+  - `ShortcutText` : texte affiché (« Ctrl+S ») — l'exécution des raccourcis
+    reste dans `HandleShortcut`, le registre est la source du *texte* ;
+  - `EnabledPredicate` : `std::function<bool()>` (ex. Annuler grisé si pile vide) ;
+  - `CheckedPredicate` : optionnel, pour les toggles (panneaux, grille) ;
+  - `Execute` : `std::function<void()>`.
+- `EditorActionRegistry.{h,cpp}` — enregistre les actions au boot
+  (construction dans `WorldEditorImGui`/`WorldEditorShell` avec capture des
+  dépendances existantes : `WorldEditorSession`, `CommandStack`, panneaux),
+  itération par catégorie/section, lookup par id. Ids uniques garantis
+  (assert + test).
+
+**Consommateurs** : menus (PR 1), barre d'actions (PR 2), palette d'outils
+(PR 2), palette de commandes (PR 3), fenêtre raccourcis (PR 3). Une action se
+déclare une fois et apparaît partout.
+
+Les 15 outils (`ActiveTool`) sont enregistrés comme actions de catégorie
+Outils avec section = famille (voir §6) : le menu Outils, la palette de
+gauche et la palette Ctrl+P en dérivent.
+
+## 4. Barre de menu cible
+
+`Fichier | Édition | Vue | Fenêtre | Outils | Aide` — en-têtes de section
+via `ImGui::SeparatorText`, raccourcis affichés sur chaque item concerné.
+
+- **Fichier** :
+  - Nouvelle zone (assistant)… ; Appliquer un preset de zone…
+  - Charger une carte ▸ (liste + Rafraîchir) ; **Cartes récentes ▸** (nouveau,
+    max 8 entrées, persistées via `UserPrefsStore` / `user_prefs.json`,
+    mises à jour à chaque load/save réussi)
+  - Sauvegarder la carte courante `Ctrl+S`
+  - — IMPORT — Importer une texture… ; Importer un son…
+  - — EXPORT — Valider la zone ; Exporter en runtime (garde le blocage
+    validation existant + tooltip)
+  - — **Quitter** (réel) : demande de fermeture par le même chemin que la
+    croix fenêtre ; si état non sauvegardé, modale de confirmation
+    « Quitter sans sauvegarder ? » (Sauvegarder et quitter / Quitter /
+    Annuler). L'état « non sauvegardé » = révision du `CommandStack`
+    différente de la révision au dernier `ActionSaveCurrentMap` réussi
+    (compteur posé par le shell).
+- **Édition** :
+  - Annuler `Ctrl+Z` ; Rétablir `Ctrl+Y` ; Historique des annulations
+    (ouvre/affiche `HistoryPanel`)
+  - — Supprimer la sélection `Suppr` (grisé si sélection vide ; branché sur
+    `DeleteCommand` existant). Pas d'item « Dupliquer » : aucune commande de
+    duplication n'existe aujourd'hui (hors périmètre, cf. §11)
+  - — Préférences… : fenêtre regroupant l'actuel menu Options
+    (AZERTY/QWERTY, mode Simple/Avancé) + vitesse caméra (sortie du menu Vue)
+  - Raccourcis clavier… (fenêtre récap, cf. §8)
+- **Vue** (viewport uniquement) : Grille (afficher/masquer) ; Aide caméra
+  (WASD) ; Atmosphère (jour/nuit).
+- **Fenêtre** : toggles de tous les panneaux du shell (+ Bibliothèque de
+  textures, Validation de zone) ; — Réinitialiser la disposition des fenêtres
+  (comportement actuel conservé).
+- **Outils** : sous-menus par famille (cf. §6), items = actions outils du
+  registre, checkmark sur l'outil actif.
+- **Aide** : Diagnostic (« pourquoi ça ne marche pas ? ») ; Raccourcis
+  clavier… ; À propos (version + hash de commit si disponible au build,
+  sinon « dev »).
+
+Disparaissent de la barre de menu : items « Sauvegarder » / « Charger une
+carte » de premier niveau (remplacés par Fichier + barre d'actions), texte de
+statut (remplacé par la barre de statut §7), menu Options (fusionné dans
+Édition > Préférences), astuces texte du menu Vue (déplacées en tooltips),
+slider vitesse caméra (déplacé dans Préférences).
+
+**Suppression de la barre anglaise fantôme** : `RenderMenuBar`,
+`SetMenuBarSuppressed` et les layouts nommés morts (Sculpting/Painting/
+Placement, aliases de Default) sont retirés de `WorldEditorShell` ; le menu
+français devient l'unique barre. Les fonctions encore utiles (toggles de
+panneaux, reset layout) passent par le registre.
+
+## 5. Barre d'actions (en haut, sous le menu — remplace la rangée d'outils)
+
+`EditorToolbar` est reconverti en **barre d'actions** (hauteur 48 px
+conservée) : `Sauvegarder | Annuler | Rétablir || Valider la zone |
+Exporter en runtime`. Icônes via `ToolbarIconAtlas` (nouvelles entrées
+d'icônes ; fallback lettre centrale comme aujourd'hui si atlas indisponible),
+tooltip « Libellé (raccourci) », grisé selon `EnabledPredicate`. Les
+invariants géométriques existants (`BuildLayout` pur, `HitTest` pur, jamais
+un pixel sur le viewport 3D — cf. `EditorToolbarTests.cpp`) sont conservés
+et les tests adaptés au nouveau contenu.
+
+## 6. Palette d'outils (nouveau panneau dockable à gauche)
+
+Nouveau panneau `ToolPalettePanel` (implémente `IPanel`, enregistré dans le
+shell, présent dans la disposition par défaut, ancré à gauche) :
+
+- Bouton « Aucun outil » (désélection) en tête.
+- Groupes repliables : **Terrain** (Sculpture, Tampon, Peinture de texture) ·
+  **Eau** (Lac, Rivière, Réseau fluvial, Littoral) · **Macro** (Chaîne de
+  montagnes, Chaîne de vallées, Érosion hydraulique, Érosion thermique/vent) ·
+  **Structures** (Grotte, Surplomb, Arche, Portail de donjon).
+- Bouton = icône + libellé, outil actif surligné (même ambre que l'actuelle
+  toolbar), tooltip avec raccourci, clic = `Execute` de l'action outil
+  (wrap `SetActiveTool`).
+- Toggleable depuis Fenêtre ; la disposition par défaut du DockBuilder est
+  mise à jour pour réserver la colonne gauche.
+
+## 7. Barre de statut (en bas, ~24 px)
+
+Fenêtre ImGui fixe pleine largeur en bas (même technique que la toolbar,
+jamais sur le viewport 3D) : à gauche le message de session
+(`WorldEditorSession::Status()`), puis carte courante (zone id), outil actif ;
+à droite l'indicateur **« Tout enregistré » / « ● Non sauvegardé »** (même
+source dirty que la confirmation de Quitter). La zone réservée au dockspace
+est réduite d'autant.
+
+## 8. Palette de commandes `Ctrl+P` et fenêtre Raccourcis
+
+- **Palette** : fenêtre modale centrée ouverte par `Ctrl+P` (ajout dans
+  `HandleShortcut`), champ texte avec focus automatique, filtrage incrémental
+  sur libellé + catégorie des actions du registre. Le filtrage/classement est
+  une **fonction pure** (`FilterActions(query, actions) → indices ordonnés`,
+  insensible aux accents/casse, préfixe > sous-chaîne) testée unitairement.
+  Navigation ↑/↓, `Entrée` exécute (si `EnabledPredicate` vrai — sinon item
+  grisé non exécutable), `Échap` ferme.
+- **Fenêtre Raccourcis clavier** (lecture seule) : tableau généré du registre,
+  groupé par catégorie, colonnes Libellé | Raccourci. Les raccourcis
+  « hors action » (déplacement caméra WASD/ZQSD, numpad modes caméra) sont
+  ajoutés via une petite table statique documentée dans le même fichier.
+  Accessible par Édition et Aide.
+
+## 9. Tests (ctest, exécutés par build-linux)
+
+- `EditorActionRegistryTests` : unicité des ids, présence des actions
+  attendues par catégorie, prédicats enabled (pile undo vide → `file.save`
+  actif mais `edit.undo` grisé), textes de raccourcis sans doublon
+  contradictoire.
+- `EditorToolbarTests` adaptés : mêmes invariants géométriques sur le nouveau
+  contenu actions.
+- `ToolPalettePanel` : construction des groupes (pure data) — familles
+  complètes, 15 outils couverts, aucun oublié/dupliqué (test croisé avec
+  l'enum `ActiveTool`).
+- `CommandPaletteTests` : filtrage pur (accents, casse, préfixe vs
+  sous-chaîne, requête vide → tout, ordre stable).
+- Cartes récentes : sérialisation/désérialisation `UserPrefs`, plafond à 8,
+  déduplication, plus récent en tête.
+
+## 10. Découpage en PRs (empilées, merge dans l'ordre)
+
+1. **PR 1 — Registre d'actions + menus + statut** : module `actions/`,
+   réorganisation complète de la barre de menu, barre de statut, Quitter réel
+   + modale, cartes récentes, fenêtre Préférences, suppression de la barre
+   anglaise fantôme. Tests registre + récents.
+2. **PR 2 — Barre d'actions + palette d'outils** : reconversion
+   `EditorToolbar`, `ToolPalettePanel`, disposition par défaut, icônes.
+   Tests toolbar + palette.
+3. **PR 3 — Palette de commandes + fenêtre Raccourcis** : `Ctrl+P`, filtrage
+   pur, fenêtre récap. Tests filtrage.
+
+**Déploiement** : ✅ client/éditeur uniquement, pas de redéploiement serveur
+(aucun opcode, aucune migration, aucune config serveur).
+
+## 11. Hors périmètre (explicitement)
+
+- Rebinding des raccourcis (rejeté : lecture seule).
+- Commande « Dupliquer la sélection » : n'existe pas dans le CommandStack
+  actuel ; à créer dans un chantier édition dédié si besoin.
+- Dispositions nommées type UE (Charger/Enregistrer la disposition) — on garde
+  uniquement Réinitialiser ; extension future possible.
+- Recherche intégrée en tête de chaque menu (la palette Ctrl+P couvre le
+  besoin en un seul endroit).
+- Toute évolution du rendu (ciel, viewport) — discutée séparément.
+- Le menu in-game de l'éditeur intégré au client (`m_editorEnabled` sans
+  `--world-editor`) : le chantier cible le binaire éditeur monde ; les
+  chemins partagés doivent rester compilables et le comportement in-game
+  inchangé.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8119,6 +8119,10 @@ namespace engine
 					// dialog Zone Presets puisse résoudre documents et
 					// catalogs au moment de l'exécution.
 					m_worldEditorImGui->SetWorldEditorShell(m_worldEditorShell.get());
+					// Réorganisation UI 2026-07-17 — « Fichier > Quitter » :
+					// demande de fermeture par le même chemin que la croix
+					// fenêtre (sortie propre de la boucle principale).
+					m_worldEditorImGui->SetQuitCallback([this] { OnQuit(); });
 
 					// Cache de vignettes pour les textures de splatting.
 					m_texturePreviewCache = std::make_unique<engine::editor::TexturePreviewCache>();
@@ -8435,6 +8439,12 @@ namespace engine
 				m_worldEditorShell->ResetForZoneChange(
 					engine::editor::SanitizeZoneId(m_worldEditorSession->Doc().zoneId));
 				m_worldEditorShell->InitNewZoneTerrain(chunksPerAxis, flatHeightMeters);
+				// Réorganisation UI 2026-07-17 — une zone fraîchement créée
+				// (fichiers déjà écrits par ActionNewMap) repart d'un état
+				// « tout enregistré » : sans ce NoteSaved, le Clear de la
+				// pile undo (ResetForZoneChange) marquerait la carte neuve
+				// « non sauvegardée » dans la barre de statut.
+				m_worldEditorShell->NoteSaved();
 				// Nouvelle carte = la caméra est replacée sur la nouvelle zone :
 				// l'origine STABLE du brouillon (mémorisée pour le gizmo/picking)
 				// pointe encore sur l'ANCIENNE carte. On l'invalide pour que le
@@ -8459,6 +8469,11 @@ namespace engine
 				m_worldEditorShell->ResetForZoneChange(
 					engine::editor::SanitizeZoneId(m_worldEditorSession->Doc().zoneId));
 				m_worldEditorShell->LoadZoneDocuments(m_cfg);
+				// Réorganisation UI 2026-07-17 — une carte fraîchement
+				// chargée repart d'un état « tout enregistré » (cf. barre de
+				// statut / modale Quitter) : le Clear de la pile undo fait
+				// par ResetForZoneChange incrémente le sériel du CommandStack.
+				m_worldEditorShell->NoteSaved();
 				// Force la reconstruction de l'aperçu 3D des bâtiments de la
 				// nouvelle zone (placements chargés depuis buildings.bin).
 				if (auto* bp = m_worldEditorShell->GetBuildingEditorPanel())

--- a/src/world_editor/actions/EditorAction.h
+++ b/src/world_editor/actions/EditorAction.h
@@ -1,0 +1,66 @@
+#pragma once
+// EditorAction — déclaration unique d'une action de l'éditeur monde
+// (réorganisation UI 2026-07-17, spec docs/superpowers/specs/
+// 2026-07-17-editor-menus-toolbar-reorg-design.md §3).
+//
+// Une action est déclarée UNE fois (id stable, libellé FR, catégorie,
+// raccourci, prédicats, callback) puis consommée par toutes les surfaces :
+// barre de menu française, barre d'actions, palette de commandes Ctrl+P et
+// fenêtre « Raccourcis clavier ». Ce header ne dépend NI d'ImGui NI du
+// WorldEditorShell : la logique registre est testable sous ctest Linux.
+
+#include <cstdint>
+#include <functional>
+#include <string>
+
+namespace engine::editor::world::actions
+{
+	/// Catégorie d'une action — pilote le groupement dans les menus, la
+	/// palette de commandes et la fenêtre « Raccourcis clavier ». L'ordre
+	/// des valeurs suit l'ordre des menus de la barre.
+	enum class ActionCategory : uint8_t
+	{
+		Fichier = 0,
+		Edition = 1,
+		Vue     = 2,
+		Fenetre = 3,
+		Outils  = 4,
+		Aide    = 5,
+	};
+
+	/// Déclaration unique d'une action de l'éditeur monde.
+	///
+	/// Champs fonctionnels (tous optionnels sauf `execute` hors tests) :
+	///   - `enabled` : nul => l'action est toujours activable ; sinon évalué
+	///     à chaque frame par les surfaces (item de menu grisé, bouton de la
+	///     barre d'actions grisé, entrée palette non exécutable).
+	///   - `checked` : nul => action « bouton » classique ; non nul => action
+	///     « toggle » (coche de menu, ex. visibilité d'un panneau).
+	///   - `execute` : effet de l'action. Toujours appelé depuis le main
+	///     thread, pendant la frame ImGui (les callbacks capturent des
+	///     pointeurs non possédés vers session/shell/config).
+	struct EditorAction
+	{
+		/// Identifiant stable kebab-case, préfixé par domaine
+		/// (ex. "file.save", "tool.terrain-sculpt", "window.panel.outliner").
+		/// Sert de clé de lookup ; jamais affiché à l'utilisateur.
+		std::string id;
+		/// Libellé français affiché (menus, palette, tooltips).
+		std::string label;
+		/// Catégorie de groupement (menu porteur).
+		ActionCategory category = ActionCategory::Fichier;
+		/// Sous-groupe optionnel dans la catégorie (en-tête `SeparatorText`
+		/// des menus, ex. "Import", "Export", "Terrain"). Vide = sans section.
+		std::string section;
+		/// Texte du raccourci affiché ("Ctrl+S"). L'EXÉCUTION du raccourci
+		/// reste dans les dispatchers existants (WorldEditorShell::
+		/// HandleShortcut, Engine) — le registre est la source du texte.
+		std::string shortcutText;
+		/// Prédicat d'activation (nul => toujours actif).
+		std::function<bool()> enabled;
+		/// Prédicat d'état coché pour les toggles (nul => pas un toggle).
+		std::function<bool()> checked;
+		/// Effet de l'action (main thread, frame ImGui en cours).
+		std::function<void()> execute;
+	};
+}

--- a/src/world_editor/actions/EditorActionRegistry.cpp
+++ b/src/world_editor/actions/EditorActionRegistry.cpp
@@ -1,0 +1,45 @@
+// EditorActionRegistry — implémentation. Voir EditorActionRegistry.h.
+
+#include "src/world_editor/actions/EditorActionRegistry.h"
+
+#include "src/shared/core/Log.h"
+
+namespace engine::editor::world::actions
+{
+	bool EditorActionRegistry::Register(EditorAction action)
+	{
+		if (action.id.empty())
+		{
+			LOG_WARN(EditorWorld, "EditorActionRegistry: id vide refuse (label='{}')",
+				action.label);
+			return false;
+		}
+		if (Find(action.id) != nullptr)
+		{
+			LOG_WARN(EditorWorld, "EditorActionRegistry: id duplique refuse '{}'",
+				action.id);
+			return false;
+		}
+		m_actions.push_back(std::move(action));
+		return true;
+	}
+
+	const EditorAction* EditorActionRegistry::Find(std::string_view id) const
+	{
+		// Lookup linéaire assumé : le registre reste petit (< 100 actions) et
+		// `Find` n'est appelé que sur des chemins UI (pas de hot loop).
+		for (const EditorAction& a : m_actions)
+		{
+			if (a.id == id)
+			{
+				return &a;
+			}
+		}
+		return nullptr;
+	}
+
+	bool EditorActionRegistry::IsEnabled(const EditorAction& action)
+	{
+		return action.enabled ? action.enabled() : true;
+	}
+}

--- a/src/world_editor/actions/EditorActionRegistry.h
+++ b/src/world_editor/actions/EditorActionRegistry.h
@@ -1,0 +1,52 @@
+#pragma once
+// EditorActionRegistry — registre central des actions de l'éditeur monde.
+// Rempli au boot (WorldEditorShell::Init pour les actions autonomes du
+// shell, WorldEditorImGui::RegisterEditorActions pour les actions session),
+// consommé chaque frame par les surfaces UI. Aucune dépendance ImGui.
+
+#include "src/world_editor/actions/EditorAction.h"
+
+#include <cstddef>
+#include <string_view>
+#include <vector>
+
+namespace engine::editor::world::actions
+{
+	/// Registre ordonné d'`EditorAction`. L'ordre d'enregistrement est
+	/// préservé par `Actions()` : les surfaces qui itèrent (menu Outils,
+	/// palette de commandes, fenêtre raccourcis) affichent donc les actions
+	/// dans l'ordre où elles ont été déclarées.
+	///
+	/// Contraintes thread/timing : toutes les méthodes doivent être appelées
+	/// depuis le main thread (les std::function capturent des états UI/doc
+	/// non thread-safe).
+	class EditorActionRegistry
+	{
+	public:
+		/// Enregistre une action. Refuse (retour false + LOG_WARN) un id vide
+		/// ou déjà présent — garantit l'unicité des ids sur laquelle reposent
+		/// `Find` et les surfaces UI.
+		/// Effet de bord : prend possession de `action` (move).
+		bool Register(EditorAction action);
+
+		/// Vue lecture seule, ordre d'enregistrement préservé.
+		const std::vector<EditorAction>& Actions() const { return m_actions; }
+
+		/// Lookup par id. \return nullptr si absent. Le pointeur reste valide
+		/// tant qu'aucun `Register`/`Clear` n'intervient (vector interne).
+		const EditorAction* Find(std::string_view id) const;
+
+		/// Évalue le prédicat `enabled` de l'action (nul => true).
+		static bool IsEnabled(const EditorAction& action);
+
+		/// Nombre d'actions enregistrées.
+		size_t Size() const { return m_actions.size(); }
+
+		/// Vide le registre. Réservé aux tests (le runtime enregistre une
+		/// seule fois par session).
+		void Clear() { m_actions.clear(); }
+
+	private:
+		std::vector<EditorAction> m_actions;
+	};
+}

--- a/src/world_editor/core/CommandStack.cpp
+++ b/src/world_editor/core/CommandStack.cpp
@@ -36,6 +36,10 @@ namespace engine::editor::world
 	{
 		if (!cmd) return;
 
+		// Toute commande accédant à Push (coalescée ou non) est une mutation
+		// du document : on incrémente le sériel de dirty-tracking avant même
+		// le coalescing (un brushstroke fusionné modifie bien le terrain).
+		++m_serial;
 		cmd->Execute();
 		m_redo.clear();
 		m_redoTimestamps.clear();
@@ -79,6 +83,7 @@ namespace engine::editor::world
 	void CommandStack::Undo()
 	{
 		if (m_undo.empty()) return;
+		++m_serial; // mutation du document (dirty-tracking, cf. Serial()).
 		auto cmd = std::move(m_undo.back());
 		m_undo.pop_back();
 		const uint64_t ts = m_undoTimestamps.back();
@@ -95,6 +100,7 @@ namespace engine::editor::world
 	void CommandStack::Redo()
 	{
 		if (m_redo.empty()) return;
+		++m_serial; // mutation du document (dirty-tracking, cf. Serial()).
 		auto cmd = std::move(m_redo.back());
 		m_redo.pop_back();
 		const uint64_t ts = m_redoTimestamps.back();
@@ -119,6 +125,9 @@ namespace engine::editor::world
 	/// destructeurs des commandes sont appelés par les `clear()`.
 	void CommandStack::Clear()
 	{
+		// Contrat simple : Clear incrémente toujours le sériel (même sur pile
+		// déjà vide) — aucun consommateur ne dépend du cas « clear no-op ».
+		++m_serial;
 		m_undo.clear();
 		m_redo.clear();
 		m_undoTimestamps.clear();

--- a/src/world_editor/core/CommandStack.h
+++ b/src/world_editor/core/CommandStack.h
@@ -149,6 +149,16 @@ namespace engine::editor::world
 		/// History pour rendre la liste sans exposer les pointeurs internes.
 		std::vector<HistoryEntry> SnapshotHistory() const;
 
+		/// Numéro de série monotone des mutations de la pile (réorganisation
+		/// UI 2026-07-17). Incrémenté par `Push` (y compris coalescé), `Undo`,
+		/// `Redo` et `Clear` ; inchangé par les no-op (Undo/Redo sur pile
+		/// vide). Sert au dirty-tracking « non sauvegardé » de l'éditeur :
+		/// `WorldEditorShell::NoteSaved` mémorise la valeur au moment du save,
+		/// `IsDirtySinceSave` compare. Contrairement à `UndoSize()`, la valeur
+		/// ne « revient » jamais en arrière (un Undo suivi d'un Redo produit
+		/// deux mutations, pas un retour à l'état sériel initial).
+		uint64_t Serial() const { return m_serial; }
+
 	private:
 		/// Évince la commande la plus ancienne (front) si la pile n'est pas
 		/// vide. Met à jour `m_totalBytes`. Appelé en boucle par `Push`.
@@ -160,5 +170,7 @@ namespace engine::editor::world
 		std::vector<uint64_t> m_redoTimestamps;
 		size_t m_totalBytes = 0;
 		CommandStackConfig m_cfg;
+		/// Compteur de mutations pour le dirty-tracking (cf. `Serial()`).
+		uint64_t m_serial = 0;
 	};
 }

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -18,7 +18,10 @@
 #include "src/shared/core/Config.h"
 #include "src/shared/core/Log.h"
 
+#include <cctype>   // std::tolower — ids kebab-case des toggles de panneaux
 #include <cstring>  // std::strcmp — filtrage du panneau « Scene » dans le menu View
+#include <functional>
+#include <utility>
 
 #include "src/world_editor/modes/EditorModeRegistry.h"
 #include "src/world_editor/prefs/UserPrefsStore.h"
@@ -330,10 +333,81 @@ namespace engine::editor::world
 			static_cast<panels::ToolPropertiesPanel*>(m_panels[5].get())->SetShell(this);
 		}
 
+		// Réorganisation UI 2026-07-17 — actions autonomes du shell (undo/
+		// redo, historique, toggles panneaux). Les actions dépendant de la
+		// session (save/load/export…) sont ajoutées par
+		// `WorldEditorImGui::RegisterEditorActions`.
+		RegisterShellActions();
+
 		m_initialized = true;
 		LOG_INFO(EditorWorld, "WorldEditorShell init OK, {} panels, layout='{}', cameraMode='{}'",
 			m_panels.size(), m_layoutPath, lastMode);
 		return true;
+	}
+
+	void WorldEditorShell::RegisterShellActions()
+	{
+		using actions::ActionCategory;
+		using actions::EditorAction;
+
+		// Helper local : construit + enregistre une action en une expression.
+		auto add = [this](const char* id, const char* label, ActionCategory cat,
+			const char* shortcut,
+			std::function<bool()> enabled, std::function<bool()> checked,
+			std::function<void()> execute)
+		{
+			EditorAction a;
+			a.id = id;
+			a.label = label;
+			a.category = cat;
+			a.shortcutText = (shortcut != nullptr) ? shortcut : "";
+			a.enabled = std::move(enabled);
+			a.checked = std::move(checked);
+			a.execute = std::move(execute);
+			(void)m_actions.Register(std::move(a));
+		};
+
+		add("edit.undo", "Annuler", ActionCategory::Edition, "Ctrl+Z",
+			[this] { return m_commandStack.CanUndo(); }, nullptr,
+			[this] { m_commandStack.Undo(); });
+		add("edit.redo", "Rétablir", ActionCategory::Edition, "Ctrl+Y",
+			[this] { return m_commandStack.CanRedo(); }, nullptr,
+			[this] { m_commandStack.Redo(); });
+
+		// Toggle de visibilité par panneau (menu « Fenêtre »). Le panneau
+		// « Scene » est exclu (doublon de la vue 3D principale, cf. menu Vue
+		// historique). Id kebab-case dérivé du nom : "Asset Browser" →
+		// "window.panel.asset-browser". Les IPanel* capturés sont possédés
+		// par `m_panels` et restent valides jusqu'à `Shutdown`.
+		for (auto& panel : m_panels)
+		{
+			if (!panel) continue;
+			const char* name = panel->GetName();
+			if (std::strcmp(name, "Scene") == 0) continue;
+			std::string id = "window.panel.";
+			for (const char* c = name; *c != '\0'; ++c)
+			{
+				id.push_back(*c == ' ' ? '-'
+					: static_cast<char>(std::tolower(static_cast<unsigned char>(*c))));
+			}
+			IPanel* p = panel.get();
+			add(id.c_str(), name, ActionCategory::Fenetre, nullptr,
+				nullptr,
+				[p] { return p->IsVisible(); },
+				[p] { p->SetVisible(!p->IsVisible()); });
+
+			// « Historique des annulations » : alias d'ouverture du panneau
+			// History dans le menu Édition (convention UE : l'historique
+			// d'annulation se trouve sous Edit).
+			if (std::strcmp(name, "History") == 0)
+			{
+				add("edit.history", "Historique des annulations",
+					ActionCategory::Edition, nullptr,
+					nullptr,
+					[p] { return p->IsVisible(); },
+					[p] { p->SetVisible(!p->IsVisible()); });
+			}
+		}
 	}
 
 	/// M100.6 — Active un outil et logge la transition. Garde l'API simple :

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -519,13 +519,15 @@ namespace engine::editor::world
 #endif
 	}
 
-	/// Rend la barre de menu File/Edit/View/Tools/Window/Help. M100.1 : la
-	/// plupart des items sont des stubs no-op qui loguent leur déclenchement.
-	/// File/New/Open/Save sont stubs jusqu'aux tickets save/load. Edit/Undo
-	/// /Redo grisés (activés en M100.2). View propose le toggle de chaque
-	/// panneau et Reset Layout. Tools vide. Window expose 4 layouts pré-
-	/// définis (3 identiques au Default en M100.1). Help/About : version
-	/// figée pour l'instant.
+	/// Rend la barre de menu de repli Edit/View/Help. Réorganisation UI
+	/// 2026-07-17 : la barre M100.1 historique (File/Edit/View/Tools/Window/
+	/// Help) est dégraissée de ses stubs no-op (File New/Open/Save/Exit),
+	/// de son menu Tools vide et de ses 4 layouts Window aliasés sur
+	/// Default. Ne restent que les menus fonctionnels : Edit (undo/redo),
+	/// View (toggles panneaux + reset layout), Help (version). Cette barre
+	/// ne sert que le mode shell « couche au-dessus » in-game : dans le
+	/// binaire éditeur monde, elle est supprimée (SetMenuBarSuppressed) au
+	/// profit du menu français complet de WorldEditorImGui.
 	void WorldEditorShell::RenderMenuBar()
 	{
 #if defined(_WIN32)
@@ -538,28 +540,6 @@ namespace engine::editor::world
 		// par WorldEditorImGui.
 		if (m_menuBarSuppressed) return;
 		if (!ImGui::BeginMainMenuBar()) return;
-
-		if (ImGui::BeginMenu("File"))
-		{
-			if (ImGui::MenuItem("New", nullptr, false, true))
-			{
-				LOG_INFO(EditorWorld, "Menu File/New (no-op M100.1, save/load à venir)");
-			}
-			if (ImGui::MenuItem("Open", nullptr, false, true))
-			{
-				LOG_INFO(EditorWorld, "Menu File/Open (no-op M100.1, save/load à venir)");
-			}
-			if (ImGui::MenuItem("Save", "Ctrl+S", false, true))
-			{
-				MarkDirty("File/Save no-op M100.1");
-			}
-			ImGui::Separator();
-			if (ImGui::MenuItem("Exit", "Ctrl+Q", false, true))
-			{
-				LOG_INFO(EditorWorld, "Menu File/Exit (no-op M100.1, dialog à venir)");
-			}
-			ImGui::EndMenu();
-		}
 
 		if (ImGui::BeginMenu("Edit"))
 		{
@@ -597,38 +577,6 @@ namespace engine::editor::world
 			{
 				ResetLayoutToDefault();
 				LOG_INFO(EditorWorld, "Menu View/Reset Layout");
-			}
-			ImGui::EndMenu();
-		}
-
-		if (ImGui::BeginMenu("Tools"))
-		{
-			ImGui::TextDisabled("(à remplir par les tickets outils)");
-			ImGui::EndMenu();
-		}
-
-		if (ImGui::BeginMenu("Window"))
-		{
-			// Les 3 derniers layouts sont identiques au Default en M100.1.
-			if (ImGui::MenuItem("Default Layout"))
-			{
-				ResetLayoutToDefault();
-				LOG_INFO(EditorWorld, "Menu Window/Default Layout");
-			}
-			if (ImGui::MenuItem("Sculpting Layout"))
-			{
-				ResetLayoutToDefault();
-				LOG_INFO(EditorWorld, "Menu Window/Sculpting Layout (alias Default M100.1)");
-			}
-			if (ImGui::MenuItem("Painting Layout"))
-			{
-				ResetLayoutToDefault();
-				LOG_INFO(EditorWorld, "Menu Window/Painting Layout (alias Default M100.1)");
-			}
-			if (ImGui::MenuItem("Placement Layout"))
-			{
-				ResetLayoutToDefault();
-				LOG_INFO(EditorWorld, "Menu Window/Placement Layout (alias Default M100.1)");
 			}
 			ImGui::EndMenu();
 		}

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -445,6 +445,16 @@ namespace engine::editor::world
 		/// la visibilité de tous les panneaux à true.
 		void ResetLayoutToDefault();
 
+		/// Réorganisation UI 2026-07-17 — Enregistre dans `m_actions` les
+		/// actions autonomes du shell (ne dépendant ni de la session ni de la
+		/// config) : Annuler/Rétablir (pile de commandes), Historique des
+		/// annulations, et un toggle de visibilité par panneau (sauf
+		/// « Scene », doublon de la vue 3D). Appelée en fin d'`Init`, après
+		/// la création des panneaux (les callbacks capturent des `IPanel*`
+		/// non possédés, valides jusqu'à `Shutdown`).
+		/// Effet de bord : remplit `m_actions`.
+		void RegisterShellActions();
+
 		/// M100.4 — Helper privé : retourne le ScenePanel (index 0 dans
 		/// `m_panels`, ordre stable garanti par Init). Utilisé par
 		/// `HandleShortcut` pour brancher Numpad 1/3/7 → SetMode et par

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/actions/EditorActionRegistry.h"
 #include "src/world_editor/buildings/BuildingDocument.h"
 #include "src/client/world/instances/BuildingTemplateLibrary.h"
 #include "src/world_editor/quests/QuestEditIo.h"
@@ -124,6 +125,27 @@ namespace engine::editor::world
 		/// (le mécanisme de save sera ajouté dans un ticket ultérieur).
 		bool IsDirty() const { return m_dirty; }
 
+		/// Réorganisation UI 2026-07-17 — À appeler après un save réussi
+		/// (`WorldEditorSession::ActionSaveCurrentMap` + persistance chunks) :
+		/// mémorise le sériel courant du `CommandStack` et remet `m_dirty` à
+		/// false. `IsDirtySinceSave` compare ensuite à ce point de référence.
+		/// Effet de bord : écrit `m_savedSerial` et `m_dirty`.
+		void NoteSaved()
+		{
+			m_savedSerial = m_commandStack.Serial();
+			m_dirty = false;
+		}
+
+		/// Réorganisation UI 2026-07-17 — true si l'état édité a changé depuis
+		/// le dernier `NoteSaved` : soit via la pile de commandes (sériel
+		/// différent), soit via un `MarkDirty` explicite. Consommé par
+		/// l'indicateur « Non sauvegardé » de la barre de statut et par la
+		/// modale de confirmation de « Quitter ».
+		bool IsDirtySinceSave() const
+		{
+			return m_dirty || m_commandStack.Serial() != m_savedSerial;
+		}
+
 		/// Retourne true si Init() a été appelé avec succès et que Shutdown()
 		/// n'a pas encore été appelé.
 		bool IsInitialized() const { return m_initialized; }
@@ -150,6 +172,16 @@ namespace engine::editor::world
 		/// tests et les UIs en lecture (HistoryPanel passe par un pointeur
 		/// non-const car il appelle Clear/RewindTo).
 		const CommandStack& GetCommandStack() const { return m_commandStack; }
+
+		/// Réorganisation UI 2026-07-17 — Registre central des actions de
+		/// l'éditeur. Le shell y enregistre à `Init` ses actions autonomes
+		/// (undo/redo, historique, toggles de panneaux, reset layout) ;
+		/// `WorldEditorImGui::RegisterEditorActions` y ajoute les actions qui
+		/// dépendent de la session (save/load/export/import/quit/outils…).
+		/// Consommé par la barre de menu française, la barre d'actions, la
+		/// palette de commandes Ctrl+P et la fenêtre « Raccourcis clavier ».
+		actions::EditorActionRegistry&       MutableActionRegistry()       { return m_actions; }
+		const actions::EditorActionRegistry& GetActionRegistry()     const { return m_actions; }
 
 		/// M100.6 — Retourne l'outil actuellement actif (None par défaut).
 		ActiveTool GetActiveTool() const { return m_activeTool; }
@@ -450,6 +482,9 @@ namespace engine::editor::world
 		engine::editor::world::quests::QuestEditIo m_questEditIo;    // SP4 — E/S authoring quêtes
 		panels::QuestEditorPanel* m_questEditorPtr = nullptr;        // non possédé (dans m_panels)
 		ActiveTool m_activeTool = ActiveTool::None;
+		actions::EditorActionRegistry m_actions; // réorganisation UI 2026-07-17
+		/// Sériel du CommandStack au dernier `NoteSaved` (dirty-tracking).
+		uint64_t m_savedSerial = 0;
 		std::string m_layoutPath;
 		bool m_dirty = false;
 		bool m_initialized = false;

--- a/src/world_editor/prefs/UserPrefs.h
+++ b/src/world_editor/prefs/UserPrefs.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace engine::editor::world::prefs
 {
@@ -23,6 +24,11 @@ namespace engine::editor::world::prefs
 		std::unordered_map<std::string, std::string> lastPresetByTool;
 		bool                                         showAdvancedTooltips = false;
 		std::unordered_map<std::string, bool>        tutorialCompletionFlags;
+		/// Réorganisation UI 2026-07-17 — zoneIds des cartes récemment
+		/// chargées/sauvegardées, plus récente en tête, plafonné à
+		/// `UserPrefsStore::kMaxRecentMaps`. Alimente le sous-menu
+		/// « Fichier > Cartes récentes ».
+		std::vector<std::string>                     recentMapIds;
 	};
 
 	/// Version de schéma courante écrite dans le champ `version`.

--- a/src/world_editor/prefs/UserPrefsStore.cpp
+++ b/src/world_editor/prefs/UserPrefsStore.cpp
@@ -120,6 +120,28 @@ namespace engine::editor::world::prefs
 			}
 		}
 
+		/// Lit un tableau `[ "a", "b", ... ]` de strings. Curseur sur le `[`.
+		/// Tolérant : s'arrête au `]` ou à la première anomalie (le contenu
+		/// déjà lu est conservé).
+		void ReadStringArray(const std::string& s, size_t p,
+			std::vector<std::string>& out)
+		{
+			SkipWs(s, p);
+			if (p >= s.size() || s[p] != '[') return;
+			++p;
+			while (p < s.size())
+			{
+				SkipWs(s, p);
+				if (p < s.size() && s[p] == ']') return;
+				std::string val;
+				if (!ReadString(s, p, val)) return;
+				out.push_back(std::move(val));
+				SkipWs(s, p);
+				if (p < s.size() && s[p] == ',') { ++p; continue; }
+				if (p < s.size() && s[p] == ']') return;
+			}
+		}
+
 		std::string EscapeJson(const std::string& in)
 		{
 			std::string out;
@@ -204,6 +226,14 @@ namespace engine::editor::world::prefs
 		{
 			ReadBoolMap(json, pos, parsed.tutorialCompletionFlags);
 		}
+		if (SeekKey(json, "recentMapIds", pos))
+		{
+			ReadStringArray(json, pos, parsed.recentMapIds);
+			if (parsed.recentMapIds.size() > kMaxRecentMaps)
+			{
+				parsed.recentMapIds.resize(kMaxRecentMaps);
+			}
+		}
 
 		m_prefs = std::move(parsed);
 	}
@@ -245,7 +275,19 @@ namespace engine::editor::world::prefs
 				    << (kv.second ? "true" : "false");
 				first = false;
 			}
-			out << (first ? "}" : "\n  }") << "\n";
+			out << (first ? "}" : "\n  }") << ",\n";
+		}
+
+		out << "  \"recentMapIds\": [";
+		{
+			bool first = true;
+			for (const std::string& id : m_prefs.recentMapIds)
+			{
+				out << (first ? "\n" : ",\n");
+				out << "    \"" << EscapeJson(id) << "\"";
+				first = false;
+			}
+			out << (first ? "]" : "\n  ]") << "\n";
 		}
 		out << "}\n";
 
@@ -311,6 +353,25 @@ namespace engine::editor::world::prefs
 		auto it = m_prefs.tutorialCompletionFlags.find(flagId);
 		if (it != m_prefs.tutorialCompletionFlags.end() && it->second == value) return;
 		m_prefs.tutorialCompletionFlags[flagId] = value;
+		(void)SaveToDisk();
+	}
+
+	void UserPrefsStore::PushRecentMap(const std::string& zoneId)
+	{
+		if (zoneId.empty()) return;
+		std::vector<std::string>& recents = m_prefs.recentMapIds;
+		// Dédoublonnage : une occurrence existante est retirée avant la
+		// réinsertion en tête (la carte « remonte »).
+		for (auto it = recents.begin(); it != recents.end(); )
+		{
+			if (*it == zoneId) it = recents.erase(it);
+			else ++it;
+		}
+		recents.insert(recents.begin(), zoneId);
+		if (recents.size() > kMaxRecentMaps)
+		{
+			recents.resize(kMaxRecentMaps);
+		}
 		(void)SaveToDisk();
 	}
 

--- a/src/world_editor/prefs/UserPrefsStore.h
+++ b/src/world_editor/prefs/UserPrefsStore.h
@@ -44,6 +44,19 @@ namespace engine::editor::world::prefs
 		bool GetTutorialFlag(const std::string& flagId) const;
 		void SetTutorialFlag(const std::string& flagId, bool value);
 
+		/// Réorganisation UI 2026-07-17 — Plafond du nombre de cartes
+		/// récentes mémorisées (sous-menu « Fichier > Cartes récentes »).
+		static constexpr size_t kMaxRecentMaps = 8;
+
+		/// Enregistre \p zoneId comme carte la plus récente : dédoublonne
+		/// (une occurrence existante remonte en tête), insère en tête,
+		/// tronque à `kMaxRecentMaps`, persiste immédiatement. Un zoneId
+		/// vide est ignoré (no-op). Effet de bord : écriture disque.
+		void PushRecentMap(const std::string& zoneId);
+
+		/// Cartes récentes, plus récente en tête.
+		const std::vector<std::string>& GetRecentMaps() const { return m_prefs.recentMapIds; }
+
 		bool IsInitialized() const { return m_initialized; }
 
 		/// Réinitialise l'état (défauts, non initialisé). Réservé aux tests.

--- a/src/world_editor/tests/EditorActionRegistryTests.cpp
+++ b/src/world_editor/tests/EditorActionRegistryTests.cpp
@@ -1,0 +1,190 @@
+/// Tests unitaires CPU pour le registre d'actions de l'éditeur monde
+/// (réorganisation UI 2026-07-17, PR 1).
+///
+/// Pas d'ImGui ni de GPU — la suite tourne sous ctest Linux. On vérifie :
+///   - Register accepte une action valide et préserve l'ordre d'insertion.
+///   - Register refuse un id vide et un id dupliqué (unicité garantie).
+///   - Find retrouve une action par id, nullptr sinon.
+///   - IsEnabled : nul => true ; sinon le prédicat est évalué.
+///   - Les toggles (checked) et l'exécution (execute) sont câblés.
+///   - CommandStack::Serial() : monotone sur Push/Undo/Redo/Clear (le
+///     dirty-tracking « non sauvegardé » de la barre de statut et de la
+///     modale Quitter repose dessus).
+///
+/// Framework : REQUIRE maison + main monolithique (pattern identique aux
+/// autres suites de tests world_editor).
+
+#include "src/world_editor/actions/EditorActionRegistry.h"
+#include "src/world_editor/core/CommandStack.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::editor::world::actions::ActionCategory;
+	using engine::editor::world::actions::EditorAction;
+	using engine::editor::world::actions::EditorActionRegistry;
+	using engine::editor::world::CommandStack;
+	using engine::editor::world::ICommand;
+
+	/// Fabrique une action minimale valide pour les tests.
+	EditorAction MakeAction(const char* id, const char* label)
+	{
+		EditorAction a;
+		a.id = id;
+		a.label = label;
+		a.execute = [] {};
+		return a;
+	}
+
+	/// Test : enregistrement nominal + ordre d'insertion préservé + Size.
+	void Test_Register_PreservesInsertionOrder()
+	{
+		EditorActionRegistry reg;
+		REQUIRE(reg.Size() == 0);
+		REQUIRE(reg.Register(MakeAction("file.save", "Sauvegarder")));
+		REQUIRE(reg.Register(MakeAction("edit.undo", "Annuler")));
+		REQUIRE(reg.Register(MakeAction("edit.redo", "Retablir")));
+		REQUIRE(reg.Size() == 3);
+		REQUIRE(reg.Actions()[0].id == "file.save");
+		REQUIRE(reg.Actions()[1].id == "edit.undo");
+		REQUIRE(reg.Actions()[2].id == "edit.redo");
+	}
+
+	/// Test : id vide refusé, id dupliqué refusé (le registre reste intact).
+	void Test_Register_RejectsEmptyAndDuplicateIds()
+	{
+		EditorActionRegistry reg;
+		REQUIRE(!reg.Register(MakeAction("", "Sans id")));
+		REQUIRE(reg.Size() == 0);
+
+		REQUIRE(reg.Register(MakeAction("file.save", "Sauvegarder")));
+		REQUIRE(!reg.Register(MakeAction("file.save", "Doublon")));
+		REQUIRE(reg.Size() == 1);
+		REQUIRE(reg.Find("file.save")->label == "Sauvegarder");
+	}
+
+	/// Test : Find retrouve par id, nullptr si absent.
+	void Test_Find_ReturnsActionOrNull()
+	{
+		EditorActionRegistry reg;
+		REQUIRE(reg.Register(MakeAction("view.grid", "Grille")));
+		const EditorAction* found = reg.Find("view.grid");
+		REQUIRE(found != nullptr);
+		REQUIRE(found->label == "Grille");
+		REQUIRE(reg.Find("absent.id") == nullptr);
+	}
+
+	/// Test : IsEnabled — prédicat nul => true ; sinon évalué à l'appel.
+	void Test_IsEnabled_EvaluatesPredicate()
+	{
+		EditorAction always = MakeAction("a.always", "Toujours");
+		REQUIRE(EditorActionRegistry::IsEnabled(always));
+
+		bool gate = false;
+		EditorAction gated = MakeAction("a.gated", "Conditionnelle");
+		gated.enabled = [&gate] { return gate; };
+		REQUIRE(!EditorActionRegistry::IsEnabled(gated));
+		gate = true;
+		REQUIRE(EditorActionRegistry::IsEnabled(gated));
+	}
+
+	/// Test : toggle (checked) + execute câblés — le pattern utilisé par les
+	/// items de menu à coche (visibilité de panneau, grille).
+	void Test_ToggleAction_CheckedAndExecute()
+	{
+		bool visible = false;
+		EditorAction toggle = MakeAction("window.panel.test", "Panneau test");
+		toggle.category = ActionCategory::Fenetre;
+		toggle.checked = [&visible] { return visible; };
+		toggle.execute = [&visible] { visible = !visible; };
+
+		EditorActionRegistry reg;
+		REQUIRE(reg.Register(std::move(toggle)));
+		const EditorAction* a = reg.Find("window.panel.test");
+		REQUIRE(a != nullptr);
+		REQUIRE(a->checked && a->checked() == false);
+		a->execute();
+		REQUIRE(a->checked() == true);
+		a->execute();
+		REQUIRE(a->checked() == false);
+	}
+
+	/// Commande stub : aucun effet, empreinte fixe — sert uniquement à
+	/// exercer Push/Undo/Redo de la pile pour le test de Serial().
+	class StubCommand final : public ICommand
+	{
+	public:
+		const char* GetLabel() const override { return "stub"; }
+		size_t GetMemoryFootprint() const override { return 16; }
+		void Execute() override {}
+		void Undo() override {}
+	};
+
+	/// Test : Serial() est monotone croissant à chaque mutation de la pile
+	/// (Push, Undo, Redo, Clear) et stable sinon. Les no-op (Undo sur pile
+	/// vide) ne l'incrémentent pas.
+	void Test_CommandStackSerial_MonotonicOnMutations()
+	{
+		CommandStack stack;
+		const uint64_t s0 = stack.Serial();
+		REQUIRE(s0 == 0);
+
+		// No-op : Undo/Redo sur piles vides ne mutent rien.
+		stack.Undo();
+		stack.Redo();
+		REQUIRE(stack.Serial() == s0);
+
+		stack.Push(std::make_unique<StubCommand>());
+		const uint64_t s1 = stack.Serial();
+		REQUIRE(s1 > s0);
+
+		stack.Undo();
+		const uint64_t s2 = stack.Serial();
+		REQUIRE(s2 > s1);
+
+		stack.Redo();
+		const uint64_t s3 = stack.Serial();
+		REQUIRE(s3 > s2);
+
+		stack.Clear();
+		const uint64_t s4 = stack.Serial();
+		REQUIRE(s4 > s3);
+
+		// Clear sur pile déjà vide : toujours compté comme mutation ? Non —
+		// on fige le contrat : Clear n'incrémente que s'il a vidé quelque
+		// chose est trop subtil ; le contrat simple retenu est « Clear
+		// incrémente toujours » (coût nul, aucune surprise consommateur).
+		stack.Clear();
+		REQUIRE(stack.Serial() > s4);
+	}
+}
+
+int main()
+{
+	Test_Register_PreservesInsertionOrder();
+	Test_Register_RejectsEmptyAndDuplicateIds();
+	Test_Find_ReturnsActionOrNull();
+	Test_IsEnabled_EvaluatesPredicate();
+	Test_ToggleAction_CheckedAndExecute();
+	Test_CommandStackSerial_MonotonicOnMutations();
+
+	if (g_failed > 0)
+	{
+		std::fprintf(stderr, "[EditorActionRegistryTests] %d failure(s)\n", g_failed);
+		return 1;
+	}
+	std::fprintf(stdout, "[EditorActionRegistryTests] all tests passed\n");
+	return 0;
+}

--- a/src/world_editor/tests/EditorModesTests.cpp
+++ b/src/world_editor/tests/EditorModesTests.cpp
@@ -304,6 +304,65 @@ namespace
 		store.ResetForTesting();
 	}
 
+	/// Réorganisation UI 2026-07-17 — cartes récentes : dédoublonnage (la
+	/// carte remonte en tête), plafond kMaxRecentMaps, zoneId vide ignoré.
+	void Test_UserPrefs_RecentMaps_DedupAndCap()
+	{
+		auto& store = prefs::UserPrefsStore::Instance();
+		store.ResetForTesting();
+
+		store.PushRecentMap("zone_a");
+		store.PushRecentMap("zone_b");
+		store.PushRecentMap("zone_c");
+		REQUIRE(store.GetRecentMaps().size() == 3u);
+		REQUIRE(store.GetRecentMaps()[0] == "zone_c");
+		REQUIRE(store.GetRecentMaps()[2] == "zone_a");
+
+		// Re-push d'une carte existante : elle remonte en tête, pas de doublon.
+		store.PushRecentMap("zone_a");
+		REQUIRE(store.GetRecentMaps().size() == 3u);
+		REQUIRE(store.GetRecentMaps()[0] == "zone_a");
+		REQUIRE(store.GetRecentMaps()[1] == "zone_c");
+
+		// zoneId vide : no-op.
+		store.PushRecentMap("");
+		REQUIRE(store.GetRecentMaps().size() == 3u);
+
+		// Plafond : pousser 10 zones distinctes -> seules les 8 dernières restent.
+		for (int i = 0; i < 10; ++i)
+		{
+			store.PushRecentMap("zone_flood_" + std::to_string(i));
+		}
+		REQUIRE(store.GetRecentMaps().size() == prefs::UserPrefsStore::kMaxRecentMaps);
+		REQUIRE(store.GetRecentMaps()[0] == "zone_flood_9");
+
+		store.ResetForTesting();
+	}
+
+	/// Réorganisation UI 2026-07-17 — round-trip disque des cartes récentes
+	/// (sérialisation JSON symétrique, ordre préservé).
+	void Test_UserPrefs_RecentMaps_RoundTripPersist()
+	{
+		const auto root = MakeTempContentRoot("prefs_recent");
+		auto& store = prefs::UserPrefsStore::Instance();
+		store.ResetForTesting();
+		store.Init(root.string());
+
+		store.PushRecentMap("vallee_de_la_planche");
+		store.PushRecentMap("zone_1");
+
+		store.ResetForTesting();
+		const bool existed = store.Init(root.string());
+		REQUIRE(existed);
+		REQUIRE(store.GetRecentMaps().size() == 2u);
+		REQUIRE(store.GetRecentMaps()[0] == "zone_1");
+		REQUIRE(store.GetRecentMaps()[1] == "vallee_de_la_planche");
+
+		std::error_code ec;
+		std::filesystem::remove_all(root, ec);
+		store.ResetForTesting();
+	}
+
 	void Test_UserPrefs_TolerantToMalformedFile()
 	{
 		const auto root = MakeTempContentRoot("prefs_bad");
@@ -337,6 +396,8 @@ int main()
 	Test_UserPrefs_FirstLaunchCreatesDefaults();
 	Test_UserPrefs_RoundTripPersist();
 	Test_UserPrefs_AtomicSaveLeavesNoTmp();
+	Test_UserPrefs_RecentMaps_DedupAndCap();
+	Test_UserPrefs_RecentMaps_RoundTripPersist();
 	Test_UserPrefs_TolerantToMalformedFile();
 
 	if (g_failed > 0)

--- a/src/world_editor/tests/EditorToolbarTests.cpp
+++ b/src/world_editor/tests/EditorToolbarTests.cpp
@@ -179,6 +179,29 @@ namespace
 		REQUIRE(std::strcmp(deselect.letter, "X") == 0);
 	}
 
+	/// Test (réorganisation UI 2026-07-17) : NoteSaved/IsDirtySinceSave — le
+	/// dirty-tracking consommé par la barre de statut et la modale Quitter.
+	/// Un shell neuf n'est pas dirty ; MarkDirty le rend dirty ; NoteSaved le
+	/// blanchit ; une mutation de la pile de commandes le re-salit.
+	void Test_Shell_DirtySinceSave_Tracking()
+	{
+		WorldEditorShell shell;
+		REQUIRE(!shell.IsDirtySinceSave());
+
+		shell.MarkDirty("test");
+		REQUIRE(shell.IsDirtySinceSave());
+
+		shell.NoteSaved();
+		REQUIRE(!shell.IsDirtySinceSave());
+
+		// Mutation de la pile (Clear incrémente le sériel) → dirty à nouveau.
+		shell.MutableCommandStack().Clear();
+		REQUIRE(shell.IsDirtySinceSave());
+
+		shell.NoteSaved();
+		REQUIRE(!shell.IsDirtySinceSave());
+	}
+
 	/// Test : activation d'un nouvel outil ne déclenche AUCUN side effect
 	/// sur l'état dirty / panels / initialized du shell. C'est un proxy
 	/// observable pour l'invariant de visibilité du terrain : si
@@ -213,6 +236,7 @@ int main()
 	Test_Toolbar_ClickRoutesToSetActiveTool();
 	Test_Toolbar_HitTestOutsideAllButtons_ReturnsFalse();
 	Test_Toolbar_MissingIcon_FallsBackToPlaceholder();
+	Test_Shell_DirtySinceSave_Tracking();
 	Test_NewToolActivation_DoesNotResetCameraOrFrustumCullState();
 
 	if (g_failed > 0)

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -11,6 +11,7 @@
 #include "src/world_editor/modes/EditorModeRegistry.h"
 #include "src/world_editor/prefs/UserPrefsStore.h"
 #include "src/world_editor/actions/EditorActionRegistry.h"
+#include "src/world_editor/ui/ToolbarIconAtlas.h" // libellé FR de l'outil actif (barre de statut)
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/core/WorldEditorShell.h"
@@ -1698,8 +1699,50 @@ namespace engine::editor
 			}
 			ImGui::End();
 
+			// Réorganisation UI 2026-07-17 — barre de statut enrichie
+			// (convention UE) : message de session | carte courante | outil
+			// actif, et à droite l'indicateur « Tout enregistré / Non
+			// sauvegardé » (même source dirty que la modale Quitter :
+			// WorldEditorShell::IsDirtySinceSave). Remplace l'affichage du
+			// statut dans la barre de menu (supprimé par la réorganisation).
 			ImGui::Begin("Statut", nullptr, ImGuiWindowFlags_NoMouseInputs);
-			ImGui::TextWrapped("%s", m_session->Status().c_str());
+			{
+				ImGui::TextUnformatted(m_session->Status().c_str());
+				ImGui::SameLine();
+				ImGui::TextDisabled("|  Carte : %s", m_session->Doc().zoneId.c_str());
+				if (m_shell != nullptr)
+				{
+					ImGui::SameLine();
+					const engine::editor::world::ToolIconStyle toolStyle =
+						engine::editor::world::ToolbarIconAtlas::Get(m_shell->GetActiveTool());
+					ImGui::TextDisabled("|  Outil : %s",
+						(m_shell->GetActiveTool() == engine::editor::world::ActiveTool::None)
+							? "aucun" : toolStyle.tooltipFr);
+
+					// Indicateur de sauvegarde aligné à droite.
+					const bool dirty = m_shell->IsDirtySinceSave();
+					const char* saveText =
+						dirty ? "\xE2\x97\x8F Non sauvegardé" : "Tout enregistré";
+					const float textW = ImGui::CalcTextSize(saveText).x;
+					const float avail = ImGui::GetContentRegionAvail().x;
+					if (avail > textW + 16.0f)
+					{
+						ImGui::SameLine(0.0f, avail - textW - 8.0f);
+					}
+					else
+					{
+						ImGui::SameLine();
+					}
+					if (dirty)
+					{
+						ImGui::TextColored(ImVec4(1.0f, 0.77f, 0.25f, 1.0f), "%s", saveText);
+					}
+					else
+					{
+						ImGui::TextDisabled("%s", saveText);
+					}
+				}
+			}
 			ImGui::End();
 		}
 		else

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -9,6 +9,8 @@
 #include "src/world_editor/ui/TreeSpeciesCatalog.h"
 #include "src/world_editor/ui/WorldEditorSession.h"
 #include "src/world_editor/modes/EditorModeRegistry.h"
+#include "src/world_editor/prefs/UserPrefsStore.h"
+#include "src/world_editor/actions/EditorActionRegistry.h"
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/core/WorldEditorShell.h"
@@ -846,279 +848,16 @@ namespace engine::editor
 		// rectangle après son rendu, plus bas dans cette frame.
 		m_widgetTargets.Clear();
 
-		if (ImGui::BeginMainMenuBar())
-		{
-			if (ImGui::BeginMenu("Fichier"))
-			{
-				if (ImGui::MenuItem("Sauvegarder la carte courante", "Ctrl+S", false, m_session != nullptr && m_cfg != nullptr)
-					&& m_session && m_cfg)
-				{
-					(void)m_session->ActionSaveCurrentMap(*m_cfg);
-				}
-				// Lot C vague 4 — Export runtime BLOQUÉ si la dernière validation a
-				// remonté des erreurs. Le bouton est désactivé tant que
-				// `m_lastValidationReport.HasBlockingErrors()` ; il reste actif si
-				// aucune validation n'a encore tourné (l'utilisateur reste libre,
-				// mais le panneau Validation l'invite à valider avant export).
-				const bool exportBlocked = m_validationHasRun && m_lastValidationReport.HasBlockingErrors();
-				const bool exportEnabled = m_session != nullptr && m_cfg != nullptr && !exportBlocked;
-				if (ImGui::MenuItem("Exporter en runtime", nullptr, false, exportEnabled)
-					&& m_session && m_cfg && !exportBlocked)
-				{
-					(void)m_session->ActionExportRuntime(*m_cfg);
-				}
-				// Enregistre le rectangle de cette entrée menu pour le guidance
-				// overlay (id stable conforme à la convention <panel>.<sous>.<id>).
-				m_widgetTargets.Register("menubar.file.export_runtime",
-					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
-					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
-				if (exportBlocked && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-				{
-					ImGui::SetTooltip("Export bloque : corrigez les erreurs de validation (panneau Validation).");
-				}
-				// Lot C vague 4 — Bouton de validation de zone dans le menu Fichier.
-				if (ImGui::MenuItem("Valider la zone", nullptr, false, m_shell != nullptr))
-				{
-					RunZoneValidation();
-				}
-				m_widgetTargets.Register("toolbar.button.validate",
-					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
-					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
-				ImGui::Separator();
-				// Lot C vague 4 — assistant « Nouvelle zone » (QuickStartWizard).
-				// Désactivé si le Shell n'est pas branché (la génération a besoin
-				// des 4 documents + catalogs + CommandStack, comme le dialog preset).
-				if (ImGui::MenuItem("Nouvelle zone (assistant)...", nullptr, false,
-					m_shell != nullptr)
-					&& m_shell)
-				{
-					// Transition fermé→ouvert : on réinitialise l'assistant pour
-					// qu'il reparte de l'étape 1 (Climat), sans état résiduel d'une
-					// session précédente (choix, seed, bandeau de résumé).
-					if (!m_showWizard)
-					{
-						ResetWizardState();
-					}
-					m_showWizard = true;
-				}
-				m_widgetTargets.Register("menubar.file.new_zone_wizard",
-					{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
-					  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
-				// M100.46 incrément 3 — entrée menu pour appliquer un Zone
-				// Preset. Désactivée si le Shell n'est pas branché (le
-				// dialog a besoin des 4 documents + catalogs).
-				if (ImGui::MenuItem("Appliquer un preset de zone...", nullptr, false,
-					m_shell != nullptr && m_zonePresetDialog != nullptr)
-					&& m_shell && m_zonePresetDialog)
-				{
-					m_zonePresetDialog->Open();
-				}
-				ImGui::Separator();
-				if (ImGui::MenuItem("Importer une texture (PNG/JPG/TGA/BMP)...", nullptr, false, m_session != nullptr && m_cfg != nullptr)
-					&& m_session && m_cfg)
-				{
-					(void)m_session->ActionImportTexture(*m_cfg);
-				}
-				if (ImGui::MenuItem("Importer un son (WAV/OGG)...", nullptr, false, m_session != nullptr && m_cfg != nullptr)
-					&& m_session && m_cfg)
-				{
-					(void)m_session->ActionImportAudio(*m_cfg);
-				}
-				ImGui::Separator();
-				ImGui::MenuItem("Quitter", nullptr, false, false);
-				ImGui::EndMenu();
-			}
-			// Menu Édition — migré depuis WorldEditorShell::RenderMenuBar
-			// quand sa barre est supprimée (m_worldEditorExe). Undo/Redo
-			// forwardés au CommandStack du Shell.
-			if (m_shell && ImGui::BeginMenu("Edition"))
-			{
-				auto& stack = m_shell->MutableCommandStack();
-				if (ImGui::MenuItem("Annuler", "Ctrl+Z", false, stack.CanUndo()))
-				{
-					stack.Undo();
-				}
-				if (ImGui::MenuItem("Rétablir", "Ctrl+Y", false, stack.CanRedo()))
-				{
-					stack.Redo();
-				}
-				ImGui::EndMenu();
-			}
-			if (ImGui::BeginMenu("Vue"))
-			{
-				// Toggle grille — placé en tête du menu Vue pour être trouvable
-				// immédiatement sans ré-ouvrir le panneau "Affichage & grille"
-				// (qui peut être fermé par l'utilisateur sans moyen évident
-				// de le rouvrir). Le checkmark reflète l'état courant de
-				// `WorldEditorSession::ShowGrid()`. Pas de raccourci clavier
-				// par choix utilisateur.
-				if (m_session)
-				{
-					ImGui::MenuItem("Grille (afficher/masquer)", nullptr,
-						&m_session->ShowGrid());
-				}
-				ImGui::Separator();
-				// Panel toggles — migrés depuis WorldEditorShell::RenderMenuBar.
-				// Chaque panneau du Shell se rend dockable individuellement.
-				if (m_shell)
-				{
-					for (auto& panel : m_shell->MutablePanels())
-					{
-						if (!panel) continue;
-						// Fenêtre « Scene » retirée (doublon de la vue 3D principale,
-						// cf. ScenePanel::Render) : plus de toggle dans ce menu.
-						if (std::strcmp(panel->GetName(), "Scene") == 0) continue;
-						bool visible = panel->IsVisible();
-						if (ImGui::MenuItem(panel->GetName(), nullptr, &visible))
-						{
-							panel->SetVisible(visible);
-						}
-					}
-					ImGui::Separator();
-				}
-				if (ImGui::MenuItem("Reinitialiser la disposition des fenetres"))
-				{
-					// Reinitialisation in-process : on retire le node DockBuilder courant et on
-					// repasse m_defaultLayoutAttempted a false. La frame suivante reconstruit la
-					// disposition par defaut via le bloc DockBuilder en haut de BuildUi().
-					const ImGuiID dockId = ImGui::GetID("WorldEditorDockSpaceV2");
-					ImGui::DockBuilderRemoveNode(dockId);
-					m_defaultLayoutAttempted = false;
-					// Supprime aussi le fichier .ini pour que la reinitialisation persiste apres
-					// le redemarrage (sinon ImGui rechargerait l'ancienne disposition au prochain run).
-					std::error_code ec;
-					std::filesystem::remove("world_editor_imgui.ini", ec);
-					if (m_session)
-					{
-						m_session->SetStatus("Disposition reinitialisee.");
-					}
-				}
-				ImGui::MenuItem("Bibliotheque de textures", nullptr, &m_showTextureLibrary);
-				// Panneau « Atmosphere » (cycle jour/nuit). Le panneau est
-				// dessine inline par `BuildUi` (pas un Shell panel), donc
-				// pas liste dans la boucle Panels() ci-dessus. Toggle direct
-				// via ce flag — corrige la regression apres #622 (suppression
-				// barre M100.1 qui exposait tous les panels).
-				ImGui::MenuItem("Atmosphere (jour/nuit)", nullptr, &m_showAtmospherePanel);
-				// Aide caméra : overlay texte avec instructions WASD,
-				// position monde, etc. Cachée par défaut pour ne pas
-				// polluer le dock (cf. #629).
-				ImGui::MenuItem("Aide camera (instructions WASD)", nullptr, &m_showCameraHelp);
-				// Lot C vague 4 — toggle du panneau Validation (ouvert aussi
-				// automatiquement à chaque « Valider la zone »).
-				ImGui::MenuItem("Validation de zone", nullptr, &m_showValidationPanel);
-				ImGui::Separator();
-				if (m_cfg)
-				{
-					float mult = static_cast<float>(m_cfg->GetDouble("controls.editor_camera_speed_multiplier", 1.0));
-					ImGui::TextDisabled("Vitesse de deplacement (Shift = course) :");
-					if (ImGui::SliderFloat("Vitesse camera (x)", &mult, 0.25f, 5.0f, "%.2f"))
-					{
-						mult = std::clamp(mult, 0.25f, 5.0f);
-						m_cfg->SetValue("controls.editor_camera_speed_multiplier", static_cast<double>(mult));
-					}
-					ImGui::TextDisabled("Astuce : montez ce curseur pour traverser plus vite les");
-					ImGui::TextDisabled("grandes cartes pendant la creation.");
-					ImGui::Separator();
-				}
-				ImGui::TextDisabled("Astuce : faites glisser une fenetre par sa barre de titre");
-				ImGui::TextDisabled("pour la docker a gauche, a droite ou en bas.");
-				ImGui::EndMenu();
-			}
-			if (m_cfg && ImGui::BeginMenu("Options"))
-			{
-				const std::string cur = m_cfg->GetString("controls.movement_layout", "wasd");
-				const bool zqsdActive = (cur == "zqsd");
-				if (ImGui::MenuItem("Deplacement : QWERTY (WASD)", nullptr, !zqsdActive))
-				{
-					m_cfg->SetValue("controls.movement_layout", std::string("wasd"));
-					TryPersistMovementLayoutToUserSettings("wasd");
-				}
-				if (ImGui::MenuItem("Deplacement : AZERTY (ZQSD)", nullptr, zqsdActive))
-				{
-					m_cfg->SetValue("controls.movement_layout", std::string("zqsd"));
-					TryPersistMovementLayoutToUserSettings("zqsd");
-				}
-
-				// M100.45 (A.5) — toggle Mode éditeur Simple/Avancé. Le
-				// EditorModeRegistry persiste le choix dans user_prefs.json
-				// et notifie les ToolPropertiesPanel pour re-render immédiat.
-				ImGui::Separator();
-				if (ImGui::BeginMenu("Mode editeur"))
-				{
-					namespace modes = engine::editor::world::modes;
-					auto& reg = modes::EditorModeRegistry::Instance();
-					const modes::EditorMode current = reg.GetCurrentMode();
-					if (ImGui::MenuItem("Simple", "recommande pour demarrer",
-						current == modes::EditorMode::Simple))
-					{
-						reg.SetCurrentMode(modes::EditorMode::Simple);
-					}
-					if (ImGui::MenuItem("Avance", "acces complet aux parametres",
-						current == modes::EditorMode::Advanced))
-					{
-						reg.SetCurrentMode(modes::EditorMode::Advanced);
-					}
-					ImGui::EndMenu();
-				}
-				ImGui::EndMenu();
-			}
-			// Lot C vague 4 — Menu « Aide » : ouvre le panneau Diagnostic
-			// (« Pourquoi ca ne marche pas ? »). Distinct du menu Vue (reserve
-			// aux toggles de panneaux/disposition) car le diagnostic releve de
-			// l'assistance contextuelle (jumeau du futur tutoriel/guidance).
-			if (ImGui::BeginMenu("Aide"))
-			{
-				ImGui::MenuItem("Diagnostic (pourquoi ca ne marche pas ?)", nullptr,
-					&m_showDiagnosticPanel);
-				ImGui::EndMenu();
-			}
-			// Barre d'outils rapide a droite du menu : sauvegarde 1-clic + chargement carte.
-			if (m_session != nullptr && m_cfg != nullptr)
-			{
-				ImGui::Separator();
-				if (ImGui::MenuItem("Sauvegarder"))
-				{
-					(void)m_session->ActionSaveCurrentMap(*m_cfg);
-				}
-				if (!m_session->AvailableMapsScanned())
-				{
-					m_session->RefreshAvailableMaps(*m_cfg);
-				}
-				if (ImGui::BeginMenu("Charger une carte"))
-				{
-					const std::vector<std::string>& mapIds = m_session->AvailableMapIds();
-					if (mapIds.empty())
-					{
-						ImGui::TextDisabled("Aucune carte. Creez-en une via le panneau 'Carte'.");
-					}
-					else
-					{
-						for (size_t i = 0; i < mapIds.size(); ++i)
-						{
-							if (ImGui::MenuItem(mapIds[i].c_str()))
-							{
-								(void)m_session->ActionLoadMapByZoneId(*m_cfg, mapIds[i]);
-								m_session->SelectedAvailableMapIndex() = static_cast<int>(i);
-							}
-						}
-					}
-					ImGui::Separator();
-					if (ImGui::MenuItem("Rafraichir la liste"))
-					{
-						m_session->RefreshAvailableMaps(*m_cfg);
-					}
-					ImGui::EndMenu();
-				}
-				// Statut court a droite
-				if (!m_session->Status().empty())
-				{
-					ImGui::Separator();
-					ImGui::TextUnformatted(m_session->Status().c_str());
-				}
-			}
-			ImGui::EndMainMenuBar();
-		}
+		// Réorganisation UI 2026-07-17 — les actions sont enregistrées une
+		// fois dans le registre du shell, puis la barre de menu française,
+		// la modale Quitter et les fenêtres Préférences / À propos sont
+		// rendues depuis ce registre (spec docs/superpowers/specs/
+		// 2026-07-17-editor-menus-toolbar-reorg-design.md).
+		RegisterEditorActions();
+		RenderMenuBarFr();
+		RenderQuitConfirmModal();
+		RenderPreferencesWindow();
+		RenderAboutWindow();
 
 		// M100.46 incrément 3 — dessine la popup modale Zone Presets
 		// (no-op si non ouverte ou Shell non branché). m_cfg passé pour
@@ -2883,6 +2622,556 @@ namespace engine::editor
 		(void)window;
 #endif
 	}
+
+#if defined(_WIN32)
+	// ── Réorganisation UI 2026-07-17 : registre d'actions + menus français ──
+	// (spec docs/superpowers/specs/2026-07-17-editor-menus-toolbar-reorg-design.md)
+
+	void WorldEditorImGui::RegisterEditorActions()
+	{
+		if (m_actionsRegistered || m_shell == nullptr) return;
+		m_actionsRegistered = true;
+
+		namespace weact = engine::editor::world::actions;
+		using engine::editor::world::ActiveTool;
+		weact::EditorActionRegistry& reg = m_shell->MutableActionRegistry();
+
+		// Helper local : construit + enregistre une action en une expression.
+		auto add = [&reg](const char* id, const char* label,
+			weact::ActionCategory cat, const char* section, const char* shortcut,
+			std::function<bool()> enabled, std::function<bool()> checked,
+			std::function<void()> execute)
+		{
+			weact::EditorAction a;
+			a.id = id;
+			a.label = label;
+			a.category = cat;
+			a.section = (section != nullptr) ? section : "";
+			a.shortcutText = (shortcut != nullptr) ? shortcut : "";
+			a.enabled = std::move(enabled);
+			a.checked = std::move(checked);
+			a.execute = std::move(execute);
+			(void)reg.Register(std::move(a));
+		};
+
+		// ---- Fichier --------------------------------------------------------
+		add("file.new-zone-wizard", "Nouvelle zone (assistant)...",
+			weact::ActionCategory::Fichier, "Nouveau", nullptr,
+			[this] { return m_shell != nullptr; }, nullptr,
+			[this]
+			{
+				// Transition fermé→ouvert : repartir de l'étape 1 sans état
+				// résiduel d'une session précédente (choix, seed, résumé).
+				if (!m_showWizard) { ResetWizardState(); }
+				m_showWizard = true;
+			});
+		add("file.zone-preset", "Appliquer un preset de zone...",
+			weact::ActionCategory::Fichier, "Nouveau", nullptr,
+			[this] { return m_shell != nullptr && m_zonePresetDialog != nullptr; }, nullptr,
+			[this] { if (m_zonePresetDialog) { m_zonePresetDialog->Open(); } });
+		add("file.save", "Sauvegarder la carte courante",
+			weact::ActionCategory::Fichier, "Enregistrer", "Ctrl+S",
+			[this] { return m_session != nullptr && m_cfg != nullptr; }, nullptr,
+			[this] { (void)SaveCurrentMapAndNote(); });
+		add("file.import.texture", "Importer une texture (PNG/JPG/TGA/BMP)...",
+			weact::ActionCategory::Fichier, "Import", nullptr,
+			[this] { return m_session != nullptr && m_cfg != nullptr; }, nullptr,
+			[this] { if (m_session && m_cfg) { (void)m_session->ActionImportTexture(*m_cfg); } });
+		add("file.import.audio", "Importer un son (WAV/OGG)...",
+			weact::ActionCategory::Fichier, "Import", nullptr,
+			[this] { return m_session != nullptr && m_cfg != nullptr; }, nullptr,
+			[this] { if (m_session && m_cfg) { (void)m_session->ActionImportAudio(*m_cfg); } });
+		add("zone.validate", "Valider la zone",
+			weact::ActionCategory::Fichier, "Export", nullptr,
+			[this] { return m_shell != nullptr; }, nullptr,
+			[this] { RunZoneValidation(); });
+		// Export runtime BLOQUÉ si la dernière validation a remonté des
+		// erreurs (comportement Lot C vague 4 conservé). Reste actif si
+		// aucune validation n'a encore tourné.
+		add("zone.export", "Exporter en runtime",
+			weact::ActionCategory::Fichier, "Export", nullptr,
+			[this]
+			{
+				const bool blocked = m_validationHasRun
+					&& m_lastValidationReport.HasBlockingErrors();
+				return m_session != nullptr && m_cfg != nullptr && !blocked;
+			},
+			nullptr,
+			[this] { if (m_session && m_cfg) { (void)m_session->ActionExportRuntime(*m_cfg); } });
+		add("file.quit", "Quitter",
+			weact::ActionCategory::Fichier, nullptr, nullptr,
+			[this] { return static_cast<bool>(m_onQuitRequested); }, nullptr,
+			[this]
+			{
+				// Modifications non sauvegardées → confirmation ; sinon
+				// fermeture directe via le callback Engine::OnQuit.
+				if (m_shell != nullptr && m_shell->IsDirtySinceSave())
+				{
+					m_quitConfirmRequested = true;
+				}
+				else if (m_onQuitRequested)
+				{
+					m_onQuitRequested();
+				}
+			});
+
+		// ---- Édition (les actions undo/redo/historique sont enregistrées
+		// par le shell lui-même, cf. WorldEditorShell::RegisterShellActions) --
+		add("edit.preferences", "Préférences...",
+			weact::ActionCategory::Edition, nullptr, nullptr,
+			nullptr, nullptr,
+			[this] { m_showPreferencesWindow = true; });
+
+		// ---- Vue (options du viewport uniquement) ---------------------------
+		add("view.grid", "Grille (afficher/masquer)",
+			weact::ActionCategory::Vue, nullptr, nullptr,
+			[this] { return m_session != nullptr; },
+			[this] { return m_session != nullptr && m_session->ShowGrid(); },
+			[this] { if (m_session) { m_session->ShowGrid() = !m_session->ShowGrid(); } });
+		add("view.camera-help", "Aide caméra (instructions WASD)",
+			weact::ActionCategory::Vue, nullptr, nullptr,
+			nullptr,
+			[this] { return m_showCameraHelp; },
+			[this] { m_showCameraHelp = !m_showCameraHelp; });
+		add("view.atmosphere", "Atmosphère (jour/nuit)",
+			weact::ActionCategory::Vue, nullptr, nullptr,
+			nullptr,
+			[this] { return m_showAtmospherePanel; },
+			[this] { m_showAtmospherePanel = !m_showAtmospherePanel; });
+
+		// ---- Fenêtre (toggles hors panneaux du shell) -----------------------
+		add("window.texture-library", "Bibliothèque de textures",
+			weact::ActionCategory::Fenetre, nullptr, nullptr,
+			nullptr,
+			[this] { return m_showTextureLibrary; },
+			[this] { m_showTextureLibrary = !m_showTextureLibrary; });
+		add("window.validation-panel", "Validation de zone",
+			weact::ActionCategory::Fenetre, nullptr, nullptr,
+			nullptr,
+			[this] { return m_showValidationPanel; },
+			[this] { m_showValidationPanel = !m_showValidationPanel; });
+		add("window.layout.reset", "Réinitialiser la disposition des fenêtres",
+			weact::ActionCategory::Fenetre, "Disposition", nullptr,
+			nullptr, nullptr,
+			[this] { ResetDockLayout(); });
+
+		// ---- Outils (les 15 outils du shell, groupés par famille) ----------
+		// Un clic sur l'outil déjà actif le désélectionne (retour à None) —
+		// même convention que le bouton X de la barre d'icônes.
+		struct ToolActionSpec
+		{
+			const char* id;
+			const char* label;
+			const char* section;
+			const char* shortcut;
+			ActiveTool  tool;
+		};
+		static constexpr ToolActionSpec kToolActions[] = {
+			{ "tool.terrain-sculpt", "Sculpture du terrain", "Terrain", "B", ActiveTool::TerrainSculpt },
+			{ "tool.terrain-stamp", "Tampon de terrain", "Terrain", "N", ActiveTool::TerrainStamp },
+			{ "tool.splat-paint", "Peinture de texture (sol)", "Terrain", "P", ActiveTool::SplatPaint },
+			{ "tool.lake", "Lac", "Eau", "L", ActiveTool::Lake },
+			{ "tool.river", "Rivière", "Eau", "R", ActiveTool::River },
+			{ "tool.river-network", "Réseau fluvial", "Eau", "Ctrl+Shift+N", ActiveTool::RiverNetwork },
+			{ "tool.coastline", "Littoral", "Eau", "Ctrl+Shift+C", ActiveTool::Coastline },
+			{ "tool.mountain-range", "Chaîne de montagnes", "Macro", "Ctrl+Shift+M", ActiveTool::MountainRange },
+			{ "tool.valley-chain", "Chaîne de vallées", "Macro", "Ctrl+Shift+V", ActiveTool::ValleyChain },
+			{ "tool.hydraulic-erosion", "Érosion hydraulique", "Macro", "Ctrl+Shift+H", ActiveTool::HydraulicErosion },
+			{ "tool.thermal-wind-erosion", "Érosion thermique/vent", "Macro", "Ctrl+Shift+T", ActiveTool::ThermalWindErosion },
+			{ "tool.cave", "Grotte", "Structures", "Ctrl+Shift+G", ActiveTool::Cave },
+			{ "tool.overhang", "Surplomb", "Structures", "Ctrl+Shift+O", ActiveTool::Overhang },
+			{ "tool.arch", "Arche", "Structures", "Ctrl+Shift+A", ActiveTool::Arch },
+			{ "tool.dungeon-portal", "Portail de donjon", "Structures", "Ctrl+Shift+D", ActiveTool::DungeonPortal },
+		};
+		for (const ToolActionSpec& spec : kToolActions)
+		{
+			const ActiveTool tool = spec.tool;
+			add(spec.id, spec.label, weact::ActionCategory::Outils,
+				spec.section, spec.shortcut,
+				[this] { return m_shell != nullptr; },
+				[this, tool] { return m_shell != nullptr && m_shell->GetActiveTool() == tool; },
+				[this, tool]
+				{
+					if (m_shell == nullptr) return;
+					m_shell->SetActiveTool(
+						m_shell->GetActiveTool() == tool ? ActiveTool::None : tool);
+				});
+		}
+
+		// ---- Aide -----------------------------------------------------------
+		add("help.diagnostic", "Diagnostic (pourquoi ça ne marche pas ?)",
+			weact::ActionCategory::Aide, nullptr, nullptr,
+			nullptr,
+			[this] { return m_showDiagnosticPanel; },
+			[this] { m_showDiagnosticPanel = !m_showDiagnosticPanel; });
+		add("help.about", "À propos...",
+			weact::ActionCategory::Aide, nullptr, nullptr,
+			nullptr, nullptr,
+			[this] { m_showAboutWindow = true; });
+	}
+
+	bool WorldEditorImGui::MenuItemForAction(const char* id)
+	{
+		namespace weact = engine::editor::world::actions;
+		const weact::EditorAction* a =
+			(m_shell != nullptr) ? m_shell->GetActionRegistry().Find(id) : nullptr;
+		if (a == nullptr) return false;
+		const bool enabled  = weact::EditorActionRegistry::IsEnabled(*a);
+		const bool checked  = a->checked ? a->checked() : false;
+		const char* shortcut = a->shortcutText.empty() ? nullptr : a->shortcutText.c_str();
+		if (ImGui::MenuItem(a->label.c_str(), shortcut, checked, enabled))
+		{
+			if (a->execute) { a->execute(); }
+			return true;
+		}
+		return false;
+	}
+
+	void WorldEditorImGui::RenderMenuBarFr()
+	{
+		namespace weact = engine::editor::world::actions;
+		namespace prefs = engine::editor::world::prefs;
+		if (!ImGui::BeginMainMenuBar()) return;
+
+		const bool sessionReady = (m_session != nullptr && m_cfg != nullptr);
+
+		if (ImGui::BeginMenu("Fichier"))
+		{
+			ImGui::SeparatorText("Nouveau");
+			MenuItemForAction("file.new-zone-wizard");
+			// Rectangle-cible du guidance overlay (id stable, convention
+			// <panel>.<sous>.<id> — Lot C vague 4).
+			m_widgetTargets.Register("menubar.file.new_zone_wizard",
+				{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
+				  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
+			MenuItemForAction("file.zone-preset");
+
+			ImGui::SeparatorText("Ouvrir");
+			if (sessionReady && !m_session->AvailableMapsScanned())
+			{
+				m_session->RefreshAvailableMaps(*m_cfg);
+			}
+			ImGui::BeginDisabled(!sessionReady);
+			if (ImGui::BeginMenu("Charger une carte"))
+			{
+				const std::vector<std::string>& mapIds = m_session->AvailableMapIds();
+				if (mapIds.empty())
+				{
+					ImGui::TextDisabled("Aucune carte. Créez-en une via le panneau 'Carte'.");
+				}
+				else
+				{
+					for (size_t i = 0; i < mapIds.size(); ++i)
+					{
+						if (ImGui::MenuItem(mapIds[i].c_str())
+							&& m_session->ActionLoadMapByZoneId(*m_cfg, mapIds[i]))
+						{
+							m_session->SelectedAvailableMapIndex() = static_cast<int>(i);
+							prefs::UserPrefsStore::Instance().PushRecentMap(mapIds[i]);
+						}
+					}
+				}
+				ImGui::Separator();
+				if (ImGui::MenuItem("Rafraîchir la liste"))
+				{
+					m_session->RefreshAvailableMaps(*m_cfg);
+				}
+				ImGui::EndMenu();
+			}
+			// Cartes récentes (user_prefs.json) : entrée grisée si la carte
+			// n'existe plus dans world_editor/maps/ (supprimée hors éditeur).
+			if (ImGui::BeginMenu("Cartes récentes"))
+			{
+				const std::vector<std::string>& recents =
+					prefs::UserPrefsStore::Instance().GetRecentMaps();
+				if (recents.empty())
+				{
+					ImGui::TextDisabled("Aucune carte récente.");
+				}
+				else
+				{
+					const std::vector<std::string>& mapIds = m_session->AvailableMapIds();
+					for (const std::string& zoneId : recents)
+					{
+						const bool available =
+							std::find(mapIds.begin(), mapIds.end(), zoneId) != mapIds.end();
+						if (ImGui::MenuItem(zoneId.c_str(), nullptr, false, available)
+							&& m_session->ActionLoadMapByZoneId(*m_cfg, zoneId))
+						{
+							prefs::UserPrefsStore::Instance().PushRecentMap(zoneId);
+						}
+					}
+				}
+				ImGui::EndMenu();
+			}
+			ImGui::EndDisabled();
+
+			ImGui::SeparatorText("Enregistrer");
+			MenuItemForAction("file.save");
+
+			ImGui::SeparatorText("Import");
+			MenuItemForAction("file.import.texture");
+			MenuItemForAction("file.import.audio");
+
+			ImGui::SeparatorText("Export");
+			MenuItemForAction("zone.validate");
+			m_widgetTargets.Register("toolbar.button.validate",
+				{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
+				  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
+			MenuItemForAction("zone.export");
+			m_widgetTargets.Register("menubar.file.export_runtime",
+				{ ImGui::GetItemRectMin().x, ImGui::GetItemRectMin().y,
+				  ImGui::GetItemRectMax().x, ImGui::GetItemRectMax().y });
+			{
+				const bool exportBlocked = m_validationHasRun
+					&& m_lastValidationReport.HasBlockingErrors();
+				if (exportBlocked && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+				{
+					ImGui::SetTooltip("Export bloqué : corrigez les erreurs de validation (panneau Validation).");
+				}
+			}
+
+			ImGui::Separator();
+			MenuItemForAction("file.quit");
+			ImGui::EndMenu();
+		}
+
+		if (ImGui::BeginMenu("Édition"))
+		{
+			MenuItemForAction("edit.undo");
+			MenuItemForAction("edit.redo");
+			MenuItemForAction("edit.history");
+			ImGui::Separator();
+			MenuItemForAction("edit.preferences");
+			ImGui::EndMenu();
+		}
+
+		if (ImGui::BeginMenu("Vue"))
+		{
+			MenuItemForAction("view.grid");
+			MenuItemForAction("view.camera-help");
+			MenuItemForAction("view.atmosphere");
+			ImGui::EndMenu();
+		}
+
+		if (ImGui::BeginMenu("Fenêtre"))
+		{
+			ImGui::SeparatorText("Panneaux");
+			if (m_shell != nullptr)
+			{
+				// Toggles de panneaux enregistrés par le shell (ordre stable).
+				for (const weact::EditorAction& a : m_shell->GetActionRegistry().Actions())
+				{
+					if (a.id.rfind("window.panel.", 0) == 0)
+					{
+						MenuItemForAction(a.id.c_str());
+					}
+				}
+			}
+			MenuItemForAction("window.texture-library");
+			MenuItemForAction("window.validation-panel");
+			ImGui::SeparatorText("Disposition");
+			MenuItemForAction("window.layout.reset");
+			ImGui::TextDisabled("Astuce : faites glisser une fenêtre par sa barre de titre");
+			ImGui::TextDisabled("pour la docker à gauche, à droite ou en bas.");
+			ImGui::EndMenu();
+		}
+
+		if (ImGui::BeginMenu("Outils"))
+		{
+			if (m_shell == nullptr)
+			{
+				ImGui::TextDisabled("Shell éditeur non branché.");
+			}
+			else
+			{
+				// Sous-menus par famille — même source (registre, section)
+				// que la future palette d'outils et la palette Ctrl+P.
+				static constexpr const char* kFamilies[] =
+					{ "Terrain", "Eau", "Macro", "Structures" };
+				for (const char* family : kFamilies)
+				{
+					if (!ImGui::BeginMenu(family)) continue;
+					for (const weact::EditorAction& a : m_shell->GetActionRegistry().Actions())
+					{
+						if (a.category == weact::ActionCategory::Outils
+							&& a.section == family)
+						{
+							MenuItemForAction(a.id.c_str());
+						}
+					}
+					ImGui::EndMenu();
+				}
+			}
+			ImGui::EndMenu();
+		}
+
+		if (ImGui::BeginMenu("Aide"))
+		{
+			MenuItemForAction("help.diagnostic");
+			ImGui::Separator();
+			MenuItemForAction("help.about");
+			ImGui::EndMenu();
+		}
+
+		ImGui::EndMainMenuBar();
+	}
+
+	bool WorldEditorImGui::SaveCurrentMapAndNote()
+	{
+		if (m_session == nullptr || m_cfg == nullptr) return false;
+		if (!m_session->ActionSaveCurrentMap(*m_cfg)) return false;
+		if (m_shell != nullptr)
+		{
+			m_shell->NoteSaved();
+		}
+		engine::editor::world::prefs::UserPrefsStore::Instance()
+			.PushRecentMap(m_session->Doc().zoneId);
+		return true;
+	}
+
+	void WorldEditorImGui::ResetDockLayout()
+	{
+		// Réinitialisation in-process : on retire le node DockBuilder courant
+		// et on repasse m_defaultLayoutAttempted à false. La frame suivante
+		// reconstruit la disposition par défaut via le bloc DockBuilder en
+		// haut de BuildUi().
+		const ImGuiID dockId = ImGui::GetID("WorldEditorDockSpaceV2");
+		ImGui::DockBuilderRemoveNode(dockId);
+		m_defaultLayoutAttempted = false;
+		// Supprime aussi le fichier .ini pour que la réinitialisation persiste
+		// après le redémarrage (sinon ImGui rechargerait l'ancienne disposition
+		// au prochain run).
+		std::error_code ec;
+		std::filesystem::remove("world_editor_imgui.ini", ec);
+		if (m_session)
+		{
+			m_session->SetStatus("Disposition réinitialisée.");
+		}
+	}
+
+	void WorldEditorImGui::RenderQuitConfirmModal()
+	{
+		if (m_quitConfirmRequested)
+		{
+			ImGui::OpenPopup("Quitter l'éditeur ?");
+			m_quitConfirmRequested = false;
+		}
+		// Centre la modale sur le viewport (confort ; pas d'état persisté).
+		const ImGuiViewport* vp = ImGui::GetMainViewport();
+		ImGui::SetNextWindowPos(
+			ImVec2(vp->WorkPos.x + vp->WorkSize.x * 0.5f,
+			       vp->WorkPos.y + vp->WorkSize.y * 0.5f),
+			ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+		if (ImGui::BeginPopupModal("Quitter l'éditeur ?", nullptr,
+			ImGuiWindowFlags_AlwaysAutoResize))
+		{
+			ImGui::TextUnformatted("Des modifications non sauvegardées existent.");
+			ImGui::TextDisabled("Carte : %s",
+				(m_session != nullptr) ? m_session->Doc().zoneId.c_str() : "(inconnue)");
+			ImGui::Separator();
+			if (ImGui::Button("Sauvegarder et quitter"))
+			{
+				if (SaveCurrentMapAndNote() && m_onQuitRequested)
+				{
+					m_onQuitRequested();
+				}
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Quitter sans sauvegarder"))
+			{
+				if (m_onQuitRequested) { m_onQuitRequested(); }
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Annuler"))
+			{
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+		}
+	}
+
+	void WorldEditorImGui::RenderPreferencesWindow()
+	{
+		if (!m_showPreferencesWindow) return;
+		ImGui::SetNextWindowSize(ImVec2(480.0f, 0.0f), ImGuiCond_FirstUseEver);
+		if (ImGui::Begin("Préférences", &m_showPreferencesWindow,
+			ImGuiWindowFlags_AlwaysAutoResize))
+		{
+			// -- Clavier (migré de l'ancien menu Options) ---------------------
+			ImGui::SeparatorText("Clavier");
+			if (m_cfg != nullptr)
+			{
+				const std::string cur = m_cfg->GetString("controls.movement_layout", "wasd");
+				const bool zqsdActive = (cur == "zqsd");
+				if (ImGui::RadioButton("QWERTY (WASD)", !zqsdActive) && zqsdActive)
+				{
+					m_cfg->SetValue("controls.movement_layout", std::string("wasd"));
+					TryPersistMovementLayoutToUserSettings("wasd");
+				}
+				ImGui::SameLine();
+				if (ImGui::RadioButton("AZERTY (ZQSD)", zqsdActive) && !zqsdActive)
+				{
+					m_cfg->SetValue("controls.movement_layout", std::string("zqsd"));
+					TryPersistMovementLayoutToUserSettings("zqsd");
+				}
+			}
+
+			// -- Caméra (migré de l'ancien menu Vue) --------------------------
+			ImGui::SeparatorText("Caméra");
+			if (m_cfg != nullptr)
+			{
+				float mult = static_cast<float>(
+					m_cfg->GetDouble("controls.editor_camera_speed_multiplier", 1.0));
+				ImGui::TextDisabled("Vitesse de déplacement (Shift = course) :");
+				if (ImGui::SliderFloat("Vitesse caméra (x)", &mult, 0.25f, 5.0f, "%.2f"))
+				{
+					mult = std::clamp(mult, 0.25f, 5.0f);
+					m_cfg->SetValue("controls.editor_camera_speed_multiplier",
+						static_cast<double>(mult));
+				}
+				ImGui::TextDisabled("Astuce : montez ce curseur pour traverser plus vite les");
+				ImGui::TextDisabled("grandes cartes pendant la création.");
+			}
+
+			// -- Mode éditeur (migré de l'ancien menu Options, M100.45) -------
+			ImGui::SeparatorText("Mode éditeur");
+			{
+				namespace modes = engine::editor::world::modes;
+				auto& reg = modes::EditorModeRegistry::Instance();
+				const modes::EditorMode current = reg.GetCurrentMode();
+				if (ImGui::RadioButton("Simple (recommandé pour démarrer)",
+					current == modes::EditorMode::Simple))
+				{
+					reg.SetCurrentMode(modes::EditorMode::Simple);
+				}
+				if (ImGui::RadioButton("Avancé (accès complet aux paramètres)",
+					current == modes::EditorMode::Advanced))
+				{
+					reg.SetCurrentMode(modes::EditorMode::Advanced);
+				}
+			}
+		}
+		ImGui::End();
+	}
+
+	void WorldEditorImGui::RenderAboutWindow()
+	{
+		if (!m_showAboutWindow) return;
+		if (ImGui::Begin("À propos", &m_showAboutWindow,
+			ImGuiWindowFlags_AlwaysAutoResize))
+		{
+			ImGui::TextUnformatted("LCDLLN World Editor");
+			ImGui::TextDisabled("Éditeur de cartes interne — binaire lcdlln_world_editor.exe");
+			ImGui::Separator();
+			ImGui::TextDisabled("Spec UI : docs/superpowers/specs/");
+			ImGui::TextDisabled("2026-07-17-editor-menus-toolbar-reorg-design.md");
+		}
+		ImGui::End();
+	}
+#endif // _WIN32
 
 	void WorldEditorImGui::DetachPlatformWindow(engine::platform::Window& window)
 	{

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 
 #include <vector>
@@ -118,6 +119,14 @@ namespace engine::editor
 		{
 			m_shell = shell;
 		}
+
+		/// Réorganisation UI 2026-07-17 — Branche le callback de demande de
+		/// fermeture de l'application (côté Engine : `Engine::OnQuit`).
+		/// Consommé par l'action « Fichier > Quitter » : appel direct si
+		/// aucun changement non sauvegardé, sinon après confirmation via la
+		/// modale (cf. `RenderQuitConfirmModal`). Si non branché, l'entrée
+		/// « Quitter » est grisée.
+		void SetQuitCallback(std::function<void()> cb) { m_onQuitRequested = std::move(cb); }
 
 		/// \param hwndNative \c HWND sous Windows, sinon ignoré.
 		/// \param cfg utilisé pour charger les polices TTF de l'UI auth (Windlass / Morpheus) dans
@@ -298,6 +307,75 @@ namespace engine::editor
 		bool m_wizardHasGenerated = false;
 		/// Id du preset effectivement résolu+exécuté (affiché dans le résumé).
 		std::string m_wizardLastPresetId;
+
+		// ── Réorganisation UI 2026-07-17 : menus + registre d'actions ─────────
+		/// True après le premier `RegisterEditorActions` (le registre du shell
+		/// prend les actions une seule fois par session).
+		bool m_actionsRegistered = false;
+		/// Visibilité de la fenêtre « Préférences » (Édition > Préférences…) :
+		/// regroupe layout clavier QWERTY/AZERTY, vitesse caméra et mode
+		/// éditeur Simple/Avancé (l'ancien menu Options est supprimé).
+		bool m_showPreferencesWindow = false;
+		/// Visibilité de la fenêtre « À propos » (Aide > À propos).
+		bool m_showAboutWindow = false;
+		/// Posé par l'action `file.quit` quand des changements non sauvegardés
+		/// existent ; consommé une seule fois par `RenderQuitConfirmModal` qui
+		/// pousse l'`ImGui::OpenPopup` correspondant.
+		bool m_quitConfirmRequested = false;
+		/// Callback de fermeture d'application (Engine::OnQuit). Nul si non
+		/// branché → « Quitter » grisé.
+		std::function<void()> m_onQuitRequested;
+
+		/// Réorganisation UI 2026-07-17 — Enregistre dans le registre du shell
+		/// toutes les actions qui dépendent de la session/config/UI ImGui
+		/// (fichier, import/export, vue, fenêtre, outils, aide). Idempotent
+		/// via `m_actionsRegistered`. No-op si `m_shell` est nul (le registre
+		/// vit dans le shell). Doit être appelée en début de `BuildUi`, main
+		/// thread. Effet de bord : remplit `m_shell->MutableActionRegistry()`.
+		void RegisterEditorActions();
+
+		/// Rend un item de menu depuis une action du registre (label,
+		/// raccourci, coche, grisage) et l'exécute au clic.
+		/// \param id id d'action (ex. "file.save") ; item absent si inconnu.
+		/// \return true si l'item vient d'être cliqué (et exécuté).
+		/// Effet de bord : ImGui state + exécution de l'action au clic.
+		bool MenuItemForAction(const char* id);
+
+		/// Rend la barre de menu française réorganisée (Fichier / Édition /
+		/// Vue / Fenêtre / Outils / Aide) depuis le registre d'actions.
+		/// Remplace l'ancien bloc inline de `BuildUi` (menus Fichier/Edition/
+		/// Vue/Options/Aide + items top-level Sauvegarder/Charger).
+		/// Effet de bord : ImGui state, exécution d'actions au clic,
+		/// enregistrement des rectangles guidance (`m_widgetTargets`).
+		void RenderMenuBarFr();
+
+		/// Rend la fenêtre « Préférences » si `m_showPreferencesWindow`.
+		/// Effet de bord : écrit `controls.movement_layout` et
+		/// `controls.editor_camera_speed_multiplier` dans `m_cfg`, persiste le
+		/// layout clavier dans user_settings.json, change le mode éditeur via
+		/// `EditorModeRegistry` (persisté dans user_prefs.json).
+		void RenderPreferencesWindow();
+
+		/// Rend la fenêtre « À propos » si `m_showAboutWindow`.
+		void RenderAboutWindow();
+
+		/// Rend la modale de confirmation de fermeture (3 choix : sauvegarder
+		/// et quitter / quitter sans sauvegarder / annuler). Ouverte quand
+		/// `m_quitConfirmRequested` a été posé par l'action `file.quit`.
+		/// Effet de bord : peut appeler `m_onQuitRequested` et sauvegarder.
+		void RenderQuitConfirmModal();
+
+		/// Sauvegarde la carte courante et, en cas de succès, blanchit le
+		/// dirty-tracking (`WorldEditorShell::NoteSaved`) et pousse le zoneId
+		/// dans les cartes récentes (user_prefs.json).
+		/// \return true si `ActionSaveCurrentMap` a réussi.
+		bool SaveCurrentMapAndNote();
+
+		/// Réinitialise la disposition des fenêtres dockées (retire le node
+		/// DockBuilder `WorldEditorDockSpaceV2`, supprime world_editor_imgui.ini,
+		/// re-arme la pose de la disposition par défaut à la frame suivante).
+		/// Extrait de l'ancien item de menu « Réinitialiser la disposition ».
+		void ResetDockLayout();
 
 		/// Lot C vague 4 — Construit un `ValidationContext` (vues lecture seule)
 		/// depuis les documents du shell branché puis exécute `m_zoneValidator`,


### PR DESCRIPTION
## Contexte

Reorganisation de l'UI de l'editeur monde sur les conventions Unreal Engine (comparaison utilisateur avec UE 5.8). PR 1 d'une pile de 3 :

1. **PR1 (celle-ci)** : registre d'actions central + menus + barre de statut
2. PR2 : barre d'actions + palette d'outils a gauche
3. PR3 : palette de commandes Ctrl+P + fenetre Raccourcis clavier

Spec : `docs/superpowers/specs/2026-07-17-editor-menus-toolbar-reorg-design.md`
Plan : `docs/superpowers/plans/2026-07-17-editor-menus-toolbar-reorg.md`

## Contenu

- **Registre d'actions central** (`src/world_editor/actions/`) : chaque action declaree UNE fois (id stable, libelle FR, categorie, raccourci, predicats enabled/checked, callback) ; consommee par les menus (et par la barre d'actions / palette Ctrl+P des PR2-PR3).
- **Menus reorganises** `Fichier | Edition | Vue | Fenetre | Outils | Aide` avec en-tetes de section (SeparatorText) :
  - Fichier : Nouveau (assistant, preset) / Ouvrir (Charger + **Cartes recentes** persistees) / Enregistrer / Import / Export (gating validation conserve) / **Quitter reel** avec modale de confirmation si non sauvegarde (callback `Engine::OnQuit`).
  - Edition : Annuler/Retablir/Historique + **Preferences** (fenetre regroupant clavier AZERTY-QWERTY, vitesse camera, mode Simple/Avance — l'ancien menu Options disparait).
  - Vue : viewport uniquement (grille, aide camera, atmosphere).
  - Fenetre : toggles de tous les panneaux + reinitialisation de la disposition.
  - Outils : les 15 outils en sous-menus Terrain / Eau / Macro / Structures, coche sur l'outil actif.
- **Barre de statut enrichie** (fenetre Statut du bas) : message | carte courante | outil actif + indicateur droite « Tout enregistre / ● Non sauvegarde ».
- **Dirty-tracking** : `CommandStack::Serial()` (compteur de mutations) + `WorldEditorShell::NoteSaved()/IsDirtySinceSave()` ; blanchi apres save/chargement/creation de zone.
- **Cartes recentes** : `UserPrefsStore::PushRecentMap` (dedoublonnage, plafond 8, persistance atomique user_prefs.json).
- **Degraissage** de la barre anglaise M100.1 fantome (stubs File, menu Tools vide, layouts alias) — repli minimal Edit/View/Help conserve pour le mode shell in-game.

## Ecarts vs spec (documentes)

- « Supprimer la selection » NON livre : `DeleteCommand` existant n'est cable que sur les `PropInstance` legacy, pas sur l'EditorSelection actuelle — item retire plutot que faussement cable (comme « Dupliquer », deja hors perimetre).
- Barre M100.1 **degraissee** plutot que supprimee (repli fonctionnel du mode shell sans UI francaise).

## Tests

- `editor_action_registry_tests` (**non gate WIN32** → tourne sous ctest Linux) : unicite ids, ordre, predicats, toggles, Serial() monotone.
- `editor_toolbar_tests` : + dirty-depuis-save (MarkDirty/NoteSaved/mutation pile).
- `editor_modes_tests` : + cartes recentes (dedoublonnage, plafond 8, round-trip disque).

## Deploiement

**Deploiement** : ✅ client/editeur uniquement, pas de redeploiement serveur.

## Ordre de merge

PR1 → PR2 → PR3 (pile ; chaque PR re-basera sur la precedente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)