### PR TITLE
feat(editor): PR3 - palette de commandes Ctrl+P + fenetre Raccourcis clavier

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,6 +343,7 @@ add_library(engine_core
   src/world_editor/actions/EditorActionRegistry.cpp
   src/world_editor/ui/ToolPaletteModel.cpp
   src/world_editor/panels/ToolPalettePanel.cpp
+  src/world_editor/ui/CommandPaletteModel.cpp
   # M101.4 / M101.5 — editeur de routines nodal (panel + commandes + palette/inspecteur).
   src/world_editor/routine/RoutineGraphCommands.cpp
   src/world_editor/routine/RoutineGraphPanel.cpp
@@ -1754,6 +1755,19 @@ else()
   target_compile_options(tool_palette_model_tests PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 add_test(NAME tool_palette_model_tests COMMAND tool_palette_model_tests)
+
+# Réorganisation UI 2026-07-17 (PR 3) — Tests unitaires CPU du filtrage pur
+# de la palette de commandes Ctrl+P : normalisation accents/casse, préfixe
+# de mot > sous-chaîne, match catégorie, stabilité. NON gaté WIN32.
+add_executable(command_palette_model_tests src/world_editor/tests/CommandPaletteModelTests.cpp)
+target_include_directories(command_palette_model_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(command_palette_model_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(command_palette_model_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+else()
+  target_compile_options(command_palette_model_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+add_test(NAME command_palette_model_tests COMMAND command_palette_model_tests)
 
 # M100.36 — Tests unitaires CPU pour le watershed D8 + flow accumulation +
 # Douglas-Peucker + OceanSettings + RiverNetworkCommand + water.bin v1/v2

--- a/src/world_editor/tests/CommandPaletteModelTests.cpp
+++ b/src/world_editor/tests/CommandPaletteModelTests.cpp
@@ -1,0 +1,167 @@
+/// Tests unitaires CPU pour le filtrage de la palette de commandes Ctrl+P
+/// (réorganisation UI 2026-07-17, PR 3).
+///
+/// Pas d'ImGui — la suite tourne sous ctest Linux. On vérifie :
+///   - NormalizeForSearch : minuscules + translittération des accents FR,
+///     idempotence.
+///   - FilterPaletteEntries : requête vide → tout dans l'ordre ; insensible
+///     casse/accents ; préfixe de mot classé avant sous-chaîne ; match sur
+///     la catégorie ; aucun match → vide ; stabilité de l'ordre.
+///
+/// Framework : REQUIRE maison + main monolithique (pattern des autres
+/// suites world_editor).
+
+#include "src/world_editor/ui/CommandPaletteModel.h"
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::editor::world::palette::FilterPaletteEntries;
+	using engine::editor::world::palette::NormalizeForSearch;
+	using engine::editor::world::palette::PaletteEntry;
+
+	PaletteEntry Make(const char* id, const char* label, const char* cat)
+	{
+		PaletteEntry e;
+		e.id = id;
+		e.label = label;
+		e.categoryFr = cat;
+		return e;
+	}
+
+	/// Jeu d'entrées représentatif (libellés réels du registre).
+	std::vector<PaletteEntry> MakeEntries()
+	{
+		return {
+			Make("file.save",        "Sauvegarder la carte courante", "Fichier"),   // 0
+			Make("edit.undo",        "Annuler",                       "Édition"),   // 1
+			Make("edit.redo",        "Rétablir",                      "Édition"),   // 2
+			Make("zone.export",      "Exporter en runtime",           "Fichier"),   // 3
+			Make("tool.river",       "Rivière",                       "Outils"),    // 4
+			Make("tool.hydraulic-erosion", "Érosion hydraulique",     "Outils"),    // 5
+		};
+	}
+
+	/// Test : normalisation — minuscules, accents translittérés, idempotence.
+	void Test_Normalize_LowercaseAndAccents()
+	{
+		REQUIRE(NormalizeForSearch("Sauvegarder") == "sauvegarder");
+		REQUIRE(NormalizeForSearch("Érosion hydraulique") == "erosion hydraulique");
+		REQUIRE(NormalizeForSearch("Rivière") == "riviere");
+		REQUIRE(NormalizeForSearch("Chaîne de vallées") == "chaine de vallees");
+		REQUIRE(NormalizeForSearch("Ça œuvre") == "ca oeuvre");
+		// Idempotence : normaliser un texte déjà normalisé ne change rien.
+		REQUIRE(NormalizeForSearch(NormalizeForSearch("Préférences"))
+			== NormalizeForSearch("Préférences"));
+	}
+
+	/// Test : requête vide (ou espaces) → toutes les entrées, ordre d'origine.
+	void Test_Filter_EmptyQueryReturnsAllInOrder()
+	{
+		const auto entries = MakeEntries();
+		const std::vector<size_t> all = FilterPaletteEntries("", entries);
+		REQUIRE(all.size() == entries.size());
+		for (size_t i = 0; i < all.size(); ++i) { REQUIRE(all[i] == i); }
+
+		const std::vector<size_t> spaces = FilterPaletteEntries("   ", entries);
+		REQUIRE(spaces.size() == entries.size());
+	}
+
+	/// Test : insensible à la casse ET aux accents (requête accentuée ou non).
+	void Test_Filter_CaseAndAccentInsensitive()
+	{
+		const auto entries = MakeEntries();
+		const std::vector<size_t> byPlain = FilterPaletteEntries("erosion", entries);
+		REQUIRE(byPlain.size() == 1u);
+		REQUIRE(byPlain[0] == 5u);
+
+		const std::vector<size_t> byAccent = FilterPaletteEntries("Érosion", entries);
+		REQUIRE(byAccent.size() == 1u);
+		REQUIRE(byAccent[0] == 5u);
+
+		const std::vector<size_t> upper = FilterPaletteEntries("RIVIERE", entries);
+		REQUIRE(upper.size() == 1u);
+		REQUIRE(upper[0] == 4u);
+	}
+
+	/// Test : préfixe de mot classé AVANT sous-chaîne. « re » préfixe
+	/// « Rétablir » et « runtime » (mot de « Exporter en runtime ») mais
+	/// n'est que sous-chaîne de « Sauvegarder ».
+	void Test_Filter_WordPrefixRanksBeforeSubstring()
+	{
+		const auto entries = MakeEntries();
+		const std::vector<size_t> res = FilterPaletteEntries("re", entries);
+		// Préfixes de mot : "Rétablir" (2) et "runtime" dans (3) — ordre
+		// d'origine préservé entre eux. Sous-chaînes ensuite : "Sauvegarder"
+		// (0, "...der la ca..." ne contient pas "re" ? si : "Sauvegarder"
+		// contient "r e" ? — vérifions plutôt par appartenance et rangs.
+		REQUIRE(!res.empty());
+		// (2) et (3) doivent être présents et AVANT (0) s'il matche.
+		size_t rank2 = res.size(), rank3 = res.size(), rank0 = res.size();
+		for (size_t i = 0; i < res.size(); ++i)
+		{
+			if (res[i] == 2u) rank2 = i;
+			if (res[i] == 3u) rank3 = i;
+			if (res[i] == 0u) rank0 = i;
+		}
+		REQUIRE(rank2 < res.size());
+		REQUIRE(rank3 < res.size());
+		REQUIRE(rank2 < rank3); // ordre d'origine entre égaux
+		if (rank0 < res.size())
+		{
+			REQUIRE(rank2 < rank0);
+			REQUIRE(rank3 < rank0);
+		}
+	}
+
+	/// Test : match sur la catégorie (taper « outils » liste les outils).
+	void Test_Filter_MatchesCategory()
+	{
+		const auto entries = MakeEntries();
+		const std::vector<size_t> res = FilterPaletteEntries("outils", entries);
+		REQUIRE(res.size() == 2u);
+		REQUIRE(res[0] == 4u);
+		REQUIRE(res[1] == 5u);
+	}
+
+	/// Test : aucun match → résultat vide (pas de crash, pas de fallback).
+	void Test_Filter_NoMatchReturnsEmpty()
+	{
+		const auto entries = MakeEntries();
+		REQUIRE(FilterPaletteEntries("zzzz_introuvable", entries).empty());
+		// Entrées vides : toujours sûr.
+		const std::vector<PaletteEntry> none;
+		REQUIRE(FilterPaletteEntries("a", none).empty());
+		REQUIRE(FilterPaletteEntries("", none).empty());
+	}
+}
+
+int main()
+{
+	Test_Normalize_LowercaseAndAccents();
+	Test_Filter_EmptyQueryReturnsAllInOrder();
+	Test_Filter_CaseAndAccentInsensitive();
+	Test_Filter_WordPrefixRanksBeforeSubstring();
+	Test_Filter_MatchesCategory();
+	Test_Filter_NoMatchReturnsEmpty();
+
+	if (g_failed > 0)
+	{
+		std::fprintf(stderr, "[CommandPaletteModelTests] %d failure(s)\n", g_failed);
+		return 1;
+	}
+	std::fprintf(stdout, "[CommandPaletteModelTests] all tests passed\n");
+	return 0;
+}

--- a/src/world_editor/tests/CommandPaletteModelTests.cpp
+++ b/src/world_editor/tests/CommandPaletteModelTests.cpp
@@ -96,34 +96,22 @@ namespace
 		REQUIRE(upper[0] == 4u);
 	}
 
-	/// Test : préfixe de mot classé AVANT sous-chaîne. « re » préfixe
-	/// « Rétablir » et « runtime » (mot de « Exporter en runtime ») mais
-	/// n'est que sous-chaîne de « Sauvegarder ».
+	/// Test : préfixe de mot classé AVANT sous-chaîne, requête "r" :
+	///   - préfixes de mot : « Rétablir » (2), « runtime » dans « Exporter
+	///     en runtime » (3), « Rivière » (4) — ordre d'origine préservé ;
+	///   - sous-chaînes seulement : « Sauvegarder… » (0), « Annuler » (1),
+	///     « Érosion hydraulique » (5) — après les préfixes, ordre préservé.
 	void Test_Filter_WordPrefixRanksBeforeSubstring()
 	{
 		const auto entries = MakeEntries();
-		const std::vector<size_t> res = FilterPaletteEntries("re", entries);
-		// Préfixes de mot : "Rétablir" (2) et "runtime" dans (3) — ordre
-		// d'origine préservé entre eux. Sous-chaînes ensuite : "Sauvegarder"
-		// (0, "...der la ca..." ne contient pas "re" ? si : "Sauvegarder"
-		// contient "r e" ? — vérifions plutôt par appartenance et rangs.
-		REQUIRE(!res.empty());
-		// (2) et (3) doivent être présents et AVANT (0) s'il matche.
-		size_t rank2 = res.size(), rank3 = res.size(), rank0 = res.size();
-		for (size_t i = 0; i < res.size(); ++i)
-		{
-			if (res[i] == 2u) rank2 = i;
-			if (res[i] == 3u) rank3 = i;
-			if (res[i] == 0u) rank0 = i;
-		}
-		REQUIRE(rank2 < res.size());
-		REQUIRE(rank3 < res.size());
-		REQUIRE(rank2 < rank3); // ordre d'origine entre égaux
-		if (rank0 < res.size())
-		{
-			REQUIRE(rank2 < rank0);
-			REQUIRE(rank3 < rank0);
-		}
+		const std::vector<size_t> res = FilterPaletteEntries("r", entries);
+		REQUIRE(res.size() == 6u);
+		REQUIRE(res[0] == 2u);
+		REQUIRE(res[1] == 3u);
+		REQUIRE(res[2] == 4u);
+		REQUIRE(res[3] == 0u);
+		REQUIRE(res[4] == 1u);
+		REQUIRE(res[5] == 5u);
 	}
 
 	/// Test : match sur la catégorie (taper « outils » liste les outils).

--- a/src/world_editor/ui/CommandPaletteModel.cpp
+++ b/src/world_editor/ui/CommandPaletteModel.cpp
@@ -1,0 +1,131 @@
+// CommandPaletteModel — implémentation. Voir CommandPaletteModel.h.
+
+#include "src/world_editor/ui/CommandPaletteModel.h"
+
+#include <algorithm>
+#include <cctype>
+
+namespace engine::editor::world::palette
+{
+	namespace
+	{
+		/// Table de translittération UTF-8 → ASCII des accents français
+		/// courants (les libellés d'actions sont en UTF-8). Chaque entrée
+		/// mappe une séquence multi-octets vers son équivalent non accentué.
+		struct AccentMap { const char* utf8; const char* ascii; };
+		constexpr AccentMap kAccents[] = {
+			{ "à", "a" }, { "â", "a" }, { "ä", "a" },
+			{ "é", "e" }, { "è", "e" }, { "ê", "e" }, { "ë", "e" },
+			{ "î", "i" }, { "ï", "i" },
+			{ "ô", "o" }, { "ö", "o" },
+			{ "ù", "u" }, { "û", "u" }, { "ü", "u" },
+			{ "ç", "c" }, { "œ", "oe" },
+			{ "À", "a" }, { "Â", "a" }, { "Ä", "a" },
+			{ "É", "e" }, { "È", "e" }, { "Ê", "e" }, { "Ë", "e" },
+			{ "Î", "i" }, { "Ï", "i" },
+			{ "Ô", "o" }, { "Ö", "o" },
+			{ "Ù", "u" }, { "Û", "u" }, { "Ü", "u" },
+			{ "Ç", "c" }, { "Œ", "oe" },
+		};
+
+		/// Si `text` à la position `pos` commence par une séquence accentuée
+		/// connue, ajoute l'équivalent ASCII à `out` et retourne la longueur
+		/// consommée ; sinon retourne 0.
+		size_t TryTransliterate(std::string_view text, size_t pos, std::string& out)
+		{
+			for (const AccentMap& m : kAccents)
+			{
+				const std::string_view seq{ m.utf8 };
+				if (text.size() - pos >= seq.size()
+					&& text.compare(pos, seq.size(), seq) == 0)
+				{
+					out += m.ascii;
+					return seq.size();
+				}
+			}
+			return 0;
+		}
+
+		/// True si `word` commence à un début de mot de `text` (position 0 ou
+		/// précédée d'un espace/ponctuation). `text` et `word` déjà normalisés.
+		bool MatchesWordPrefix(const std::string& text, const std::string& word)
+		{
+			size_t pos = text.find(word);
+			while (pos != std::string::npos)
+			{
+				if (pos == 0) return true;
+				const char prev = text[pos - 1];
+				if (prev == ' ' || prev == '.' || prev == '(' || prev == '-'
+					|| prev == '/' || prev == '\'')
+				{
+					return true;
+				}
+				pos = text.find(word, pos + 1);
+			}
+			return false;
+		}
+	}
+
+	std::string NormalizeForSearch(std::string_view text)
+	{
+		std::string out;
+		out.reserve(text.size());
+		size_t i = 0;
+		while (i < text.size())
+		{
+			const size_t consumed = TryTransliterate(text, i, out);
+			if (consumed > 0)
+			{
+				i += consumed;
+				continue;
+			}
+			const unsigned char c = static_cast<unsigned char>(text[i]);
+			if (c < 0x80)
+			{
+				out.push_back(static_cast<char>(std::tolower(c)));
+			}
+			else
+			{
+				// Octet UTF-8 hors table : conservé tel quel (comparaison
+				// exacte reste possible pour les caractères non mappés).
+				out.push_back(text[i]);
+			}
+			++i;
+		}
+		return out;
+	}
+
+	std::vector<size_t> FilterPaletteEntries(std::string_view query,
+		const std::vector<PaletteEntry>& entries)
+	{
+		const std::string q = NormalizeForSearch(query);
+		// Requête vide ou espaces : tout, ordre d'origine.
+		const bool emptyQuery =
+			q.find_first_not_of(' ') == std::string::npos;
+
+		std::vector<size_t> prefixMatches;
+		std::vector<size_t> substringMatches;
+		for (size_t i = 0; i < entries.size(); ++i)
+		{
+			if (emptyQuery)
+			{
+				prefixMatches.push_back(i);
+				continue;
+			}
+			const std::string label = NormalizeForSearch(entries[i].label);
+			const std::string category = NormalizeForSearch(entries[i].categoryFr);
+			if (MatchesWordPrefix(label, q))
+			{
+				prefixMatches.push_back(i);
+			}
+			else if (label.find(q) != std::string::npos
+				|| category.find(q) != std::string::npos)
+			{
+				substringMatches.push_back(i);
+			}
+		}
+		prefixMatches.insert(prefixMatches.end(),
+			substringMatches.begin(), substringMatches.end());
+		return prefixMatches;
+	}
+}

--- a/src/world_editor/ui/CommandPaletteModel.h
+++ b/src/world_editor/ui/CommandPaletteModel.h
@@ -1,0 +1,41 @@
+#pragma once
+// CommandPaletteModel — logique pure (sans ImGui) de la palette de commandes
+// Ctrl+P (réorganisation UI 2026-07-17, PR 3). Le filtrage/classement des
+// actions est une fonction pure testable sous ctest Linux ; la fenêtre ImGui
+// (WorldEditorImGui::RenderCommandPalette) ne fait que la consommer.
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace engine::editor::world::palette
+{
+	/// Entrée candidate de la palette : projection texte d'une action du
+	/// registre (id + libellé + catégorie + raccourci déjà résolus).
+	struct PaletteEntry
+	{
+		std::string id;           ///< id d'action ("file.save")
+		std::string label;        ///< libellé FR affiché
+		std::string categoryFr;   ///< catégorie affichée ("Fichier", "Outils"…)
+		std::string shortcutText; ///< raccourci affiché ("" si aucun)
+		bool enabled = true;      ///< prédicat `enabled` évalué au moment du snapshot
+	};
+
+	/// Normalisation pour la recherche : minuscules ASCII + translittération
+	/// des accents français courants (é→e, à→a, ç→c, œ→oe…). Idempotente.
+	/// Sans effet de bord.
+	std::string NormalizeForSearch(std::string_view text);
+
+	/// Filtre et classe les entrées pour une requête utilisateur.
+	/// Insensible à la casse et aux accents. Règles de classement :
+	///   1. préfixe du libellé (ou d'un mot du libellé) → avant
+	///   2. sous-chaîne du libellé ou de la catégorie → après
+	///   3. à rang égal, l'ordre d'origine est préservé (tri stable).
+	/// Une requête vide (ou espaces) retourne TOUTES les entrées dans
+	/// l'ordre d'origine.
+	/// \return indices dans `entries`, ordonnés du meilleur match au moins bon.
+	/// Sans effet de bord.
+	std::vector<size_t> FilterPaletteEntries(std::string_view query,
+		const std::vector<PaletteEntry>& entries);
+}

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -12,6 +12,7 @@
 #include "src/world_editor/prefs/UserPrefsStore.h"
 #include "src/world_editor/actions/EditorActionRegistry.h"
 #include "src/world_editor/ui/ToolbarIconAtlas.h" // libellé FR de l'outil actif (barre de statut)
+#include "src/world_editor/ui/CommandPaletteModel.h" // filtrage pur de la palette Ctrl+P (PR 3)
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/core/WorldEditorShell.h"
@@ -855,10 +856,18 @@ namespace engine::editor
 		// rendues depuis ce registre (spec docs/superpowers/specs/
 		// 2026-07-17-editor-menus-toolbar-reorg-design.md).
 		RegisterEditorActions();
+		// PR 3 — Ctrl+P ouvre la palette de commandes (détection ImGui
+		// directe : pas de plumbing Engine nécessaire).
+		if (ImGui::IsKeyChordPressed(ImGuiMod_Ctrl | ImGuiKey_P))
+		{
+			OpenCommandPalette();
+		}
 		RenderMenuBarFr();
 		RenderQuitConfirmModal();
 		RenderPreferencesWindow();
 		RenderAboutWindow();
+		RenderCommandPalette();
+		RenderShortcutsWindow();
 
 		// M100.46 incrément 3 — dessine la popup modale Zone Presets
 		// (no-op si non ouverte ou Shell non branché). m_cfg passé pour
@@ -2769,6 +2778,16 @@ namespace engine::editor
 			weact::ActionCategory::Edition, nullptr, nullptr,
 			nullptr, nullptr,
 			[this] { m_showPreferencesWindow = true; });
+		// PR 3 — palette de commandes + fenêtre récapitulative des raccourcis.
+		add("app.command-palette", "Palette de commandes...",
+			weact::ActionCategory::Edition, nullptr, "Ctrl+P",
+			nullptr, nullptr,
+			[this] { OpenCommandPalette(); });
+		add("help.shortcuts", "Raccourcis clavier...",
+			weact::ActionCategory::Aide, nullptr, nullptr,
+			nullptr,
+			[this] { return m_showShortcutsWindow; },
+			[this] { m_showShortcutsWindow = !m_showShortcutsWindow; });
 
 		// ---- Vue (options du viewport uniquement) ---------------------------
 		add("view.grid", "Grille (afficher/masquer)",
@@ -2990,7 +3009,9 @@ namespace engine::editor
 			MenuItemForAction("edit.redo");
 			MenuItemForAction("edit.history");
 			ImGui::Separator();
+			MenuItemForAction("app.command-palette");
 			MenuItemForAction("edit.preferences");
+			MenuItemForAction("help.shortcuts");
 			ImGui::EndMenu();
 		}
 
@@ -3057,6 +3078,7 @@ namespace engine::editor
 		if (ImGui::BeginMenu("Aide"))
 		{
 			MenuItemForAction("help.diagnostic");
+			MenuItemForAction("help.shortcuts");
 			ImGui::Separator();
 			MenuItemForAction("help.about");
 			ImGui::EndMenu();
@@ -3217,6 +3239,206 @@ namespace engine::editor
 			ImGui::TextDisabled("Spec UI : docs/superpowers/specs/");
 			ImGui::TextDisabled("2026-07-17-editor-menus-toolbar-reorg-design.md");
 		}
+		ImGui::End();
+	}
+	void WorldEditorImGui::RenderCommandPalette()
+	{
+		if (!m_showCommandPalette) return;
+		namespace weact = engine::editor::world::actions;
+		namespace wpal  = engine::editor::world::palette;
+
+		// Fenêtre centrée horizontalement, ancrée vers le haut (style UE /
+		// VS Code). Taille figée : la liste défile dans un child.
+		const ImGuiViewport* vp = ImGui::GetMainViewport();
+		ImGui::SetNextWindowPos(
+			ImVec2(vp->WorkPos.x + vp->WorkSize.x * 0.5f, vp->WorkPos.y + 72.0f),
+			ImGuiCond_Always, ImVec2(0.5f, 0.0f));
+		ImGui::SetNextWindowSize(ImVec2(560.0f, 380.0f), ImGuiCond_Always);
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse
+			| ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoDocking
+			| ImGuiWindowFlags_NoSavedSettings;
+		if (!ImGui::Begin("Palette de commandes", &m_showCommandPalette, flags))
+		{
+			ImGui::End();
+			return;
+		}
+
+		// Champ de recherche avec focus automatique à l'ouverture.
+		if (m_paletteFocusQuery)
+		{
+			ImGui::SetKeyboardFocusHere();
+			m_paletteFocusQuery = false;
+		}
+		ImGui::SetNextItemWidth(-1.0f);
+		const bool enterPressed = ImGui::InputTextWithHint("##palette_query",
+			"Commencez à taper pour rechercher une action...",
+			m_paletteQuery, sizeof(m_paletteQuery),
+			ImGuiInputTextFlags_EnterReturnsTrue);
+
+		// Snapshot des actions du registre → entrées texte de la palette.
+		std::vector<wpal::PaletteEntry> entries;
+		if (m_shell != nullptr)
+		{
+			static constexpr const char* kCategoryFr[] =
+				{ "Fichier", "Édition", "Vue", "Fenêtre", "Outils", "Aide" };
+			const auto& actionsVec = m_shell->GetActionRegistry().Actions();
+			entries.reserve(actionsVec.size());
+			for (const weact::EditorAction& a : actionsVec)
+			{
+				wpal::PaletteEntry e;
+				e.id = a.id;
+				e.label = a.label;
+				const size_t catIdx = static_cast<size_t>(a.category);
+				e.categoryFr = (catIdx < 6u) ? kCategoryFr[catIdx] : "";
+				e.shortcutText = a.shortcutText;
+				e.enabled = weact::EditorActionRegistry::IsEnabled(a);
+				entries.push_back(std::move(e));
+			}
+		}
+		const std::vector<size_t> order =
+			wpal::FilterPaletteEntries(m_paletteQuery, entries);
+
+		// Navigation clavier ↑/↓ dans la liste filtrée.
+		if (ImGui::IsKeyPressed(ImGuiKey_DownArrow)) { ++m_paletteSelected; }
+		if (ImGui::IsKeyPressed(ImGuiKey_UpArrow))   { --m_paletteSelected; }
+		if (order.empty())
+		{
+			m_paletteSelected = 0;
+		}
+		else
+		{
+			m_paletteSelected = std::clamp(m_paletteSelected, 0,
+				static_cast<int>(order.size()) - 1);
+		}
+
+		// Liste filtrée : libellé à gauche, catégorie + raccourci grisés à
+		// droite. Les actions désactivées sont affichées grisées et ne sont
+		// pas exécutables.
+		const weact::EditorAction* toExecute = nullptr;
+		ImGui::BeginChild("##palette_list", ImVec2(0.0f, 0.0f), ImGuiChildFlags_None);
+		for (size_t rank = 0; rank < order.size(); ++rank)
+		{
+			const wpal::PaletteEntry& e = entries[order[rank]];
+			const bool selected = (static_cast<int>(rank) == m_paletteSelected);
+
+			ImGui::PushID(static_cast<int>(rank));
+			if (!e.enabled) { ImGui::BeginDisabled(); }
+			if (ImGui::Selectable(e.label.c_str(), selected))
+			{
+				m_paletteSelected = static_cast<int>(rank);
+				if (e.enabled && m_shell != nullptr)
+				{
+					toExecute = m_shell->GetActionRegistry().Find(e.id);
+				}
+			}
+			if (!e.enabled) { ImGui::EndDisabled(); }
+
+			// Colonne droite : catégorie + raccourci.
+			std::string right = e.categoryFr;
+			if (!e.shortcutText.empty())
+			{
+				right += "  ";
+				right += e.shortcutText;
+			}
+			if (!right.empty())
+			{
+				ImGui::SameLine();
+				const float w = ImGui::CalcTextSize(right.c_str()).x;
+				const float avail = ImGui::GetContentRegionAvail().x;
+				if (avail > w + 8.0f)
+				{
+					ImGui::SameLine(0.0f, avail - w - 4.0f);
+				}
+				ImGui::TextDisabled("%s", right.c_str());
+			}
+			if (selected && (ImGui::IsKeyPressed(ImGuiKey_DownArrow)
+				|| ImGui::IsKeyPressed(ImGuiKey_UpArrow)))
+			{
+				ImGui::SetScrollHereY();
+			}
+			ImGui::PopID();
+		}
+		ImGui::EndChild();
+
+		// Entrée = exécute la sélection courante de la liste filtrée.
+		if (enterPressed && !order.empty() && m_shell != nullptr)
+		{
+			const wpal::PaletteEntry& e =
+				entries[order[static_cast<size_t>(m_paletteSelected)]];
+			if (e.enabled)
+			{
+				toExecute = m_shell->GetActionRegistry().Find(e.id);
+			}
+		}
+		if (toExecute != nullptr)
+		{
+			m_showCommandPalette = false;
+			if (toExecute->execute) { toExecute->execute(); }
+		}
+		if (ImGui::IsKeyPressed(ImGuiKey_Escape))
+		{
+			m_showCommandPalette = false;
+		}
+		ImGui::End();
+	}
+
+	void WorldEditorImGui::RenderShortcutsWindow()
+	{
+		if (!m_showShortcutsWindow) return;
+		namespace weact = engine::editor::world::actions;
+
+		ImGui::SetNextWindowSize(ImVec2(520.0f, 460.0f), ImGuiCond_FirstUseEver);
+		if (!ImGui::Begin("Raccourcis clavier", &m_showShortcutsWindow))
+		{
+			ImGui::End();
+			return;
+		}
+
+		// Section 1 — raccourcis d'actions, générés depuis le registre :
+		// ajouter une action avec `shortcutText` la fait apparaître ici sans
+		// maintenance manuelle.
+		if (m_shell != nullptr)
+		{
+			static constexpr const char* kCategoryFr[] =
+				{ "Fichier", "Édition", "Vue", "Fenêtre", "Outils", "Aide" };
+			for (size_t cat = 0; cat < 6u; ++cat)
+			{
+				bool headerShown = false;
+				for (const weact::EditorAction& a : m_shell->GetActionRegistry().Actions())
+				{
+					if (static_cast<size_t>(a.category) != cat) continue;
+					if (a.shortcutText.empty()) continue;
+					if (!headerShown)
+					{
+						ImGui::SeparatorText(kCategoryFr[cat]);
+						headerShown = true;
+					}
+					ImGui::TextUnformatted(a.label.c_str());
+					ImGui::SameLine(320.0f);
+					ImGui::TextDisabled("%s", a.shortcutText.c_str());
+				}
+			}
+		}
+
+		// Section 2 — raccourcis hors registre (dispatchés par Engine /
+		// WorldEditorShell::HandleShortcut) : documentés statiquement ici.
+		struct StaticShortcut { const char* label; const char* keys; };
+		static constexpr StaticShortcut kStaticShortcuts[] = {
+			{ "Déplacement caméra",              "WASD / ZQSD (cf. Préférences)" },
+			{ "Course (caméra plus rapide)",     "Shift" },
+			{ "Mode caméra FPS / Orbital / Top", "Pavé num. 1 / 3 / 7" },
+			{ "Panneaux du shell",               "F1..F12" },
+			{ "Annuler / Rétablir",              "Ctrl+Z / Ctrl+Y" },
+			{ "Palette de commandes",            "Ctrl+P" },
+		};
+		ImGui::SeparatorText("Caméra & navigation");
+		for (const StaticShortcut& s : kStaticShortcuts)
+		{
+			ImGui::TextUnformatted(s.label);
+			ImGui::SameLine(320.0f);
+			ImGui::TextDisabled("%s", s.keys);
+		}
+
 		ImGui::End();
 	}
 #endif // _WIN32

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -326,6 +326,42 @@ namespace engine::editor
 		/// branché → « Quitter » grisé.
 		std::function<void()> m_onQuitRequested;
 
+		// ── Réorganisation UI 2026-07-17 (PR 3) : palette Ctrl+P + raccourcis ──
+		/// Visibilité de la palette de commandes (Ctrl+P ou menu Édition).
+		bool m_showCommandPalette = false;
+		/// Buffer de la requête de recherche de la palette (ImGui::InputText).
+		char m_paletteQuery[128] = {};
+		/// Index sélectionné dans la liste FILTRÉE de la palette (↑/↓/Entrée).
+		int m_paletteSelected = 0;
+		/// Posé à l'ouverture : donne le focus clavier au champ de recherche
+		/// à la frame suivante, puis consommé.
+		bool m_paletteFocusQuery = false;
+		/// Visibilité de la fenêtre « Raccourcis clavier » (lecture seule).
+		bool m_showShortcutsWindow = false;
+
+		/// Ouvre la palette de commandes : réinitialise requête + sélection
+		/// et arme le focus clavier sur le champ de recherche.
+		void OpenCommandPalette()
+		{
+			m_showCommandPalette = true;
+			m_paletteFocusQuery = true;
+			m_paletteSelected = 0;
+			m_paletteQuery[0] = '\0';
+		}
+
+		/// Rend la palette de commandes si visible : champ de recherche
+		/// (filtrage incrémental via `FilterPaletteEntries` sur le registre
+		/// d'actions), navigation ↑/↓, `Entrée` exécute l'action sélectionnée
+		/// (si son prédicat `enabled` est vrai), `Échap` ferme.
+		/// Effet de bord : ImGui state + exécution d'action.
+		void RenderCommandPalette();
+
+		/// Rend la fenêtre « Raccourcis clavier » si visible : tableau généré
+		/// depuis le registre (actions à raccourci non vide, groupées par
+		/// catégorie) + table statique des raccourcis hors registre (caméra
+		/// WASD/ZQSD, Numpad, F1..F12, Ctrl+P). Lecture seule.
+		void RenderShortcutsWindow();
+
 		/// Réorganisation UI 2026-07-17 — Enregistre dans le registre du shell
 		/// toutes les actions qui dépendent de la session/config/UI ImGui
 		/// (fichier, import/export, vue, fenêtre, outils, aide). Idempotent


### PR DESCRIPTION
## Contexte

PR 3/3 de la reorganisation UI de l'editeur monde (conventions UE). Empilee sur #977 (PR2), elle-meme sur #976 (PR1).

## Contenu

- **Palette de commandes `Ctrl+P`** (equivalent du « Commencez a taper pour rechercher » d'UE, centralise en un seul endroit) : fenetre centree, filtrage incremental insensible casse/accents sur toutes les actions du registre (libelle + categorie), classement prefixe-de-mot > sous-chaine, navigation ↑/↓, `Entree` execute, `Echap` ferme, actions grisees non executables. Aussi accessible par Edition > Palette de commandes.
- **Fenetre « Raccourcis clavier »** (lecture seule, decision validee en cadrage) : tableau GENERE depuis le registre (toute action avec un raccourci y apparait sans maintenance) groupe par categorie + table statique des raccourcis hors registre (camera WASD/ZQSD, pave num. 1/3/7, F1..F12, Ctrl+Z/Y, Ctrl+P). Accessible par Edition et Aide.
- Filtrage = fonction pure (`CommandPaletteModel`) : `NormalizeForSearch` (translitteration accents FR) + `FilterPaletteEntries`.

## Tests

- `command_palette_model_tests` (**non gate WIN32** → ctest Linux) : normalisation accents/casse + idempotence, requete vide = tout, insensibilite, prefixe > sous-chaine, match categorie, aucun match = vide.

## Deploiement

**Deploiement** : ✅ client/editeur uniquement, pas de redeploiement serveur.

## Ordre de merge

#976 (PR1) → #977 (PR2) → **cette PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)