### PR TITLE
feat(editor): PR2 - barre d'actions + palette d'outils laterale

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,8 +338,10 @@ add_library(engine_core
   src/world_editor/core/WorldEditorShell.cpp
   src/world_editor/core/CommandStack.cpp
   # Réorganisation UI 2026-07-17 — registre central des actions (menus,
-  # barre d'actions, palette de commandes, fenêtre raccourcis).
+  # barre d'actions, palette de commandes, fenêtre raccourcis) + modèle pur
+  # de la palette d'outils (familles + libellés FR).
   src/world_editor/actions/EditorActionRegistry.cpp
+  src/world_editor/ui/ToolPaletteModel.cpp
   # M101.4 / M101.5 — editeur de routines nodal (panel + commandes + palette/inspecteur).
   src/world_editor/routine/RoutineGraphCommands.cpp
   src/world_editor/routine/RoutineGraphPanel.cpp
@@ -1738,6 +1740,19 @@ else()
   target_compile_options(editor_action_registry_tests PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 add_test(NAME editor_action_registry_tests COMMAND editor_action_registry_tests)
+
+# Réorganisation UI 2026-07-17 (PR 2) — Tests unitaires CPU du modèle pur de
+# la palette d'outils : couverture exacte des 15 outils par les 4 familles,
+# unicité des titres et libellés FR. NON gaté WIN32 (ctest Linux).
+add_executable(tool_palette_model_tests src/world_editor/tests/ToolPaletteModelTests.cpp)
+target_include_directories(tool_palette_model_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(tool_palette_model_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(tool_palette_model_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+else()
+  target_compile_options(tool_palette_model_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+add_test(NAME tool_palette_model_tests COMMAND tool_palette_model_tests)
 
 # M100.36 — Tests unitaires CPU pour le watershed D8 + flow accumulation +
 # Douglas-Peucker + OceanSettings + RiverNetworkCommand + water.bin v1/v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,7 @@ add_library(engine_core
   # de la palette d'outils (familles + libellés FR).
   src/world_editor/actions/EditorActionRegistry.cpp
   src/world_editor/ui/ToolPaletteModel.cpp
+  src/world_editor/panels/ToolPalettePanel.cpp
   # M101.4 / M101.5 — editeur de routines nodal (panel + commandes + palette/inspecteur).
   src/world_editor/routine/RoutineGraphCommands.cpp
   src/world_editor/routine/RoutineGraphPanel.cpp

--- a/src/world_editor/core/ActiveTool.h
+++ b/src/world_editor/core/ActiveTool.h
@@ -1,0 +1,39 @@
+#pragma once
+// ActiveTool — identifiant de l'outil actif du shell éditeur monde.
+// Réorganisation UI 2026-07-17 : extrait de WorldEditorShell.h pour que les
+// modules purs (ToolPaletteModel, tests ctest Linux) puissent référencer
+// l'enum sans tirer tout le shell (outils, documents, panneaux).
+
+#include <cstdint>
+
+namespace engine::editor::world
+{
+	/// Identifiant de l'outil actif dans le shell éditeur monde (M100.6+).
+	/// `None` est l'état initial après `Init`. `TerrainSculpt` est activé
+	/// par le raccourci `B` (M100.6) ; `TerrainStamp` est activé par le
+	/// raccourci `N` (M100.7) ; `SplatPaint` est activé par le raccourci `P`
+	/// (M100.10). Les futurs outils (place…) s'ajouteront ici.
+	enum class ActiveTool : uint8_t
+	{
+		None          = 0,
+		TerrainSculpt = 1,
+		TerrainStamp  = 2,
+		SplatPaint    = 3,
+		Lake          = 4,  // M100.13 — raccourci L
+		River         = 5,  // M100.13 — raccourci R
+		MountainRange    = 6,   // M100.35 — raccourci Ctrl+Shift+M
+		ValleyChain      = 7,   // M100.35 — raccourci Ctrl+Shift+V
+		RiverNetwork     = 8,   // M100.36 — raccourci Ctrl+Shift+N (network)
+		Coastline           = 9,   // M100.37 — raccourci Ctrl+Shift+C
+		HydraulicErosion    = 10,  // M100.38 — raccourci Ctrl+Shift+H
+		ThermalWindErosion  = 11,  // M100.39 — raccourci Ctrl+Shift+T
+		Cave                = 12,  // M100.40 — raccourci Ctrl+Shift+G (Grotte)
+		Overhang            = 13,  // M100.41 — raccourci Ctrl+Shift+O (Overhang)
+		Arch                = 14,  // M100.42 — raccourci Ctrl+Shift+A (Arche)
+		DungeonPortal       = 15,  // M100.43 — raccourci Ctrl+Shift+D (Donjon)
+	};
+
+	/// Nombre d'outils « réels » (hors None). Sert aux tests d'exhaustivité
+	/// (palette d'outils : chaque outil apparaît exactement une fois).
+	inline constexpr int kActiveToolCount = 15;
+}

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -11,6 +11,7 @@
 #include "src/world_editor/panels/ToolPropertiesPanel.h"
 #include "src/world_editor/panels/HistoryPanel.h"
 #include "src/world_editor/panels/SurfaceTablePanel.h"
+#include "src/world_editor/panels/ToolPalettePanel.h"
 #include "src/world_editor/panels/CollisionEditorPanel.h"
 #include "src/world_editor/routine/RoutineGraphPanel.h"
 #include "src/world_editor/ui/EditorToolbar.h"
@@ -148,6 +149,13 @@ namespace engine::editor::world
 			m_questEditorPtr = questEditor.get();
 			m_panels.emplace_back(std::move(questEditor));
 		}
+
+		// Réorganisation UI 2026-07-17 (PR 2) — palette d'outils latérale
+		// (remplace la rangée d'outils M100.35 de l'EditorToolbar, devenue
+		// barre d'actions). Ajoutée en FIN de liste : les raccourcis F1..F12
+		// et plusieurs branchements mappent des INDICES FIXES dans m_panels
+		// (Scene=0 … ToolProperties=5) — ne jamais insérer avant.
+		m_panels.emplace_back(std::make_unique<panels::ToolPalettePanel>(this));
 
 #if defined(_WIN32)
 		std::error_code ec;

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "src/world_editor/core/ActiveTool.h"
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/actions/EditorActionRegistry.h"
@@ -40,30 +41,9 @@ namespace engine::editor::world
 	namespace panels { class BuildingEditorPanel; }
 	namespace panels { class QuestEditorPanel; }
 
-	/// Identifiant de l'outil actif dans le shell éditeur monde (M100.6+).
-	/// `None` est l'état initial après `Init`. `TerrainSculpt` est activé
-	/// par le raccourci `B` (M100.6) ; `TerrainStamp` est activé par le
-	/// raccourci `N` (M100.7) ; `SplatPaint` est activé par le raccourci `P`
-	/// (M100.10). Les futurs outils (place…) s'ajouteront ici.
-	enum class ActiveTool : uint8_t
-	{
-		None          = 0,
-		TerrainSculpt = 1,
-		TerrainStamp  = 2,
-		SplatPaint    = 3,
-		Lake          = 4,  // M100.13 — raccourci L
-		River         = 5,  // M100.13 — raccourci R
-		MountainRange    = 6,   // M100.35 — raccourci Ctrl+Shift+M
-		ValleyChain      = 7,   // M100.35 — raccourci Ctrl+Shift+V
-		RiverNetwork     = 8,   // M100.36 — raccourci Ctrl+Shift+N (network)
-		Coastline           = 9,   // M100.37 — raccourci Ctrl+Shift+C
-		HydraulicErosion    = 10,  // M100.38 — raccourci Ctrl+Shift+H
-		ThermalWindErosion  = 11,  // M100.39 — raccourci Ctrl+Shift+T
-		Cave                = 12,  // M100.40 — raccourci Ctrl+Shift+G (Grotte)
-		Overhang            = 13,  // M100.41 — raccourci Ctrl+Shift+O (Overhang)
-		Arch                = 14,  // M100.42 — raccourci Ctrl+Shift+A (Arche)
-		DungeonPortal       = 15,  // M100.43 — raccourci Ctrl+Shift+D (Donjon)
-	};
+	// Réorganisation UI 2026-07-17 : l'enum `ActiveTool` vit désormais dans
+	// core/ActiveTool.h (inclus ci-dessous) pour être consommable par les
+	// modules purs (ToolPaletteModel, tests Linux) sans tirer tout le shell.
 
 	/// Coquille principale de l'éditeur de monde 3D (M100.1). Instanciée une
 	/// fois par processus quand `editor.world.enabled` est vrai (config.json)

--- a/src/world_editor/panels/ToolPalettePanel.cpp
+++ b/src/world_editor/panels/ToolPalettePanel.cpp
@@ -1,0 +1,97 @@
+// ToolPalettePanel — implémentation. Voir ToolPalettePanel.h.
+
+#include "src/world_editor/panels/ToolPalettePanel.h"
+
+#include "src/world_editor/core/WorldEditorShell.h"
+#include "src/world_editor/ui/ToolPaletteModel.h"
+#include "src/world_editor/ui/ToolbarIconAtlas.h"
+
+#include <string>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world::panels
+{
+	void ToolPalettePanel::Render()
+	{
+#if defined(_WIN32)
+		if (m_shell == nullptr) return;
+		if (!ImGui::Begin(GetName(), nullptr))
+		{
+			ImGui::End();
+			return;
+		}
+
+		WorldEditorShell& shell = *m_shell;
+		const ActiveTool current = shell.GetActiveTool();
+
+		// Bouton « Aucun outil » en tête (équivalent de l'ex-bouton X).
+		{
+			const bool active = (current == ActiveTool::None);
+			if (ImGui::Selectable(ToolLabelFr(ActiveTool::None), active))
+			{
+				shell.SetActiveTool(ActiveTool::None);
+			}
+		}
+		ImGui::Separator();
+
+		// Rend un bouton d'outil : pastille couleur (atlas) + libellé FR,
+		// surligné si actif, tooltip « libellé (raccourci) » via le registre.
+		// Un clic sur l'outil actif le désélectionne (convention menu Outils).
+		auto renderToolButton = [&shell, current](ActiveTool tool)
+		{
+			const ToolIconStyle style = ToolbarIconAtlas::Get(tool);
+			const bool active = (current == tool);
+
+			ImGui::PushID(static_cast<int>(tool));
+			ImDrawList* dl = ImGui::GetWindowDrawList();
+			const ImVec2 pos = ImGui::GetCursorScreenPos();
+			const float sq = ImGui::GetTextLineHeight();
+
+			// Le Selectable réserve la place de la pastille par des espaces
+			// de tête ; la pastille est dessinée par-dessus juste après.
+			const std::string label = std::string("     ") + ToolLabelFr(tool);
+			if (ImGui::Selectable(label.c_str(), active))
+			{
+				shell.SetActiveTool(active ? ActiveTool::None : tool);
+			}
+			dl->AddRectFilled(
+				ImVec2(pos.x + 2.0f, pos.y + 1.0f),
+				ImVec2(pos.x + 2.0f + sq, pos.y + 1.0f + sq),
+				static_cast<ImU32>(style.bgColorArgb), 3.0f);
+
+			if (ImGui::IsItemHovered())
+			{
+				// Raccourci depuis le registre d'actions (source unique).
+				const actions::EditorAction* a =
+					shell.GetActionRegistry().Find(ToolActionId(tool));
+				if (a != nullptr && !a->shortcutText.empty())
+				{
+					ImGui::SetTooltip("%s (%s)", style.tooltipFr, a->shortcutText.c_str());
+				}
+				else
+				{
+					ImGui::SetTooltip("%s", style.tooltipFr);
+				}
+			}
+			ImGui::PopID();
+		};
+
+		for (const ToolPaletteGroup& group : GetToolPaletteGroups())
+		{
+			if (!ImGui::CollapsingHeader(group.titleFr, ImGuiTreeNodeFlags_DefaultOpen))
+			{
+				continue;
+			}
+			for (ActiveTool tool : group.tools)
+			{
+				renderToolButton(tool);
+			}
+		}
+
+		ImGui::End();
+#endif
+	}
+}

--- a/src/world_editor/panels/ToolPalettePanel.h
+++ b/src/world_editor/panels/ToolPalettePanel.h
@@ -1,0 +1,44 @@
+#pragma once
+// ToolPalettePanel — palette d'outils latérale (réorganisation UI
+// 2026-07-17, PR 2, convention UE « Modes »). Remplace la rangée d'outils
+// horizontale M100.35 : les 15 outils du shell sont présentés en 4 familles
+// repliables (Terrain / Eau / Macro / Structures — cf. ToolPaletteModel),
+// avec l'outil actif surligné et un bouton « Aucun outil » en tête.
+
+#include "src/world_editor/core/IPanel.h"
+
+namespace engine::editor::world { class WorldEditorShell; }
+
+namespace engine::editor::world::panels
+{
+	/// Panneau dockable « Palette d'outils » du shell éditeur monde.
+	/// Docké à gauche dans la disposition par défaut (même node que la
+	/// fenêtre « Outils » de la session M43.x). Un clic sur un outil appelle
+	/// `WorldEditorShell::SetActiveTool` (clic sur l'outil déjà actif =
+	/// désélection, même convention que le menu Outils).
+	class ToolPalettePanel final : public IPanel
+	{
+	public:
+		/// \param shell Shell propriétaire de l'outil actif. Pointeur non
+		///   possédé, non nul, valide pendant toute la vie du panneau (le
+		///   shell possède le panneau via `m_panels`).
+		explicit ToolPalettePanel(WorldEditorShell* shell) : m_shell(shell) {}
+
+		const char* GetName() const override { return "Palette d'outils"; }
+
+		/// Rend les groupes repliables + boutons d'outils. L'outil actif a
+		/// un fond ambre (même teinte que l'ex-toolbar M100.35), la pastille
+		/// de couleur vient de `ToolbarIconAtlas`, le tooltip affiche le
+		/// raccourci depuis le registre d'actions du shell.
+		/// Effet de bord : crée une window ImGui « Palette d'outils » ;
+		/// appelle `SetActiveTool` au clic.
+		void Render() override;
+
+		bool IsVisible() const override { return m_visible; }
+		void SetVisible(bool visible) override { m_visible = visible; }
+
+	private:
+		WorldEditorShell* m_shell = nullptr;
+		bool m_visible = true;
+	};
+}

--- a/src/world_editor/tests/EditorToolbarTests.cpp
+++ b/src/world_editor/tests/EditorToolbarTests.cpp
@@ -1,15 +1,18 @@
-/// Tests unitaires CPU pour M100.35 — EditorToolbar.
+/// Tests unitaires CPU pour la barre d'actions (réorganisation UI
+/// 2026-07-17 — ex-toolbar d'outils M100.35).
 ///
 /// Pas d'ImGui ni de GPU. On vérifie :
-///   - Le layout calculé ne couvre PAS le viewport 3D (l'invariant clé du
-///     ticket : la toolbar reste au-dessus, pas au-dessus du terrain).
+///   - Le layout calculé ne couvre PAS le viewport 3D (invariant M100.35
+///     conservé : la barre reste dans sa bande, jamais sur le terrain).
+///   - Un id d'action absent du registre ne produit PAS de bouton.
 ///   - Le hit-test pur renvoie le bon index de bouton.
-///   - `HandleClick` route correctement vers `WorldEditorShell::SetActiveTool`.
-///   - Le fallback "icône absente" est non-crashable (l'atlas retourne un
-///     style valide même pour le bouton de désélection / les outils non
-///     mappés).
-///   - `SetActiveTool` ne mute pas d'état "rendu" du shell (proxy : ne
-///     touche pas à `m_dirty`, `m_initialized`, `m_panels.size()`).
+///   - `HandleClick` exécute l'action du registre (stub qui flippe un bool)
+///     et respecte le prédicat `enabled` (action grisée = no-op).
+///   - Le fallback de `ToolbarIconAtlas::GetForAction` est non-crashable.
+///   - `SetActiveTool` ne mute pas d'état « rendu » du shell (proxy pour
+///     l'invariant de visibilité du terrain).
+///   - Dirty-tracking `NoteSaved`/`IsDirtySinceSave` (barre de statut +
+///     modale Quitter).
 ///
 /// Framework : REQUIRE maison + main monolithique (pattern identique aux
 /// autres suites de tests world_editor).
@@ -20,6 +23,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <functional>
 
 namespace
 {
@@ -38,14 +42,41 @@ namespace
 	using engine::editor::world::ToolbarIconAtlas;
 	using engine::editor::world::ToolIconStyle;
 	using engine::editor::world::WorldEditorShell;
+	using engine::editor::world::actions::ActionCategory;
+	using engine::editor::world::actions::EditorAction;
 
-	/// Test : la toolbar ne couvre PAS le viewport. La règle : la zone Y
-	/// occupée par la toolbar reste sous la zone du viewport (toolbar.y +
-	/// height ≤ topOfViewport). Concrètement : la toolbar est posée *juste
-	/// au-dessus* du dockspace, dont le top commence où la toolbar finit.
+	/// Enregistre une action stub `id` qui incrémente `counter` à chaque
+	/// exécution. `enabled` nul => toujours active.
+	void RegisterStub(WorldEditorShell& shell, const char* id, int* counter,
+		std::function<bool()> enabled = nullptr)
+	{
+		EditorAction a;
+		a.id = id;
+		a.label = id;
+		a.category = ActionCategory::Fichier;
+		a.enabled = std::move(enabled);
+		a.execute = [counter] { ++(*counter); };
+		(void)shell.MutableActionRegistry().Register(std::move(a));
+	}
+
+	/// Enregistre les 5 actions attendues par la barre, comptées dans
+	/// `counters[0..4]` (ordre save/undo/redo/validate/export).
+	void RegisterAllFive(WorldEditorShell& shell, int* counters)
+	{
+		RegisterStub(shell, "file.save",     &counters[0]);
+		RegisterStub(shell, "edit.undo",     &counters[1]);
+		RegisterStub(shell, "edit.redo",     &counters[2]);
+		RegisterStub(shell, "zone.validate", &counters[3]);
+		RegisterStub(shell, "zone.export",   &counters[4]);
+	}
+
+	/// Test : la barre ne couvre PAS le viewport (toolbar.y + height borne
+	/// tous les boutons) et les 5 actions donnent 5 boutons.
 	void Test_Toolbar_DoesNotCoverViewport()
 	{
 		WorldEditorShell shell;
+		int counters[5] = {};
+		RegisterAllFive(shell, counters);
 		EditorToolbar toolbar(shell);
 
 		// Viewport simulé : 1920x1080, menu bar 20 px.
@@ -56,124 +87,129 @@ namespace
 		REQUIRE(layout.toolbarHeight == EditorToolbar::kToolbarHeightPx);
 		REQUIRE(layout.toolbarY == menuBarHeight);
 		REQUIRE(layout.toolbarWidth == viewportWidth);
+		REQUIRE(layout.buttons.size() == 5u);
 
 		// Le top du viewport 3D commence à `toolbarY + toolbarHeight`.
 		const float viewportTopY = layout.toolbarY + layout.toolbarHeight;
-		// Tous les boutons ont y < viewportTopY (donc strictement dans la
-		// bande toolbar, jamais sous le terrain).
 		for (const auto& b : layout.buttons)
 		{
 			REQUIRE(b.y + b.height <= viewportTopY);
 		}
 	}
 
-	/// Test : click sur le bouton d'un outil donné route vers
-	/// `SetActiveTool` avec le bon enum.
-	void Test_Toolbar_ClickRoutesToSetActiveTool()
+	/// Test : un id absent du registre est omis du layout (mode shell
+	/// in-game : les actions session ne sont pas enregistrées).
+	void Test_Toolbar_UnknownActionOmitted()
 	{
 		WorldEditorShell shell;
+		int c0 = 0, c1 = 0;
+		RegisterStub(shell, "edit.undo", &c0);
+		RegisterStub(shell, "edit.redo", &c1);
+		EditorToolbar toolbar(shell);
+
+		const ToolbarLayout layout = toolbar.BuildLayout(1920.0f, 20.0f);
+		REQUIRE(layout.buttons.size() == 2u);
+		REQUIRE(layout.buttons[0].actionId == "edit.undo");
+		REQUIRE(layout.buttons[1].actionId == "edit.redo");
+
+		// Registre entièrement vide → aucun bouton, pas de crash.
+		WorldEditorShell emptyShell;
+		EditorToolbar emptyToolbar(emptyShell);
+		REQUIRE(emptyToolbar.BuildLayout(1920.0f, 20.0f).buttons.empty());
+	}
+
+	/// Test : click sur un bouton route vers l'exécution de la BONNE action.
+	void Test_Toolbar_ClickExecutesAction()
+	{
+		WorldEditorShell shell;
+		int counters[5] = {};
+		RegisterAllFive(shell, counters);
 		EditorToolbar toolbar(shell);
 		const ToolbarLayout layout = toolbar.BuildLayout(1920.0f, 20.0f);
 
-		// Trouve le bouton Mountain Range et clique son centre.
-		size_t mountainIdx = layout.buttons.size();
+		// Trouve le bouton "zone.validate" et clique son centre.
+		size_t validateIdx = layout.buttons.size();
 		for (size_t i = 0; i < layout.buttons.size(); ++i)
 		{
-			if (layout.buttons[i].tool == ActiveTool::MountainRange)
-			{
-				mountainIdx = i;
-				break;
-			}
+			if (layout.buttons[i].actionId == "zone.validate") { validateIdx = i; break; }
 		}
-		REQUIRE(mountainIdx < layout.buttons.size());
+		REQUIRE(validateIdx < layout.buttons.size());
 
-		const auto& b = layout.buttons[mountainIdx];
-		const float mx = b.x + b.width * 0.5f;
-		const float my = b.y + b.height * 0.5f;
-
+		const auto& b = layout.buttons[validateIdx];
 		size_t hitIdx = 0;
-		REQUIRE(EditorToolbar::HitTest(layout, mx, my, hitIdx));
-		REQUIRE(hitIdx == mountainIdx);
+		REQUIRE(EditorToolbar::HitTest(layout,
+			b.x + b.width * 0.5f, b.y + b.height * 0.5f, hitIdx));
+		REQUIRE(hitIdx == validateIdx);
 
-		REQUIRE(shell.GetActiveTool() == ActiveTool::None);
 		toolbar.HandleClick(layout, hitIdx);
-		REQUIRE(shell.GetActiveTool() == ActiveTool::MountainRange);
+		REQUIRE(counters[3] == 1); // zone.validate exécutée
+		REQUIRE(counters[0] == 0 && counters[1] == 0
+			&& counters[2] == 0 && counters[4] == 0);
 
-		// Idem pour Valley Chain.
-		size_t valleyIdx = layout.buttons.size();
-		for (size_t i = 0; i < layout.buttons.size(); ++i)
-		{
-			if (layout.buttons[i].tool == ActiveTool::ValleyChain)
-			{
-				valleyIdx = i;
-				break;
-			}
-		}
-		REQUIRE(valleyIdx < layout.buttons.size());
-		toolbar.HandleClick(layout, valleyIdx);
-		REQUIRE(shell.GetActiveTool() == ActiveTool::ValleyChain);
+		// Index hors plage : no-op.
+		toolbar.HandleClick(layout, layout.buttons.size());
+		REQUIRE(counters[3] == 1);
+	}
 
-		// Cliquer le bouton X (désélection) bascule vers None.
-		size_t deselectIdx = layout.buttons.size();
-		for (size_t i = 0; i < layout.buttons.size(); ++i)
-		{
-			if (layout.buttons[i].tool == ActiveTool::None)
-			{
-				deselectIdx = i;
-				break;
-			}
-		}
-		REQUIRE(deselectIdx < layout.buttons.size());
-		toolbar.HandleClick(layout, deselectIdx);
-		REQUIRE(shell.GetActiveTool() == ActiveTool::None);
+	/// Test : une action au prédicat `enabled` faux n'est PAS exécutée au
+	/// clic (bouton grisé).
+	void Test_Toolbar_DisabledActionIsNoOp()
+	{
+		WorldEditorShell shell;
+		int execCount = 0;
+		bool gate = false;
+		RegisterStub(shell, "file.save", &execCount, [&gate] { return gate; });
+		EditorToolbar toolbar(shell);
+		const ToolbarLayout layout = toolbar.BuildLayout(1920.0f, 20.0f);
+		REQUIRE(layout.buttons.size() == 1u);
+
+		toolbar.HandleClick(layout, 0);
+		REQUIRE(execCount == 0); // grisée → no-op
+
+		gate = true;
+		toolbar.HandleClick(layout, 0);
+		REQUIRE(execCount == 1); // réactivée → exécutée
 	}
 
 	/// Test : HitTest hors zone de tous les boutons → false.
 	void Test_Toolbar_HitTestOutsideAllButtons_ReturnsFalse()
 	{
 		WorldEditorShell shell;
+		int counters[5] = {};
+		RegisterAllFive(shell, counters);
 		EditorToolbar toolbar(shell);
 		const ToolbarLayout layout = toolbar.BuildLayout(1920.0f, 20.0f);
 
 		size_t hitIdx = 999;
-		// Bien sous tous les boutons (Y au milieu du viewport, où il n'y a
-		// pas de toolbar).
+		// Bien sous tous les boutons (Y au milieu du viewport).
 		REQUIRE(!EditorToolbar::HitTest(layout, 100.0f, 500.0f, hitIdx));
 		REQUIRE(hitIdx == 999); // pas muté
 
-		// Au-dessus de toute la toolbar.
+		// Au-dessus de toute la barre.
 		REQUIRE(!EditorToolbar::HitTest(layout, 100.0f, 0.0f, hitIdx));
 	}
 
-	/// Test : l'atlas fournit un style placeholder valide pour chaque outil
-	/// connu et un fallback pour l'inconnu — pas de crash, pas de pointeur
-	/// null sur `letter` ou `tooltipFr`.
-	void Test_Toolbar_MissingIcon_FallsBackToPlaceholder()
+	/// Test : l'atlas fournit un style valide pour chaque action de la barre
+	/// et un fallback pour l'inconnu — pas de pointeur nul.
+	void Test_Toolbar_ActionIcons_FallBackToPlaceholder()
 	{
-		const ActiveTool kKnown[] = {
-			ActiveTool::None,
-			ActiveTool::TerrainSculpt,
-			ActiveTool::TerrainStamp,
-			ActiveTool::SplatPaint,
-			ActiveTool::Lake,
-			ActiveTool::River,
-			ActiveTool::MountainRange,
-			ActiveTool::ValleyChain,
+		const char* kActionIds[] = {
+			"file.save", "edit.undo", "edit.redo", "zone.validate", "zone.export",
 		};
-		for (ActiveTool t : kKnown)
+		for (const char* id : kActionIds)
 		{
-			const ToolIconStyle s = ToolbarIconAtlas::Get(t);
-			REQUIRE(s.letter    != nullptr);
-			REQUIRE(s.tooltipFr != nullptr);
-			REQUIRE(std::strlen(s.letter)    > 0);
-			REQUIRE(std::strlen(s.tooltipFr) > 0);
+			const ToolIconStyle s = ToolbarIconAtlas::GetForAction(id);
+			REQUIRE(s.enabled);
+			REQUIRE(s.letter    != nullptr && std::strlen(s.letter)    > 0);
+			REQUIRE(s.tooltipFr != nullptr && std::strlen(s.tooltipFr) > 0);
 		}
 
-		// Cast d'un uint8 hors enum → style par défaut "Bientôt disponible".
-		const ToolIconStyle bogus = ToolbarIconAtlas::Get(static_cast<ActiveTool>(99));
+		const ToolIconStyle bogus = ToolbarIconAtlas::GetForAction("absent.id");
 		REQUIRE(bogus.enabled == false);
-		REQUIRE(bogus.letter  != nullptr);
+		REQUIRE(bogus.letter != nullptr);
 
+		// L'atlas outils (consommé par la palette + la barre de statut)
+		// reste non-crashable.
 		const ToolIconStyle deselect = ToolbarIconAtlas::GetDeselect();
 		REQUIRE(deselect.enabled == true);
 		REQUIRE(std::strcmp(deselect.letter, "X") == 0);
@@ -181,8 +217,6 @@ namespace
 
 	/// Test (réorganisation UI 2026-07-17) : NoteSaved/IsDirtySinceSave — le
 	/// dirty-tracking consommé par la barre de statut et la modale Quitter.
-	/// Un shell neuf n'est pas dirty ; MarkDirty le rend dirty ; NoteSaved le
-	/// blanchit ; une mutation de la pile de commandes le re-salit.
 	void Test_Shell_DirtySinceSave_Tracking()
 	{
 		WorldEditorShell shell;
@@ -203,11 +237,8 @@ namespace
 	}
 
 	/// Test : activation d'un nouvel outil ne déclenche AUCUN side effect
-	/// sur l'état dirty / panels / initialized du shell. C'est un proxy
-	/// observable pour l'invariant de visibilité du terrain : si
-	/// `SetActiveTool` n'écrit que `m_activeTool`, alors par construction
-	/// il ne peut pas muter `TerrainRenderer::IsFrustumCullEnabled`,
-	/// `m_noUserTextures` ou la position caméra (qui vivent ailleurs).
+	/// sur l'état dirty / panels / initialized du shell. Proxy observable de
+	/// l'invariant de visibilité du terrain (cf. M100.35).
 	void Test_NewToolActivation_DoesNotResetCameraOrFrustumCullState()
 	{
 		WorldEditorShell shell;
@@ -220,10 +251,6 @@ namespace
 		REQUIRE(shell.IsInitialized() == initBefore);
 		REQUIRE(shell.Panels().size() == panelsBefore);
 
-		shell.SetActiveTool(ActiveTool::ValleyChain);
-		REQUIRE(shell.GetActiveTool() == ActiveTool::ValleyChain);
-		REQUIRE(shell.IsDirty() == dirtyBefore);
-
 		shell.SetActiveTool(ActiveTool::None);
 		REQUIRE(shell.GetActiveTool() == ActiveTool::None);
 		REQUIRE(shell.IsDirty() == dirtyBefore);
@@ -233,9 +260,11 @@ namespace
 int main()
 {
 	Test_Toolbar_DoesNotCoverViewport();
-	Test_Toolbar_ClickRoutesToSetActiveTool();
+	Test_Toolbar_UnknownActionOmitted();
+	Test_Toolbar_ClickExecutesAction();
+	Test_Toolbar_DisabledActionIsNoOp();
 	Test_Toolbar_HitTestOutsideAllButtons_ReturnsFalse();
-	Test_Toolbar_MissingIcon_FallsBackToPlaceholder();
+	Test_Toolbar_ActionIcons_FallBackToPlaceholder();
 	Test_Shell_DirtySinceSave_Tracking();
 	Test_NewToolActivation_DoesNotResetCameraOrFrustumCullState();
 

--- a/src/world_editor/tests/ToolPaletteModelTests.cpp
+++ b/src/world_editor/tests/ToolPaletteModelTests.cpp
@@ -1,0 +1,102 @@
+/// Tests unitaires CPU pour le modèle de la palette d'outils
+/// (réorganisation UI 2026-07-17, PR 2).
+///
+/// Pas d'ImGui ni de shell — la suite tourne sous ctest Linux. On vérifie :
+///   - Les 4 familles couvrent exactement les 15 outils de l'enum (chaque
+///     valeur 1..15 apparaît UNE fois, aucune n'est oubliée ni dupliquée).
+///   - Aucun groupe vide, titres non vides et uniques.
+///   - `ToolLabelFr` : libellé non vide et unique pour chaque outil, cas
+///     `None` et valeur hors enum définis (pas de nullptr).
+///
+/// Framework : REQUIRE maison + main monolithique (pattern des autres
+/// suites world_editor).
+
+#include "src/world_editor/ui/ToolPaletteModel.h"
+
+#include <cstdio>
+#include <cstring>
+#include <set>
+#include <string>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::editor::world::ActiveTool;
+	using engine::editor::world::GetToolPaletteGroups;
+	using engine::editor::world::kActiveToolCount;
+	using engine::editor::world::ToolLabelFr;
+	using engine::editor::world::ToolPaletteGroup;
+
+	/// Test : couverture exacte de l'enum — chaque outil 1..15 apparaît une
+	/// et une seule fois dans l'union des groupes ; None n'y figure pas.
+	void Test_Groups_CoverAllToolsExactlyOnce()
+	{
+		const std::vector<ToolPaletteGroup>& groups = GetToolPaletteGroups();
+		std::set<int> seen;
+		size_t total = 0;
+		for (const ToolPaletteGroup& g : groups)
+		{
+			for (ActiveTool t : g.tools)
+			{
+				const int v = static_cast<int>(t);
+				REQUIRE(v >= 1 && v <= kActiveToolCount); // jamais None ni hors enum
+				REQUIRE(seen.insert(v).second);           // pas de doublon
+				++total;
+			}
+		}
+		REQUIRE(total == static_cast<size_t>(kActiveToolCount));
+	}
+
+	/// Test : structure des groupes — 4 familles, non vides, titres uniques.
+	void Test_Groups_TitlesAndNonEmpty()
+	{
+		const std::vector<ToolPaletteGroup>& groups = GetToolPaletteGroups();
+		REQUIRE(groups.size() == 4u);
+		std::set<std::string> titles;
+		for (const ToolPaletteGroup& g : groups)
+		{
+			REQUIRE(g.titleFr != nullptr && std::strlen(g.titleFr) > 0);
+			REQUIRE(titles.insert(g.titleFr).second);
+			REQUIRE(!g.tools.empty());
+		}
+	}
+
+	/// Test : ToolLabelFr — libellés définis, non vides, uniques ; cas None
+	/// et hors-enum sûrs (pas de nullptr).
+	void Test_ToolLabelFr_DefinedAndUnique()
+	{
+		std::set<std::string> labels;
+		for (int v = 1; v <= kActiveToolCount; ++v)
+		{
+			const char* label = ToolLabelFr(static_cast<ActiveTool>(v));
+			REQUIRE(label != nullptr && std::strlen(label) > 0);
+			REQUIRE(labels.insert(label).second);
+		}
+		REQUIRE(std::strcmp(ToolLabelFr(ActiveTool::None), "Aucun outil") == 0);
+		const char* bogus = ToolLabelFr(static_cast<ActiveTool>(99));
+		REQUIRE(bogus != nullptr && std::strlen(bogus) > 0);
+	}
+}
+
+int main()
+{
+	Test_Groups_CoverAllToolsExactlyOnce();
+	Test_Groups_TitlesAndNonEmpty();
+	Test_ToolLabelFr_DefinedAndUnique();
+
+	if (g_failed > 0)
+	{
+		std::fprintf(stderr, "[ToolPaletteModelTests] %d failure(s)\n", g_failed);
+		return 1;
+	}
+	std::fprintf(stdout, "[ToolPaletteModelTests] all tests passed\n");
+	return 0;
+}

--- a/src/world_editor/tests/ToolPaletteModelTests.cpp
+++ b/src/world_editor/tests/ToolPaletteModelTests.cpp
@@ -32,6 +32,7 @@ namespace
 	using engine::editor::world::ActiveTool;
 	using engine::editor::world::GetToolPaletteGroups;
 	using engine::editor::world::kActiveToolCount;
+	using engine::editor::world::ToolActionId;
 	using engine::editor::world::ToolLabelFr;
 	using engine::editor::world::ToolPaletteGroup;
 
@@ -84,6 +85,23 @@ namespace
 		const char* bogus = ToolLabelFr(static_cast<ActiveTool>(99));
 		REQUIRE(bogus != nullptr && std::strlen(bogus) > 0);
 	}
+
+	/// Test : ToolActionId — id kebab-case "tool." unique par outil ; None
+	/// et hors-enum retournent une chaîne vide (jamais nullptr).
+	void Test_ToolActionId_DefinedAndUnique()
+	{
+		std::set<std::string> ids;
+		for (int v = 1; v <= kActiveToolCount; ++v)
+		{
+			const char* id = ToolActionId(static_cast<ActiveTool>(v));
+			REQUIRE(id != nullptr && std::strlen(id) > 0);
+			REQUIRE(std::strncmp(id, "tool.", 5) == 0);
+			REQUIRE(ids.insert(id).second);
+		}
+		REQUIRE(ToolActionId(ActiveTool::None) != nullptr);
+		REQUIRE(std::strlen(ToolActionId(ActiveTool::None)) == 0);
+		REQUIRE(ToolActionId(static_cast<ActiveTool>(99)) != nullptr);
+	}
 }
 
 int main()
@@ -91,6 +109,7 @@ int main()
 	Test_Groups_CoverAllToolsExactlyOnce();
 	Test_Groups_TitlesAndNonEmpty();
 	Test_ToolLabelFr_DefinedAndUnique();
+	Test_ToolActionId_DefinedAndUnique();
 
 	if (g_failed > 0)
 	{

--- a/src/world_editor/ui/EditorToolbar.cpp
+++ b/src/world_editor/ui/EditorToolbar.cpp
@@ -1,6 +1,13 @@
+// EditorToolbar — barre d'actions (réorganisation UI 2026-07-17).
+// Remplace la rangée d'outils M100.35 : les outils vivent désormais dans la
+// palette latérale (ToolPalettePanel) ; la barre du haut ne porte plus que
+// les actions générales du registre (save / undo / redo / validate / export).
+
 #include "src/world_editor/ui/EditorToolbar.h"
 
 #include "src/world_editor/ui/ToolbarIconAtlas.h"
+
+#include <algorithm>
 
 #if defined(_WIN32)
 #	include "imgui.h"
@@ -11,23 +18,22 @@ namespace engine::editor::world
 	EditorToolbar::EditorToolbar(WorldEditorShell& shell)
 		: m_shell(shell)
 	{
-		m_orderedTools = {
-			ActiveTool::TerrainSculpt,
-			ActiveTool::TerrainStamp,
-			ActiveTool::SplatPaint,
-			ActiveTool::Lake,
-			ActiveTool::River,
-			ActiveTool::MountainRange,
-			ActiveTool::ValleyChain,
-			ActiveTool::RiverNetwork,     // M100.36
-			ActiveTool::Coastline,        // M100.37
-			ActiveTool::HydraulicErosion,   // M100.38
-			ActiveTool::ThermalWindErosion, // M100.39 (clôt Phase 2.5)
-			ActiveTool::Cave,               // M100.40 (démarre Phase 11)
-			ActiveTool::Overhang,           // M100.41
-			ActiveTool::Arch,               // M100.42
-			ActiveTool::DungeonPortal,      // M100.43
+		// Ordre d'affichage. Groupes visuels : Sauvegarder | Annuler/Rétablir
+		// | Valider/Exporter (indices 1 et 3 démarrent un nouveau groupe).
+		m_orderedActionIds = {
+			"file.save",
+			"edit.undo",
+			"edit.redo",
+			"zone.validate",
+			"zone.export",
 		};
+		m_groupStartIndices = { 1u, 3u };
+	}
+
+	bool EditorToolbar::IsGroupStart(size_t idx) const
+	{
+		return std::find(m_groupStartIndices.begin(), m_groupStartIndices.end(), idx)
+			!= m_groupStartIndices.end();
 	}
 
 	ToolbarLayout EditorToolbar::BuildLayout(float viewportWidthPx,
@@ -37,35 +43,32 @@ namespace engine::editor::world
 		layout.toolbarY      = menuBarHeightPx;
 		layout.toolbarHeight = kToolbarHeightPx;
 		layout.toolbarWidth  = viewportWidthPx;
+		layout.buttons.reserve(m_orderedActionIds.size());
 
-		// Le bouton X de désélection est ajouté en queue : (N outils) + 1.
-		const size_t totalButtons = m_orderedTools.size() + 1u;
-		layout.buttons.reserve(totalButtons);
+		const actions::EditorActionRegistry& reg = m_shell.GetActionRegistry();
 
 		float cursorX = kToolbarPaddingPx;
 		const float cursorY = layout.toolbarY + kToolbarPaddingPx;
-		for (ActiveTool tool : m_orderedTools)
+		for (size_t i = 0; i < m_orderedActionIds.size(); ++i)
 		{
+			// Un id absent du registre (ex. actions session non enregistrées
+			// en mode shell in-game) ne produit pas de bouton.
+			if (reg.Find(m_orderedActionIds[i]) == nullptr) continue;
+
+			if (IsGroupStart(i) && !layout.buttons.empty())
+			{
+				cursorX += kGroupSpacingPx;
+			}
+
 			ToolbarButtonRect r;
 			r.x = cursorX;
 			r.y = cursorY;
 			r.width = kButtonSizePx;
 			r.height = kButtonSizePx;
-			r.tool = tool;
-			layout.buttons.push_back(r);
+			r.actionId = m_orderedActionIds[i];
+			layout.buttons.push_back(std::move(r));
 			cursorX += kButtonSizePx + kButtonSpacingPx;
 		}
-
-		// Bouton de désélection (X) — un petit espace supplémentaire avant
-		// pour le séparer visuellement des autres outils.
-		cursorX += kButtonSpacingPx;
-		ToolbarButtonRect deselect;
-		deselect.x = cursorX;
-		deselect.y = cursorY;
-		deselect.width = kButtonSizePx;
-		deselect.height = kButtonSizePx;
-		deselect.tool = ActiveTool::None;
-		layout.buttons.push_back(deselect);
 
 		return layout;
 	}
@@ -90,18 +93,20 @@ namespace engine::editor::world
 		size_t buttonIndex)
 	{
 		if (buttonIndex >= layout.buttons.size()) return;
-		m_shell.SetActiveTool(layout.buttons[buttonIndex].tool);
+		const actions::EditorAction* a =
+			m_shell.GetActionRegistry().Find(layout.buttons[buttonIndex].actionId);
+		if (a == nullptr) return;
+		if (!actions::EditorActionRegistry::IsEnabled(*a)) return;
+		if (a->execute) { a->execute(); }
 	}
 
 #if defined(_WIN32)
 	void EditorToolbar::Render()
 	{
-		// Construction de la fenêtre toolbar : ancrée sous le menu bar,
-		// largeur = viewport principal, hauteur fixe. Le menu bar ImGui
-		// occupe `ImGui::GetFrameHeight()` pixels en haut du viewport
-		// principal.
+		// Construction de la fenêtre : ancrée sous le menu bar, largeur =
+		// viewport principal, hauteur fixe (mêmes flags que la toolbar
+		// M100.35 — la barre ne couvre jamais la zone 3D).
 		const ImGuiViewport* vp = ImGui::GetMainViewport();
-		const float menuBarH = ImGui::GetFrameHeight();
 		const ImVec2 toolbarPos{ vp->WorkPos.x, vp->WorkPos.y };
 		const ImVec2 toolbarSize{ vp->WorkSize.x, kToolbarHeightPx };
 
@@ -126,17 +131,25 @@ namespace engine::editor::world
 			return;
 		}
 
-		const ActiveTool current = m_shell.GetActiveTool();
-		const ImU32 activeBg = IM_COL32(255, 196, 64, 96);
-
+		const actions::EditorActionRegistry& reg = m_shell.GetActionRegistry();
 		ImDrawList* dl = ImGui::GetWindowDrawList();
 		const ImVec2 windowOrigin = ImGui::GetCursorScreenPos();
 
 		float cursorX = 0.0f;
-		for (size_t i = 0; i < m_orderedTools.size(); ++i)
+		bool anyDrawn = false;
+		for (size_t i = 0; i < m_orderedActionIds.size(); ++i)
 		{
-			const ActiveTool tool = m_orderedTools[i];
-			const ToolIconStyle style = ToolbarIconAtlas::Get(tool);
+			const actions::EditorAction* a = reg.Find(m_orderedActionIds[i]);
+			if (a == nullptr) continue;
+
+			if (IsGroupStart(i) && anyDrawn)
+			{
+				cursorX += kGroupSpacingPx;
+			}
+			anyDrawn = true;
+
+			const bool enabled = actions::EditorActionRegistry::IsEnabled(*a);
+			const ToolIconStyle style = ToolbarIconAtlas::GetForAction(a->id);
 
 			ImGui::PushID(static_cast<int>(i));
 			ImGui::SetCursorPosX(cursorX);
@@ -149,93 +162,56 @@ namespace engine::editor::world
 				buttonScreenMin.x + kButtonSizePx,
 				buttonScreenMin.y + kButtonSizePx };
 
-			// Background du bouton : ambre si actif, sinon couleur de
-			// l'icône (placeholder). Le rect est dessiné avant
-			// l'InvisibleButton pour qu'ImGui ne mange pas le rect.
-			const bool isActive = (current == tool);
-			const ImU32 baseColor = isActive
-				? activeBg
-				: static_cast<ImU32>(style.bgColorArgb);
+			// Fond : couleur de l'icône, assombrie si l'action est grisée.
+			ImU32 baseColor = static_cast<ImU32>(style.bgColorArgb);
+			if (!enabled)
+			{
+				baseColor = IM_COL32(70, 70, 70, 160);
+			}
 			dl->AddRectFilled(buttonScreenMin, buttonScreenMax, baseColor, 4.0f);
 
-			// Lettre centrale (placeholder).
+			// Lettre centrale (placeholder — un futur ticket d'art remplacera
+			// par de vraies icônes PNG, cf. ToolbarIconAtlas).
 			const ImVec2 textSize = ImGui::CalcTextSize(style.letter);
 			const ImVec2 textPos{
 				buttonScreenMin.x + (kButtonSizePx - textSize.x) * 0.5f,
 				buttonScreenMin.y + (kButtonSizePx - textSize.y) * 0.5f };
-			dl->AddText(textPos, IM_COL32_WHITE, style.letter);
+			dl->AddText(textPos,
+				enabled ? IM_COL32_WHITE : IM_COL32(160, 160, 160, 200),
+				style.letter);
 
-			// Bordure (active = jaune, sinon gris foncé).
-			const ImU32 border = isActive
-				? IM_COL32(255, 196, 64, 220)
-				: IM_COL32(40, 40, 40, 200);
-			dl->AddRect(buttonScreenMin, buttonScreenMax, border, 4.0f, 0, 1.5f);
+			dl->AddRect(buttonScreenMin, buttonScreenMax,
+				IM_COL32(40, 40, 40, 200), 4.0f, 0, 1.5f);
 
 			// InvisibleButton occupe exactement le rect du bouton.
-			ImGui::InvisibleButton("##btn",
-				ImVec2(kButtonSizePx, kButtonSizePx));
-			const bool clicked = ImGui::IsItemActivated() ||
-				(ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Left));
-			if (clicked && style.enabled)
+			ImGui::InvisibleButton("##btn", ImVec2(kButtonSizePx, kButtonSizePx));
+			const bool clicked = ImGui::IsItemHovered()
+				&& ImGui::IsMouseClicked(ImGuiMouseButton_Left);
+			if (clicked && enabled && a->execute)
 			{
-				m_shell.SetActiveTool(tool);
+				a->execute();
 			}
-			if (ImGui::IsItemHovered())
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 			{
-				ImGui::SetTooltip("%s", style.tooltipFr);
+				// Tooltip « libellé (raccourci) » depuis le registre — source
+				// unique avec les menus.
+				if (a->shortcutText.empty())
+				{
+					ImGui::SetTooltip("%s", a->label.c_str());
+				}
+				else
+				{
+					ImGui::SetTooltip("%s (%s)", a->label.c_str(), a->shortcutText.c_str());
+				}
 			}
 
 			ImGui::PopID();
 			cursorX += kButtonSizePx + kButtonSpacingPx;
-			ImGui::SameLine(); // s'aligne pour InvisibleButton suivant
-		}
-
-		// Bouton X de désélection. Petit espace avant.
-		cursorX += kButtonSpacingPx;
-		{
-			const ToolIconStyle style = ToolbarIconAtlas::GetDeselect();
-			ImGui::PushID("deselect");
-
-			const ImVec2 buttonScreenMin{
-				windowOrigin.x + cursorX,
-				windowOrigin.y };
-			const ImVec2 buttonScreenMax{
-				buttonScreenMin.x + kButtonSizePx,
-				buttonScreenMin.y + kButtonSizePx };
-
-			const bool isActive = (current == ActiveTool::None);
-			const ImU32 baseColor = isActive
-				? activeBg
-				: static_cast<ImU32>(style.bgColorArgb);
-			dl->AddRectFilled(buttonScreenMin, buttonScreenMax, baseColor, 4.0f);
-			const ImVec2 textSize = ImGui::CalcTextSize(style.letter);
-			const ImVec2 textPos{
-				buttonScreenMin.x + (kButtonSizePx - textSize.x) * 0.5f,
-				buttonScreenMin.y + (kButtonSizePx - textSize.y) * 0.5f };
-			dl->AddText(textPos, IM_COL32_WHITE, style.letter);
-			dl->AddRect(buttonScreenMin, buttonScreenMax,
-				IM_COL32(80, 0, 0, 220), 4.0f, 0, 1.5f);
-
-			ImGui::SetCursorPosX(cursorX);
-			ImGui::SetCursorPosY(0.0f);
-			ImGui::InvisibleButton("##xbtn",
-				ImVec2(kButtonSizePx, kButtonSizePx));
-			if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(ImGuiMouseButton_Left))
-			{
-				m_shell.SetActiveTool(ActiveTool::None);
-			}
-			if (ImGui::IsItemHovered())
-			{
-				ImGui::SetTooltip("%s", style.tooltipFr);
-			}
-
-			ImGui::PopID();
+			ImGui::SameLine(); // s'aligne pour l'InvisibleButton suivant
 		}
 
 		ImGui::End();
 		ImGui::PopStyleVar(3);
-
-		(void)menuBarH; // toolbarPos est calculé via vp->WorkPos qui inclut le menu bar
 	}
 #endif
 }

--- a/src/world_editor/ui/EditorToolbar.h
+++ b/src/world_editor/ui/EditorToolbar.h
@@ -3,14 +3,16 @@
 #include "src/world_editor/core/WorldEditorShell.h"
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace engine::editor::world
 {
 	class ToolbarIconAtlas;
 
-	/// Spec géométrique d'un bouton dans la toolbar (M100.35). Position en
-	/// pixels relatifs au coin haut-gauche de la toolbar (laquelle est elle-
+	/// Spec géométrique d'un bouton dans la barre d'actions (réorganisation
+	/// UI 2026-07-17 ; géométrie héritée de la toolbar M100.35). Position en
+	/// pixels relatifs au coin haut-gauche de la barre (laquelle est elle-
 	/// même ancrée juste sous le menu bar ImGui).
 	struct ToolbarButtonRect
 	{
@@ -18,13 +20,14 @@ namespace engine::editor::world
 		float y      = 0.0f;
 		float width  = 40.0f;
 		float height = 40.0f;
-		/// Outil que ce bouton active. Pour le bouton final "Désélection",
-		/// vaut `ActiveTool::None`.
-		ActiveTool tool = ActiveTool::None;
+		/// Id de l'action du registre (`EditorActionRegistry`) que ce bouton
+		/// déclenche (ex. "file.save"). Toujours non vide : un id absent du
+		/// registre ne produit PAS de bouton (omis par `BuildLayout`).
+		std::string actionId;
 	};
 
-	/// Disposition complète de la toolbar : la barre horizontale (hauteur
-	/// fixe `kToolbarHeightPx`, largeur `viewportWidth`) plus la liste des
+	/// Disposition complète de la barre : la bande horizontale (hauteur fixe
+	/// `kToolbarHeightPx`, largeur `viewportWidth`) plus la liste des
 	/// rectangles boutons. Pure data, indépendant d'ImGui — sert à la fois
 	/// au rendu et aux tests d'invariant de couverture viewport.
 	struct ToolbarLayout
@@ -35,18 +38,23 @@ namespace engine::editor::world
 		std::vector<ToolbarButtonRect> buttons;
 	};
 
-	/// Barre d'outils à boutons-icônes (M100.35). Rendue chaque frame en
-	/// haut du viewport 3D, hauteur fixe 48 px, largeur viewport. Ne couvre
-	/// JAMAIS un pixel du viewport 3D (le 3D est dessiné dans le backbuffer
-	/// avant ImGui ; la toolbar est une fenêtre ImGui dans le dockspace, son
-	/// fond est opaque mais elle vit dans la zone réservée au menu bar +
-	/// toolbar et n'empiète pas sur la région 3D).
+	/// Barre d'actions à boutons-icônes (réorganisation UI 2026-07-17 —
+	/// remplace la rangée d'outils M100.35, les outils ayant migré dans la
+	/// palette latérale `ToolPalettePanel`). Rendue chaque frame en haut du
+	/// viewport 3D, hauteur fixe 48 px, largeur viewport. Ne couvre JAMAIS
+	/// un pixel du viewport 3D (invariant M100.35 conservé).
 	///
-	/// Effet de bord à chaque clic sur un bouton : appelle
-	/// `WorldEditorShell::SetActiveTool` avec la valeur enum correspondante.
-	/// Aucune mutation directe du state caméra, frustum cull, render pass
-	/// ou framebuffer (invariant terrain visible — cf. ticket M100.35
-	/// "Contexte critique" §4).
+	/// Contenu : les actions générales du registre du shell —
+	/// Sauvegarder | Annuler / Rétablir | Valider / Exporter — groupées par
+	/// un double espacement. Un id absent du registre (ex. actions session
+	/// non enregistrées en mode shell in-game) n'affiche pas de bouton ;
+	/// une action dont le prédicat `enabled` est faux affiche un bouton
+	/// grisé non cliquable.
+	///
+	/// Effet de bord à chaque clic sur un bouton actif : `execute()` de
+	/// l'action correspondante. Aucune mutation directe du state caméra,
+	/// frustum cull, render pass ou framebuffer (invariant terrain visible —
+	/// cf. ticket M100.35 « Contexte critique » §4).
 	///
 	/// Contraintes thread/timing : `Render` doit être appelée depuis le
 	/// main thread, dans une frame ImGui en cours (`NewFrame` déjà appelée,
@@ -54,28 +62,30 @@ namespace engine::editor::world
 	class EditorToolbar
 	{
 	public:
-		/// Hauteur fixe de la toolbar en pixels (spec : 48 px).
+		/// Hauteur fixe de la barre en pixels (spec : 48 px).
 		static constexpr float kToolbarHeightPx = 48.0f;
 		/// Côté d'une icône utile (32 px) ; le bouton total = 32 + 8 padding
 		/// = 40 px de côté. Espacement horizontal entre boutons : 4 px.
 		static constexpr float kIconSizePx     = 32.0f;
 		static constexpr float kButtonSizePx   = 40.0f;
 		static constexpr float kButtonSpacingPx = 4.0f;
-		/// Padding du contenu de la toolbar : (48 - 40) / 2 = 4 px vertical.
+		/// Espacement supplémentaire entre deux GROUPES d'actions
+		/// (Sauvegarder | Annuler/Rétablir | Valider/Exporter).
+		static constexpr float kGroupSpacingPx = 12.0f;
+		/// Padding du contenu de la barre : (48 - 40) / 2 = 4 px vertical.
 		static constexpr float kToolbarPaddingPx = 4.0f;
 
 		EditorToolbar(WorldEditorShell& shell);
 
-		/// Calcule la disposition de la toolbar pour une largeur viewport
-		/// donnée. Pure : ne touche pas à `m_shell`, ne dépend que de la
-		/// largeur. Utilisée par `Render` ET par les tests d'invariant.
+		/// Calcule la disposition de la barre pour une largeur viewport
+		/// donnée. Pure : ne mute rien ; lit le registre d'actions du shell
+		/// pour omettre les ids non enregistrés. Utilisée par `Render` ET
+		/// par les tests d'invariant.
 		///
 		/// \param viewportWidthPx Largeur de la zone 3D en pixels (en
 		///   pratique : `ImGui::GetIO().DisplaySize.x`).
-		/// \param menuBarHeightPx Hauteur du menu bar ImGui (en pratique :
-		///   `ImGui::GetFrameHeightWithSpacing()` ou la valeur retournée
-		///   par `ImGui::GetCurrentContext()->NextWindowData`).
-		/// \return Layout complet (bouton par outil + bouton X final).
+		/// \param menuBarHeightPx Hauteur du menu bar ImGui.
+		/// \return Layout complet (un bouton par action trouvée au registre).
 		///
 		/// Effet de bord : aucun.
 		ToolbarLayout BuildLayout(float viewportWidthPx,
@@ -91,30 +101,34 @@ namespace engine::editor::world
 		static bool HitTest(const ToolbarLayout& layout,
 			float mouseX, float mouseY, size_t& outButtonIndex);
 
-		/// Active l'outil correspondant au bouton `buttonIndex` du layout
-		/// donné. Wrapper testable autour de `WorldEditorShell::SetActiveTool`.
-		/// No-op si l'index est hors plage.
+		/// Exécute l'action du bouton `buttonIndex` du layout donné si elle
+		/// existe au registre ET que son prédicat `enabled` est vrai.
+		/// Wrapper testable autour de `EditorAction::execute`. No-op si
+		/// l'index est hors plage, l'action absente ou désactivée.
 		///
-		/// Effet de bord : appelle `m_shell.SetActiveTool`.
+		/// Effet de bord : celui de l'action exécutée.
 		void HandleClick(const ToolbarLayout& layout, size_t buttonIndex);
 
 #if defined(_WIN32)
-		/// Rend la toolbar dans la frame ImGui courante (Win32 uniquement).
+		/// Rend la barre dans la frame ImGui courante (Win32 uniquement).
 		/// Crée une fenêtre ImGui auto-positionnée juste sous le menu bar,
-		/// dessine chaque bouton via `ImDrawList::AddRectFilled` + une
-		/// lettre centrale (style placeholder). L'outil actif a un fond
-		/// ambre `IM_COL32(255, 196, 64, 96)`. Tooltip FR après ~600 ms.
+		/// dessine chaque bouton via `ImDrawList` (style placeholder de
+		/// `ToolbarIconAtlas::GetForAction`), grise les actions dont le
+		/// prédicat `enabled` est faux, tooltip « libellé (raccourci) ».
 		///
-		/// Effet de bord : ImGui state + appelle `m_shell.SetActiveTool`
-		/// au clic.
+		/// Effet de bord : ImGui state + exécution d'action au clic.
 		void Render();
 #endif
 
 	private:
 		WorldEditorShell& m_shell;
-		/// Liste figée à la construction des outils exposés dans la
-		/// toolbar, dans l'ordre d'affichage. Le bouton final "X" (None)
-		/// est ajouté à la fin par `BuildLayout` automatiquement.
-		std::vector<ActiveTool> m_orderedTools;
+		/// Ids d'actions affichés, dans l'ordre. Figé à la construction.
+		std::vector<std::string> m_orderedActionIds;
+		/// Indices (dans `m_orderedActionIds`) qui DÉMARRENT un nouveau
+		/// groupe visuel (espacement `kGroupSpacingPx` supplémentaire).
+		std::vector<size_t> m_groupStartIndices;
+
+		/// True si `idx` démarre un nouveau groupe visuel.
+		bool IsGroupStart(size_t idx) const;
 	};
 }

--- a/src/world_editor/ui/ToolPaletteModel.cpp
+++ b/src/world_editor/ui/ToolPaletteModel.cpp
@@ -61,4 +61,28 @@ namespace engine::editor::world
 		}
 		return "?";
 	}
+
+	const char* ToolActionId(ActiveTool tool)
+	{
+		switch (tool)
+		{
+			case ActiveTool::None:               return "";
+			case ActiveTool::TerrainSculpt:      return "tool.terrain-sculpt";
+			case ActiveTool::TerrainStamp:       return "tool.terrain-stamp";
+			case ActiveTool::SplatPaint:         return "tool.splat-paint";
+			case ActiveTool::Lake:               return "tool.lake";
+			case ActiveTool::River:              return "tool.river";
+			case ActiveTool::MountainRange:      return "tool.mountain-range";
+			case ActiveTool::ValleyChain:        return "tool.valley-chain";
+			case ActiveTool::RiverNetwork:       return "tool.river-network";
+			case ActiveTool::Coastline:          return "tool.coastline";
+			case ActiveTool::HydraulicErosion:   return "tool.hydraulic-erosion";
+			case ActiveTool::ThermalWindErosion: return "tool.thermal-wind-erosion";
+			case ActiveTool::Cave:               return "tool.cave";
+			case ActiveTool::Overhang:           return "tool.overhang";
+			case ActiveTool::Arch:               return "tool.arch";
+			case ActiveTool::DungeonPortal:      return "tool.dungeon-portal";
+		}
+		return "";
+	}
 }

--- a/src/world_editor/ui/ToolPaletteModel.cpp
+++ b/src/world_editor/ui/ToolPaletteModel.cpp
@@ -1,0 +1,64 @@
+// ToolPaletteModel — implémentation. Voir ToolPaletteModel.h.
+
+#include "src/world_editor/ui/ToolPaletteModel.h"
+
+namespace engine::editor::world
+{
+	const std::vector<ToolPaletteGroup>& GetToolPaletteGroups()
+	{
+		// Construction unique au premier appel (pas d'état mutable ensuite).
+		// L'ordre des familles et des outils est l'ordre d'affichage de la
+		// palette ; il suit la progression type d'un mappeur (terrain → eau
+		// → macro-génération → structures 3D).
+		static const std::vector<ToolPaletteGroup> kGroups = {
+			{ "Terrain", {
+				ActiveTool::TerrainSculpt,
+				ActiveTool::TerrainStamp,
+				ActiveTool::SplatPaint,
+			} },
+			{ "Eau", {
+				ActiveTool::Lake,
+				ActiveTool::River,
+				ActiveTool::RiverNetwork,
+				ActiveTool::Coastline,
+			} },
+			{ "Macro", {
+				ActiveTool::MountainRange,
+				ActiveTool::ValleyChain,
+				ActiveTool::HydraulicErosion,
+				ActiveTool::ThermalWindErosion,
+			} },
+			{ "Structures", {
+				ActiveTool::Cave,
+				ActiveTool::Overhang,
+				ActiveTool::Arch,
+				ActiveTool::DungeonPortal,
+			} },
+		};
+		return kGroups;
+	}
+
+	const char* ToolLabelFr(ActiveTool tool)
+	{
+		switch (tool)
+		{
+			case ActiveTool::None:               return "Aucun outil";
+			case ActiveTool::TerrainSculpt:      return "Sculpture du terrain";
+			case ActiveTool::TerrainStamp:       return "Tampon de terrain";
+			case ActiveTool::SplatPaint:         return "Peinture de texture (sol)";
+			case ActiveTool::Lake:               return "Lac";
+			case ActiveTool::River:              return "Rivière";
+			case ActiveTool::MountainRange:      return "Chaîne de montagnes";
+			case ActiveTool::ValleyChain:        return "Chaîne de vallées";
+			case ActiveTool::RiverNetwork:       return "Réseau fluvial";
+			case ActiveTool::Coastline:          return "Littoral";
+			case ActiveTool::HydraulicErosion:   return "Érosion hydraulique";
+			case ActiveTool::ThermalWindErosion: return "Érosion thermique/vent";
+			case ActiveTool::Cave:               return "Grotte";
+			case ActiveTool::Overhang:           return "Surplomb";
+			case ActiveTool::Arch:               return "Arche";
+			case ActiveTool::DungeonPortal:      return "Portail de donjon";
+		}
+		return "?";
+	}
+}

--- a/src/world_editor/ui/ToolPaletteModel.h
+++ b/src/world_editor/ui/ToolPaletteModel.h
@@ -1,0 +1,34 @@
+#pragma once
+// ToolPaletteModel — modèle pur (sans ImGui) de la palette d'outils latérale
+// (réorganisation UI 2026-07-17, PR 2). Source unique des familles d'outils
+// et des libellés FR, partagée entre la palette dockée (ToolPalettePanel),
+// le menu « Outils » et la palette de commandes Ctrl+P (PR 3). Testable sous
+// ctest Linux (aucune dépendance shell/ImGui).
+
+#include "src/world_editor/core/ActiveTool.h"
+
+#include <vector>
+
+namespace engine::editor::world
+{
+	/// Groupe d'outils affiché par la palette (en-tête repliable + boutons).
+	struct ToolPaletteGroup
+	{
+		/// Titre FR de la famille (« Terrain », « Eau », « Macro »,
+		/// « Structures ») — mêmes chaînes que les sections du registre
+		/// d'actions (menu Outils) pour rester une source unique.
+		const char* titleFr = "";
+		/// Outils de la famille, dans l'ordre d'affichage.
+		std::vector<ActiveTool> tools;
+	};
+
+	/// Les 4 familles de la palette, couvrant exactement les 15 outils de
+	/// l'enum `ActiveTool` (hors None), ordre d'affichage stable. Construit
+	/// une fois (static locale), sans effet de bord.
+	const std::vector<ToolPaletteGroup>& GetToolPaletteGroups();
+
+	/// Libellé français court d'un outil (« Sculpture du terrain », « Lac »…).
+	/// `None` retourne "Aucun outil" ; une valeur hors enum retourne "?".
+	/// Sans effet de bord ; chaînes statiques (durée de vie programme).
+	const char* ToolLabelFr(ActiveTool tool);
+}

--- a/src/world_editor/ui/ToolPaletteModel.h
+++ b/src/world_editor/ui/ToolPaletteModel.h
@@ -31,4 +31,11 @@ namespace engine::editor::world
 	/// `None` retourne "Aucun outil" ; une valeur hors enum retourne "?".
 	/// Sans effet de bord ; chaînes statiques (durée de vie programme).
 	const char* ToolLabelFr(ActiveTool tool);
+
+	/// Id d'action du registre correspondant à un outil (ex. "tool.lake") —
+	/// mêmes ids que ceux enregistrés par
+	/// `WorldEditorImGui::RegisterEditorActions`. Sert aux surfaces (palette,
+	/// tooltips) pour retrouver raccourci/prédicats au registre. `None` et
+	/// les valeurs hors enum retournent une chaîne vide (pas d'action).
+	const char* ToolActionId(ActiveTool tool);
 }

--- a/src/world_editor/ui/ToolbarIconAtlas.cpp
+++ b/src/world_editor/ui/ToolbarIconAtlas.cpp
@@ -48,4 +48,17 @@ namespace engine::editor::world
 	{
 		return { 0xFFB04040u, "X", "Désélectionner l'outil", true };
 	}
+
+	ToolIconStyle ToolbarIconAtlas::GetForAction(std::string_view actionId)
+	{
+		// Palette distincte de celle des outils : verts/bleus « action »
+		// plutôt que les bruns « terrain ». Lettres = initiale du verbe FR.
+		if (actionId == "file.save")     return { 0xFF2F7D4Fu, "S", "Sauvegarder la carte courante", true };
+		if (actionId == "edit.undo")     return { 0xFF4A6FA5u, "Z", "Annuler",   true };
+		if (actionId == "edit.redo")     return { 0xFF4A8FA5u, "Y", "Rétablir",  true };
+		if (actionId == "zone.validate") return { 0xFF8A7A2Du, "V", "Valider la zone", true };
+		if (actionId == "zone.export")   return { 0xFF7A4A8Au, "E", "Exporter en runtime", true };
+		// Fallback : même convention que les outils non mappés.
+		return { 0xFF606060u, "?", "Bientôt disponible", false };
+	}
 }

--- a/src/world_editor/ui/ToolbarIconAtlas.h
+++ b/src/world_editor/ui/ToolbarIconAtlas.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include "src/world_editor/core/WorldEditorShell.h"
+#include "src/world_editor/core/ActiveTool.h"
 
 #include <cstdint>
+#include <string_view>
 
 namespace engine::editor::world
 {
@@ -43,5 +44,13 @@ namespace engine::editor::world
 		/// Style explicite du bouton de désélection (icône X), retourné en
 		/// fin de toolbar quel que soit l'outil actif.
 		static ToolIconStyle GetDeselect();
+
+		/// Réorganisation UI 2026-07-17 — Style placeholder pour un bouton de
+		/// la barre d'ACTIONS (save/undo/redo/validate/export), identifié par
+		/// l'id d'action du registre (ex. "file.save"). Un id non mappé
+		/// retourne le fallback neutre désactivé « Bientôt disponible ».
+		/// Le tooltip affiché par la barre vient du registre (libellé +
+		/// raccourci) ; le champ `tooltipFr` du style n'est qu'un secours.
+		static ToolIconStyle GetForAction(std::string_view actionId);
 	};
 }

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -945,6 +945,10 @@ namespace engine::editor
 
 					// Palette outils : a gauche, c'est la zone d'action principale.
 					ImGui::DockBuilderDockWindow("Outils", idLeft);
+					// Réorganisation UI 2026-07-17 (PR 2) — la palette
+					// d'outils du shell rejoint le node gauche (onglet à
+					// côté de « Outils »).
+					ImGui::DockBuilderDockWindow("Palette d'outils", idLeft);
 
 					// Inspecteur : panneaux carte / affichage / import / objets / scene sont des onglets a droite.
 					// Scene rejoint cette pile : la docker dans le node central annulait le passthrough et
@@ -1263,7 +1267,8 @@ namespace engine::editor
 			// sliders/options de l'outil actif (Sculpt, Stamp, Splat, Lake,
 			// River, Mountain Range, Valley Chain) y sont rendus
 			// contextuellement.
-			ImGui::TextDisabled("Sélection d'outil : barre d'icônes en haut du viewport.");
+			ImGui::TextDisabled("Sélection d'outil : panneau « Palette d'outils » (à gauche),");
+			ImGui::TextDisabled("menu « Outils », ou raccourcis (Ctrl+Shift+...).");
 			ImGui::TextDisabled("Paramètres : panneau « Tool Properties ».");
 			ImGui::Separator();
 			ImGui::TextWrapped(


### PR DESCRIPTION
## Contexte

PR 2/3 de la reorganisation UI de l'editeur monde (conventions UE). Empilee sur #976 (PR1 : registre d'actions + menus + statut).

## Contenu

- **Enum `ActiveTool` extrait** dans `core/ActiveTool.h` (zero call-site touche) → les modules purs et les tests Linux n'ont plus besoin de tirer tout le shell.
- **`ToolPaletteModel`** (pur, sans ImGui) : 4 familles (Terrain / Eau / Macro / Structures) couvrant exactement les 15 outils, libelles FR (`ToolLabelFr`) et ids d'action (`ToolActionId`) — source unique partagee entre palette, menu Outils et (PR3) palette de commandes.
- **`EditorToolbar` reconvertie en barre d'actions** : `Sauvegarder | Annuler/Retablir | Valider/Exporter` — boutons pilotes par le registre d'actions (grisage par predicat, tooltip « libelle (raccourci) », id absent du registre = bouton omis). Invariant geometrique M100.35 conserve (la barre ne couvre jamais le viewport 3D).
- **`ToolPalettePanel`** : panneau dockable « Palette d'outils » a gauche (style UE Modes) — familles repliables, pastille couleur, outil actif surligne, re-clic = deselection. Ajoute en FIN de `m_panels` (les raccourcis F1..F12 mappent des indices fixes).
- `ToolbarIconAtlas::GetForAction` (icones placeholder des actions).

## Tests

- `tool_palette_model_tests` (**non gate WIN32** → ctest Linux) : couverture exacte des 15 outils, unicite titres/libelles/ids.
- `editor_toolbar_tests` reecrits : invariant geometrique, action absente omise, clic → execute, action grisee = no-op, atlas fallback.

## Deploiement

**Deploiement** : ✅ client/editeur uniquement, pas de redeploiement serveur.

## Ordre de merge

#976 (PR1) → **cette PR** → PR3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)