### PR TITLE
feat(editor): polish visuel - disposition unifiee, theme sombre, icones, accueil

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,7 @@ add_library(engine_core
   src/world_editor/ui/ToolPaletteModel.cpp
   src/world_editor/panels/ToolPalettePanel.cpp
   src/world_editor/ui/CommandPaletteModel.cpp
+  src/world_editor/ui/EditorTheme.cpp
   # M101.4 / M101.5 — editeur de routines nodal (panel + commandes + palette/inspecteur).
   src/world_editor/routine/RoutineGraphCommands.cpp
   src/world_editor/routine/RoutineGraphPanel.cpp

--- a/docs/superpowers/specs/2026-07-17-editor-ui-polish-design.md
+++ b/docs/superpowers/specs/2026-07-17-editor-ui-polish-design.md
@@ -1,0 +1,63 @@
+# Polish visuel de l'éditeur monde — design
+
+Date : 2026-07-17 (suite immédiate de la réorganisation UI #976/#977/#979)
+Statut : validé en séance (retour utilisateur sur le build final : « très loin
+de l'interface d'UE » — capture montrant fenêtres flottantes superposées,
+thème ImGui par défaut, lettres placeholder).
+Périmètre : 100 % binaire éditeur — aucun redéploiement serveur.
+Boussole : **simple au premier regard, complet via les menus**.
+
+## Problèmes constatés sur le build mergé
+
+1. L'ancien `world_editor_imgui.ini` de l'utilisateur a été rechargé : les
+   nouvelles fenêtres (Palette d'outils) flottent au centre au lieu d'être
+   dockées — la disposition par défaut n'est posée qu'en l'absence d'ini.
+2. Trop de panneaux ouverts par défaut (Quest Editor, Routines…) qui se
+   chevauchent en flottant.
+3. Deux systèmes de disposition superposés : le dockspace du shell
+   (`editor_world_layout.ini`, panneaux M100.x) ET le dockspace V2 de
+   WorldEditorImGui (`world_editor_imgui.ini`, fenêtres session M43.x).
+4. Thème ImGui par défaut (gris-bleu) et lettres S/Z/Y/V/E en guise
+   d'icônes.
+5. État « aucune carte » : viewport gris vide sans guidage.
+
+## Décisions
+
+1. **Disposition versionnée et unifiée** : clé `editorLayoutVersion` dans
+   `user_prefs.json` ; si différente de `kEditorLayoutVersion` (constante
+   code, bump à chaque évolution de disposition), la disposition est
+   reconstruite automatiquement (suppression des DEUX ini + re-pose). La
+   disposition par défaut V2 docke AUSSI les panneaux du shell (par nom de
+   fenêtre) : gauche = Palette d'outils (+ Outils), droite = Carte /
+   Affichage / Atmosphère / Import / Objets / Outliner / Inspector / Tool
+   Properties en onglets, bas = Statut. Les panneaux avancés (Asset Browser,
+   Console, History, Surface Table, Collision Editor, Building Editor,
+   Quest Editor, Routines) sont **masqués par défaut** (ré-ouvrables via le
+   menu Fenêtre) et pré-dockés pour apparaître au bon endroit.
+2. **Thème sombre type UE** (`EditorTheme.cpp`, appliqué uniquement quand
+   `isWorldEditorExe`) : palette anthracite, accent doré (identité LCDLLN),
+   arrondis 4-6 px, paddings généreux, onglets/en-têtes contrastés.
+3. **Icônes vectorielles** pour la barre d'actions (disquette, flèches
+   undo/redo, coche, export) dessinées via ImDrawList — pas d'assets PNG à
+   pipeliner ; les lettres restent le fallback des ids inconnus.
+4. **Écran d'accueil** : tant qu'aucune carte n'est chargée (heightmap du
+   document vide), fenêtre centrée « Bienvenue » : bouton « Nouvelle zone
+   (assistant)… », liste des cartes récentes cliquables, renvoi vers le
+   panneau Carte ; fermable, disparaît dès qu'une carte est chargée.
+
+## Hors périmètre
+
+- Icônes des 15 outils de la palette (pastilles couleur conservées).
+- Refonte des panneaux de contenu (Carte, Tool Properties…).
+- Toute évolution du rendu 3D.
+
+## Tests
+
+- `editor_modes_tests` : round-trip `editorLayoutVersion` (défaut 0).
+- Le reste est du rendu ImGui (non testable unitairement dans ce repo) —
+  validation visuelle utilisateur.
+
+## Livraison
+
+1 PR unique (`claude/editor-ui-polish` → main) — les 4 volets sont cohérents
+et co-dépendants visuellement. **Déploiement** : ✅ client/éditeur uniquement.

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -341,6 +341,32 @@ namespace engine::editor::world
 			static_cast<panels::ToolPropertiesPanel*>(m_panels[5].get())->SetShell(this);
 		}
 
+		// Polish UI 2026-07-17 — visibilité par défaut « simple au premier
+		// regard » : seuls les panneaux du flux principal (Palette d'outils,
+		// Outliner, Inspector, Tool Properties) démarrent visibles. Les
+		// panneaux avancés restent accessibles via le menu Fenêtre (toggles
+		// du registre d'actions) et sont pré-dockés par la disposition par
+		// défaut pour apparaître au bon endroit à l'ouverture.
+		{
+			static constexpr const char* kHiddenByDefault[] = {
+				"Asset Browser", "Console", "History", "Surface Table",
+				"Collision Editor", "Building Editor", "Quest Editor",
+				"Routines",
+			};
+			for (auto& panel : m_panels)
+			{
+				if (!panel) continue;
+				for (const char* hidden : kHiddenByDefault)
+				{
+					if (std::strcmp(panel->GetName(), hidden) == 0)
+					{
+						panel->SetVisible(false);
+						break;
+					}
+				}
+			}
+		}
+
 		// Réorganisation UI 2026-07-17 — actions autonomes du shell (undo/
 		// redo, historique, toggles panneaux). Les actions dépendant de la
 		// session (save/load/export…) sont ajoutées par

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -134,6 +134,18 @@ namespace engine::editor::world
 		const std::vector<std::unique_ptr<IPanel>>& Panels() const { return m_panels; }
 		std::vector<std::unique_ptr<IPanel>>&       MutablePanels()     { return m_panels; }
 
+		/// Polish UI 2026-07-17 — Annule la lecture différée du layout dock du
+		/// shell (`editor_world_layout.ini`, chargée normalement au 1er
+		/// RenderFrame). Appelée par `WorldEditorImGui::ResetDockLayout` lors
+		/// d'une reconstruction de disposition (bump de version) : l'ancien
+		/// ini ne doit pas réappliquer les positions périmées par-dessus la
+		/// disposition unifiée fraîchement posée.
+		void DiscardPendingLayoutLoad() { m_pendingLayoutLoad = false; }
+
+		/// Chemin du fichier de layout dock du shell (lecture seule) — permet
+		/// à la reconstruction de disposition de supprimer aussi ce fichier.
+		const std::string& LayoutPath() const { return m_layoutPath; }
+
 		/// Quand l'éditeur monde tourne dans le binaire `lcdlln_world_editor.exe`,
 		/// la barre de menu M43.x (`WorldEditorImGui::BuildUi`) prend la main
 		/// avec un menu français complet (incluant Zone Presets M100.46).

--- a/src/world_editor/prefs/UserPrefs.h
+++ b/src/world_editor/prefs/UserPrefs.h
@@ -29,6 +29,13 @@ namespace engine::editor::world::prefs
 		/// `UserPrefsStore::kMaxRecentMaps`. Alimente le sous-menu
 		/// « Fichier > Cartes récentes ».
 		std::vector<std::string>                     recentMapIds;
+		/// Polish UI 2026-07-17 — version de la disposition de fenêtres que
+		/// cet utilisateur a déjà vue. Si différente de la constante
+		/// `kEditorLayoutVersion` du code (bumpée à chaque évolution de la
+		/// disposition par défaut), l'éditeur reconstruit automatiquement la
+		/// disposition (suppression des .ini + re-pose) au boot. 0 = jamais
+		/// posée (anciens profils).
+		int                                          editorLayoutVersion = 0;
 	};
 
 	/// Version de schéma courante écrite dans le champ `version`.

--- a/src/world_editor/prefs/UserPrefsStore.cpp
+++ b/src/world_editor/prefs/UserPrefsStore.cpp
@@ -234,6 +234,11 @@ namespace engine::editor::world::prefs
 				parsed.recentMapIds.resize(kMaxRecentMaps);
 			}
 		}
+		if (SeekKey(json, "editorLayoutVersion", pos))
+		{
+			try { parsed.editorLayoutVersion = std::stoi(json.substr(pos, 16)); }
+			catch (...) { parsed.editorLayoutVersion = 0; }
+		}
 
 		m_prefs = std::move(parsed);
 	}
@@ -287,8 +292,9 @@ namespace engine::editor::world::prefs
 				out << "    \"" << EscapeJson(id) << "\"";
 				first = false;
 			}
-			out << (first ? "]" : "\n  ]") << "\n";
+			out << (first ? "]" : "\n  ]") << ",\n";
 		}
+		out << "  \"editorLayoutVersion\": " << m_prefs.editorLayoutVersion << "\n";
 		out << "}\n";
 
 		// Sauvegarde atomique : .tmp puis rename.
@@ -372,6 +378,13 @@ namespace engine::editor::world::prefs
 		{
 			recents.resize(kMaxRecentMaps);
 		}
+		(void)SaveToDisk();
+	}
+
+	void UserPrefsStore::SetLayoutVersion(int version)
+	{
+		if (m_prefs.editorLayoutVersion == version) return;
+		m_prefs.editorLayoutVersion = version;
 		(void)SaveToDisk();
 	}
 

--- a/src/world_editor/prefs/UserPrefsStore.h
+++ b/src/world_editor/prefs/UserPrefsStore.h
@@ -57,6 +57,11 @@ namespace engine::editor::world::prefs
 		/// Cartes récentes, plus récente en tête.
 		const std::vector<std::string>& GetRecentMaps() const { return m_prefs.recentMapIds; }
 
+		/// Polish UI 2026-07-17 — version de disposition vue par l'utilisateur
+		/// (cf. `UserPrefs::editorLayoutVersion`). Persistance immédiate au Set.
+		int  GetLayoutVersion() const { return m_prefs.editorLayoutVersion; }
+		void SetLayoutVersion(int version);
+
 		bool IsInitialized() const { return m_initialized; }
 
 		/// Réinitialise l'état (défauts, non initialisé). Réservé aux tests.

--- a/src/world_editor/tests/EditorModesTests.cpp
+++ b/src/world_editor/tests/EditorModesTests.cpp
@@ -363,6 +363,27 @@ namespace
 		store.ResetForTesting();
 	}
 
+	/// Polish UI 2026-07-17 — round-trip disque de la version de disposition
+	/// (défaut 0 pour les anciens profils, persistance immédiate au Set).
+	void Test_UserPrefs_LayoutVersion_RoundTrip()
+	{
+		const auto root = MakeTempContentRoot("prefs_layoutver");
+		auto& store = prefs::UserPrefsStore::Instance();
+		store.ResetForTesting();
+		store.Init(root.string());
+		REQUIRE(store.GetLayoutVersion() == 0); // défaut ancien profil
+
+		store.SetLayoutVersion(2);
+		store.ResetForTesting();
+		const bool existed = store.Init(root.string());
+		REQUIRE(existed);
+		REQUIRE(store.GetLayoutVersion() == 2);
+
+		std::error_code ec;
+		std::filesystem::remove_all(root, ec);
+		store.ResetForTesting();
+	}
+
 	void Test_UserPrefs_TolerantToMalformedFile()
 	{
 		const auto root = MakeTempContentRoot("prefs_bad");
@@ -398,6 +419,7 @@ int main()
 	Test_UserPrefs_AtomicSaveLeavesNoTmp();
 	Test_UserPrefs_RecentMaps_DedupAndCap();
 	Test_UserPrefs_RecentMaps_RoundTripPersist();
+	Test_UserPrefs_LayoutVersion_RoundTrip();
 	Test_UserPrefs_TolerantToMalformedFile();
 
 	if (g_failed > 0)

--- a/src/world_editor/ui/EditorTheme.cpp
+++ b/src/world_editor/ui/EditorTheme.cpp
@@ -1,0 +1,125 @@
+// EditorTheme — implémentation. Voir EditorTheme.h.
+
+#include "src/world_editor/ui/EditorTheme.h"
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::editor::world
+{
+#if defined(_WIN32)
+	namespace
+	{
+		/// Convertit une couleur 0xRRGGBB + alpha [0..1] en ImVec4.
+		ImVec4 Rgb(unsigned int rgb, float a = 1.0f)
+		{
+			return ImVec4(
+				static_cast<float>((rgb >> 16) & 0xFF) / 255.0f,
+				static_cast<float>((rgb >> 8) & 0xFF) / 255.0f,
+				static_cast<float>(rgb & 0xFF) / 255.0f,
+				a);
+		}
+	}
+
+	void ApplyWorldEditorTheme()
+	{
+		ImGuiStyle& style = ImGui::GetStyle();
+
+		// ── Métriques : arrondis discrets, paddings généreux (lisibilité). ──
+		style.WindowRounding    = 6.0f;
+		style.ChildRounding     = 4.0f;
+		style.FrameRounding     = 4.0f;
+		style.PopupRounding     = 4.0f;
+		style.GrabRounding      = 4.0f;
+		style.TabRounding       = 4.0f;
+		style.ScrollbarRounding = 8.0f;
+		style.WindowPadding     = ImVec2(10.0f, 10.0f);
+		style.FramePadding      = ImVec2(9.0f, 5.0f);
+		style.CellPadding       = ImVec2(6.0f, 4.0f);
+		style.ItemSpacing       = ImVec2(8.0f, 6.0f);
+		style.ItemInnerSpacing  = ImVec2(6.0f, 4.0f);
+		style.IndentSpacing     = 20.0f;
+		style.ScrollbarSize     = 13.0f;
+		style.GrabMinSize       = 12.0f;
+		style.WindowBorderSize  = 1.0f;
+		style.ChildBorderSize   = 1.0f;
+		style.PopupBorderSize   = 1.0f;
+		style.FrameBorderSize   = 0.0f;
+		style.TabBarBorderSize  = 1.0f;
+		style.WindowTitleAlign  = ImVec2(0.0f, 0.5f);
+		style.SeparatorTextBorderSize = 2.0f;
+		style.DockingSeparatorSize    = 2.0f;
+
+		// ── Palette : anthracite + accent doré (identité LCDLLN). ──────────
+		const ImVec4 kBgDeep    = Rgb(0x131417);        // fonds les plus sombres
+		const ImVec4 kBgWindow  = Rgb(0x1b1d21);        // fond de fenêtre
+		const ImVec4 kBgPanel   = Rgb(0x22242a);        // frames / champs
+		const ImVec4 kBgHover   = Rgb(0x2d3038);
+		const ImVec4 kBgActive  = Rgb(0x3a3e48);
+		const ImVec4 kAccent    = Rgb(0xd9a133);        // doré LCDLLN
+		const ImVec4 kAccentDim = Rgb(0x8a6a2a);
+		const ImVec4 kText      = Rgb(0xe8e6e2);
+		const ImVec4 kTextDim   = Rgb(0x8d929b);
+
+		ImVec4* c = style.Colors;
+		c[ImGuiCol_Text]                 = kText;
+		c[ImGuiCol_TextDisabled]         = kTextDim;
+		c[ImGuiCol_WindowBg]             = kBgWindow;
+		c[ImGuiCol_ChildBg]              = ImVec4(0, 0, 0, 0);
+		c[ImGuiCol_PopupBg]              = Rgb(0x1b1d21, 0.98f);
+		c[ImGuiCol_Border]               = Rgb(0x000000, 0.55f);
+		c[ImGuiCol_BorderShadow]         = ImVec4(0, 0, 0, 0);
+		c[ImGuiCol_FrameBg]              = kBgPanel;
+		c[ImGuiCol_FrameBgHovered]       = kBgHover;
+		c[ImGuiCol_FrameBgActive]        = kBgActive;
+		c[ImGuiCol_TitleBg]              = kBgDeep;
+		c[ImGuiCol_TitleBgActive]        = Rgb(0x212329);
+		c[ImGuiCol_TitleBgCollapsed]     = Rgb(0x131417, 0.85f);
+		c[ImGuiCol_MenuBarBg]            = Rgb(0x1f2126);
+		c[ImGuiCol_ScrollbarBg]          = Rgb(0x131417, 0.6f);
+		c[ImGuiCol_ScrollbarGrab]        = Rgb(0x3a3e48);
+		c[ImGuiCol_ScrollbarGrabHovered] = Rgb(0x4a4f5a);
+		c[ImGuiCol_ScrollbarGrabActive]  = kAccentDim;
+		c[ImGuiCol_CheckMark]            = kAccent;
+		c[ImGuiCol_SliderGrab]           = Rgb(0xb8892e);
+		c[ImGuiCol_SliderGrabActive]     = kAccent;
+		c[ImGuiCol_Button]               = Rgb(0x2a2d34);
+		c[ImGuiCol_ButtonHovered]        = Rgb(0x383c45);
+		c[ImGuiCol_ButtonActive]         = Rgb(0x4a4f5a);
+		c[ImGuiCol_Header]               = Rgb(0x2d3038);
+		c[ImGuiCol_HeaderHovered]        = Rgb(0x3a3e48);
+		c[ImGuiCol_HeaderActive]         = Rgb(0x454a55);
+		c[ImGuiCol_Separator]            = Rgb(0x33363e);
+		c[ImGuiCol_SeparatorHovered]     = kAccentDim;
+		c[ImGuiCol_SeparatorActive]      = kAccent;
+		c[ImGuiCol_ResizeGrip]           = Rgb(0x33363e, 0.6f);
+		c[ImGuiCol_ResizeGripHovered]    = kAccentDim;
+		c[ImGuiCol_ResizeGripActive]     = kAccent;
+		c[ImGuiCol_Tab]                  = Rgb(0x1b1d21);
+		c[ImGuiCol_TabHovered]           = Rgb(0x3a3e48);
+		c[ImGuiCol_TabSelected]          = Rgb(0x2d3038);
+		c[ImGuiCol_TabSelectedOverline]  = kAccent;
+		c[ImGuiCol_TabDimmed]            = Rgb(0x17181c);
+		c[ImGuiCol_TabDimmedSelected]    = Rgb(0x22242a);
+		c[ImGuiCol_TabDimmedSelectedOverline] = kAccentDim;
+		c[ImGuiCol_DockingPreview]       = Rgb(0xd9a133, 0.35f);
+		c[ImGuiCol_DockingEmptyBg]       = ImVec4(0, 0, 0, 0); // passthrough 3D
+		c[ImGuiCol_PlotLines]            = kAccent;
+		c[ImGuiCol_PlotHistogram]        = kAccent;
+		c[ImGuiCol_TableHeaderBg]        = Rgb(0x22242a);
+		c[ImGuiCol_TableBorderStrong]    = Rgb(0x33363e);
+		c[ImGuiCol_TableBorderLight]     = Rgb(0x282b31);
+		c[ImGuiCol_TableRowBg]           = ImVec4(0, 0, 0, 0);
+		c[ImGuiCol_TableRowBgAlt]        = Rgb(0xffffff, 0.03f);
+		c[ImGuiCol_TextSelectedBg]       = Rgb(0xd9a133, 0.30f);
+		c[ImGuiCol_DragDropTarget]       = kAccent;
+		c[ImGuiCol_NavCursor]            = kAccent;
+		c[ImGuiCol_NavWindowingHighlight] = Rgb(0xffffff, 0.6f);
+		c[ImGuiCol_NavWindowingDimBg]    = Rgb(0x000000, 0.5f);
+		c[ImGuiCol_ModalWindowDimBg]     = Rgb(0x000000, 0.55f);
+	}
+#else
+	void ApplyWorldEditorTheme() {}
+#endif
+}

--- a/src/world_editor/ui/EditorTheme.h
+++ b/src/world_editor/ui/EditorTheme.h
@@ -1,0 +1,16 @@
+#pragma once
+// EditorTheme — thème visuel sombre du binaire éditeur monde (polish UI
+// 2026-07-17, inspiré des conventions Unreal Engine : fonds anthracite,
+// contrastes nets, accent doré identité LCDLLN, arrondis discrets,
+// espacements généreux). Appliqué UNIQUEMENT quand `isWorldEditorExe`
+// (le client de jeu garde le style ImGui de ses UIs propres).
+
+namespace engine::editor::world
+{
+	/// Applique le thème sombre de l'éditeur monde au style ImGui global.
+	/// Doit être appelée APRÈS `ImGui::CreateContext` (le style vit dans le
+	/// contexte) et avant le premier rendu. Main thread. Idempotente.
+	/// Effet de bord : écrase `ImGui::GetStyle()` (couleurs + métriques).
+	/// No-op hors Windows (ImGui absent des autres plateformes).
+	void ApplyWorldEditorTheme();
+}

--- a/src/world_editor/ui/EditorToolbar.cpp
+++ b/src/world_editor/ui/EditorToolbar.cpp
@@ -101,6 +101,84 @@ namespace engine::editor::world
 	}
 
 #if defined(_WIN32)
+	namespace
+	{
+		/// Polish UI 2026-07-17 — Dessine le glyphe vectoriel d'une action de
+		/// la barre (disquette, flèches undo/redo, coche, export) directement
+		/// via ImDrawList : pas d'assets PNG à pipeliner, rendu net à toute
+		/// échelle. \return false si l'id n'a pas de glyphe mappé — l'appelant
+		/// retombe alors sur la lettre placeholder de l'atlas.
+		bool DrawActionGlyph(ImDrawList* dl, const std::string& actionId,
+			const ImVec2& btnMin, const ImVec2& btnMax, ImU32 col)
+		{
+			const float inset = 11.0f;
+			const ImVec2 a{ btnMin.x + inset, btnMin.y + inset };
+			const ImVec2 b{ btnMax.x - inset, btnMax.y - inset };
+			const float w = b.x - a.x;
+			const float h = b.y - a.y;
+			const float th = 2.0f;
+
+			if (actionId == "file.save")
+			{
+				// Disquette : contour arrondi + volet haut + étiquette basse.
+				dl->AddRect(a, b, col, 2.0f, 0, th);
+				dl->AddRectFilled(ImVec2(a.x + w * 0.30f, a.y + th),
+					ImVec2(a.x + w * 0.70f, a.y + h * 0.35f), col);
+				dl->AddRectFilled(ImVec2(a.x + w * 0.22f, a.y + h * 0.58f),
+					ImVec2(a.x + w * 0.78f, b.y - th), col);
+				return true;
+			}
+			if (actionId == "edit.undo" || actionId == "edit.redo")
+			{
+				// Flèche à queue courbée ; redo = miroir horizontal de undo.
+				const bool mirror = (actionId == "edit.redo");
+				auto mx = [&](float x) { return mirror ? (a.x + b.x - x) : x; };
+				const float tipY = a.y + h * 0.32f;
+				const ImVec2 tip{ mx(a.x), tipY };
+				dl->AddTriangleFilled(tip,
+					ImVec2(mx(a.x + w * 0.34f), tipY - h * 0.30f),
+					ImVec2(mx(a.x + w * 0.34f), tipY + h * 0.30f), col);
+				dl->PathLineTo(ImVec2(mx(a.x + w * 0.30f), tipY));
+				dl->PathBezierCubicTo(
+					ImVec2(mx(b.x), tipY),
+					ImVec2(mx(b.x), b.y),
+					ImVec2(mx(a.x + w * 0.30f), b.y));
+				dl->PathStroke(col, 0, th);
+				return true;
+			}
+			if (actionId == "zone.validate")
+			{
+				// Coche.
+				const ImVec2 pts[3] = {
+					ImVec2(a.x, a.y + h * 0.55f),
+					ImVec2(a.x + w * 0.38f, b.y),
+					ImVec2(b.x, a.y + h * 0.08f),
+				};
+				dl->AddPolyline(pts, 3, col, 0, 2.5f);
+				return true;
+			}
+			if (actionId == "zone.export")
+			{
+				// Plateau ouvert + flèche montante (export vers le runtime).
+				const ImVec2 tray[4] = {
+					ImVec2(a.x, a.y + h * 0.55f),
+					ImVec2(a.x, b.y),
+					ImVec2(b.x, b.y),
+					ImVec2(b.x, a.y + h * 0.55f),
+				};
+				dl->AddPolyline(tray, 4, col, 0, th);
+				const float cx = (a.x + b.x) * 0.5f;
+				dl->AddLine(ImVec2(cx, a.y + h * 0.18f), ImVec2(cx, a.y + h * 0.72f), col, th);
+				dl->AddTriangleFilled(
+					ImVec2(cx, a.y - 1.0f),
+					ImVec2(cx - w * 0.24f, a.y + h * 0.30f),
+					ImVec2(cx + w * 0.24f, a.y + h * 0.30f), col);
+				return true;
+			}
+			return false;
+		}
+	}
+
 	void EditorToolbar::Render()
 	{
 		// Construction de la fenêtre : ancrée sous le menu bar, largeur =
@@ -170,15 +248,18 @@ namespace engine::editor::world
 			}
 			dl->AddRectFilled(buttonScreenMin, buttonScreenMax, baseColor, 4.0f);
 
-			// Lettre centrale (placeholder — un futur ticket d'art remplacera
-			// par de vraies icônes PNG, cf. ToolbarIconAtlas).
-			const ImVec2 textSize = ImGui::CalcTextSize(style.letter);
-			const ImVec2 textPos{
-				buttonScreenMin.x + (kButtonSizePx - textSize.x) * 0.5f,
-				buttonScreenMin.y + (kButtonSizePx - textSize.y) * 0.5f };
-			dl->AddText(textPos,
-				enabled ? IM_COL32_WHITE : IM_COL32(160, 160, 160, 200),
-				style.letter);
+			// Glyphe vectoriel (polish 2026-07-17) ; lettre placeholder de
+			// l'atlas en repli si l'id n'est pas mappé.
+			const ImU32 glyphCol = enabled
+				? IM_COL32_WHITE : IM_COL32(160, 160, 160, 200);
+			if (!DrawActionGlyph(dl, a->id, buttonScreenMin, buttonScreenMax, glyphCol))
+			{
+				const ImVec2 textSize = ImGui::CalcTextSize(style.letter);
+				const ImVec2 textPos{
+					buttonScreenMin.x + (kButtonSizePx - textSize.x) * 0.5f,
+					buttonScreenMin.y + (kButtonSizePx - textSize.y) * 0.5f };
+				dl->AddText(textPos, glyphCol, style.letter);
+			}
 
 			dl->AddRect(buttonScreenMin, buttonScreenMax,
 				IM_COL32(40, 40, 40, 200), 4.0f, 0, 1.5f);

--- a/src/world_editor/ui/EditorToolbar.cpp
+++ b/src/world_editor/ui/EditorToolbar.cpp
@@ -139,7 +139,7 @@ namespace engine::editor::world
 					ImVec2(mx(a.x + w * 0.34f), tipY - h * 0.30f),
 					ImVec2(mx(a.x + w * 0.34f), tipY + h * 0.30f), col);
 				dl->PathLineTo(ImVec2(mx(a.x + w * 0.30f), tipY));
-				dl->PathBezierCubicTo(
+				dl->PathBezierCubicCurveTo(
 					ImVec2(mx(b.x), tipY),
 					ImVec2(mx(b.x), b.y),
 					ImVec2(mx(a.x + w * 0.30f), b.y));

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -84,6 +84,14 @@ namespace engine::editor
 #if defined(_WIN32)
 	namespace
 	{
+		/// Polish UI 2026-07-17 — version de la disposition de fenêtres par
+		/// défaut. À BUMPER à chaque évolution de la disposition (ajout de
+		/// panneau docké, réorganisation des nodes…) : les profils dont
+		/// `user_prefs.json` porte une version différente voient leur
+		/// disposition reconstruite automatiquement au boot (les .ini
+		/// périmés éparpillaient les nouvelles fenêtres en flottant).
+		constexpr int kEditorLayoutVersion = 2;
+
 		void TryPersistMovementLayoutToUserSettings(std::string_view layout)
 		{
 			const char* path = "user_settings.json";
@@ -856,6 +864,26 @@ namespace engine::editor
 		// rendues depuis ce registre (spec docs/superpowers/specs/
 		// 2026-07-17-editor-menus-toolbar-reorg-design.md).
 		RegisterEditorActions();
+		// Polish UI 2026-07-17 — disposition versionnée : si le profil
+		// utilisateur vient d'une version de disposition antérieure (ou n'en
+		// a jamais vue), on reconstruit automatiquement la disposition par
+		// défaut au lieu de laisser l'ancien .ini éparpiller les nouvelles
+		// fenêtres en flottant (bug constaté au premier build mergé).
+		if (!m_layoutVersionChecked)
+		{
+			m_layoutVersionChecked = true;
+			auto& prefsStore = engine::editor::world::prefs::UserPrefsStore::Instance();
+			const int seenVersion = prefsStore.IsInitialized()
+				? prefsStore.GetLayoutVersion() : kEditorLayoutVersion;
+			if (seenVersion != kEditorLayoutVersion)
+			{
+				ResetDockLayout();
+				prefsStore.SetLayoutVersion(kEditorLayoutVersion);
+				LOG_INFO(EditorWorld,
+					"[WorldEditorImGui] Disposition reconstruite (version {} -> {})",
+					seenVersion, kEditorLayoutVersion);
+			}
+		}
 		// PR 3 — Ctrl+P ouvre la palette de commandes (détection ImGui
 		// directe : pas de plumbing Engine nécessaire).
 		if (ImGui::IsKeyChordPressed(ImGuiMod_Ctrl | ImGuiKey_P))
@@ -952,14 +980,20 @@ namespace engine::editor
 					ImGuiID idBottom = 0;
 					ImGui::DockBuilderSplitNode(idCenter, ImGuiDir_Down, 0.18f, &idBottom, &idCenter);
 
-					// Palette outils : a gauche, c'est la zone d'action principale.
-					ImGui::DockBuilderDockWindow("Outils", idLeft);
-					// Réorganisation UI 2026-07-17 (PR 2) — la palette
-					// d'outils du shell rejoint le node gauche (onglet à
-					// côté de « Outils »).
-					ImGui::DockBuilderDockWindow("Palette d'outils", idLeft);
+					// Polish UI 2026-07-17 — disposition UNIFIÉE : les panneaux
+					// du SHELL (M100.x) sont dockés ici aussi, par nom de
+					// fenêtre, dans les mêmes nodes que les fenêtres session
+					// (M43.x). Fini les deux systèmes de disposition
+					// superposés qui laissaient flotter la moitié des
+					// fenêtres (capture utilisateur du build #976-979).
 
-					// Inspecteur : panneaux carte / affichage / import / objets / scene sont des onglets a droite.
+					// Gauche : la palette d'outils d'abord (onglet actif au
+					// premier lancement), la fenêtre « Outils » (infos) derrière.
+					ImGui::DockBuilderDockWindow("Palette d'outils", idLeft);
+					ImGui::DockBuilderDockWindow("Outils", idLeft);
+
+					// Droite : onglets carte / affichage / atmosphère /
+					// import / objets + panneaux scène du shell.
 					// Scene rejoint cette pile : la docker dans le node central annulait le passthrough et
 					// bloquait l'interaction 3D (regression P1). En tant qu'onglet a droite, son contenu
 					// (diagnostic camera) reste accessible et le node central reste vide -> 3D visible
@@ -969,13 +1003,26 @@ namespace engine::editor
 					ImGui::DockBuilderDockWindow("Atmosphere", idRight);
 					ImGui::DockBuilderDockWindow("Import assets", idRight);
 					ImGui::DockBuilderDockWindow("Objets sur la carte", idRight);
+					ImGui::DockBuilderDockWindow("Outliner", idRight);
+					ImGui::DockBuilderDockWindow("Inspector", idRight);
+					ImGui::DockBuilderDockWindow("Tool Properties", idRight);
+					// Panneaux avancés masqués par défaut : pré-dockés pour
+					// apparaître au bon endroit quand le menu Fenêtre les ouvre.
+					ImGui::DockBuilderDockWindow("Quest Editor", idRight);
+					ImGui::DockBuilderDockWindow("Building Editor", idRight);
+					ImGui::DockBuilderDockWindow("Surface Table", idRight);
+					ImGui::DockBuilderDockWindow("Collision Editor", idRight);
+					ImGui::DockBuilderDockWindow("History", idRight);
+					ImGui::DockBuilderDockWindow("Asset Browser", idBottom);
+					ImGui::DockBuilderDockWindow("Console", idBottom);
+					ImGui::DockBuilderDockWindow("Routines", idBottom);
 					// La fenêtre « Camera (aide) » n'est PAS dockée — ses flags
 					// `NoMouseInputs` polluent le tab bar du node quand elle
 					// est dans le même groupe que d'autres tabs (cause des
 					// onglets non cliquables, bug confirmé utilisateur).
 					// Elle est opt-in via `Vue > Aide camera` et flotte.
 
-					// Statut en bas, plein largeur.
+					// Statut en bas, plein largeur (onglet actif du node bas).
 					ImGui::DockBuilderDockWindow("Statut", idBottom);
 
 					ImGui::DockBuilderFinish(dockId);
@@ -3114,6 +3161,19 @@ namespace engine::editor
 		// au prochain run).
 		std::error_code ec;
 		std::filesystem::remove("world_editor_imgui.ini", ec);
+		// Polish UI 2026-07-17 — la disposition est désormais UNIFIÉE : les
+		// panneaux du shell sont dockés par la même disposition par défaut.
+		// L'ancien layout du shell (`editor_world_layout.ini`) ne doit donc
+		// ni être rechargé (lecture différée annulée) ni survivre sur disque
+		// (il réappliquerait des positions périmées par-dessus).
+		if (m_shell != nullptr)
+		{
+			m_shell->DiscardPendingLayoutLoad();
+			if (!m_shell->LayoutPath().empty())
+			{
+				std::filesystem::remove(m_shell->LayoutPath(), ec);
+			}
+		}
 		if (m_session)
 		{
 			m_session->SetStatus("Disposition réinitialisée.");

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -13,6 +13,7 @@
 #include "src/world_editor/actions/EditorActionRegistry.h"
 #include "src/world_editor/ui/ToolbarIconAtlas.h" // libellé FR de l'outil actif (barre de statut)
 #include "src/world_editor/ui/CommandPaletteModel.h" // filtrage pur de la palette Ctrl+P (PR 3)
+#include "src/world_editor/ui/EditorTheme.h" // thème sombre éditeur (polish 2026-07-17)
 #include "src/world_editor/core/CommandStack.h"
 #include "src/world_editor/core/IPanel.h"
 #include "src/world_editor/core/WorldEditorShell.h"
@@ -491,6 +492,13 @@ namespace engine::editor
 		io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 		// Pas de NavEnableKeyboard : sinon io.WantCaptureKeyboard reste souvent vrai et bloque WASD (camera FPS).
 		ImGui::StyleColorsDark();
+		// Polish UI 2026-07-17 — thème sombre dédié à l'éditeur monde
+		// (anthracite + accent doré, arrondis, paddings). Uniquement pour le
+		// binaire éditeur : le client de jeu garde ses styles d'UI propres.
+		if (isWorldEditorExe)
+		{
+			engine::editor::world::ApplyWorldEditorTheme();
+		}
 
 		// Polices auth (Windlass / Morpheus) chargees dans l'atlas ImGui AVANT ImGui_ImplVulkan_Init -
 		// celui-ci construit la texture des fonts une seule fois a partir de l'atlas. Sans ce chargement,

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -904,6 +904,7 @@ namespace engine::editor
 		RenderAboutWindow();
 		RenderCommandPalette();
 		RenderShortcutsWindow();
+		RenderWelcomeOverlay();
 
 		// M100.46 incrément 3 — dessine la popup modale Zone Presets
 		// (no-op si non ouverte ou Shell non branché). m_cfg passé pour
@@ -3505,6 +3506,89 @@ namespace engine::editor
 			ImGui::TextUnformatted(s.label);
 			ImGui::SameLine(320.0f);
 			ImGui::TextDisabled("%s", s.keys);
+		}
+
+		ImGui::End();
+	}
+
+	void WorldEditorImGui::RenderWelcomeOverlay()
+	{
+		if (m_welcomeDismissed) return;
+		if (m_session == nullptr || m_cfg == nullptr) return;
+		// Une carte est « chargée » dès que le document référence une
+		// heightmap (même critère que l'état Terrain du panneau Outils).
+		if (!m_session->Doc().heightmapContentRelativePath.empty()) return;
+
+		namespace weact = engine::editor::world::actions;
+		namespace prefs = engine::editor::world::prefs;
+
+		const ImGuiViewport* vp = ImGui::GetMainViewport();
+		ImGui::SetNextWindowPos(
+			ImVec2(vp->WorkPos.x + vp->WorkSize.x * 0.5f,
+			       vp->WorkPos.y + vp->WorkSize.y * 0.42f),
+			ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+		ImGui::SetNextWindowSize(ImVec2(440.0f, 0.0f), ImGuiCond_Always);
+		const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDocking
+			| ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize
+			| ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize;
+		if (!ImGui::Begin("Bienvenue", nullptr, flags))
+		{
+			ImGui::End();
+			return;
+		}
+
+		ImGui::TextUnformatted("LCDLLN World Editor");
+		ImGui::TextDisabled("Aucune carte n'est chargée pour l'instant.");
+		ImGui::Spacing();
+
+		// Action principale : l'assistant guidé de création de zone.
+		if (ImGui::Button("Nouvelle zone (assistant)...", ImVec2(-1.0f, 0.0f)))
+		{
+			if (m_shell != nullptr)
+			{
+				const weact::EditorAction* a =
+					m_shell->GetActionRegistry().Find("file.new-zone-wizard");
+				if (a != nullptr && a->execute) { a->execute(); }
+			}
+		}
+
+		ImGui::SeparatorText("Cartes récentes");
+		{
+			if (!m_session->AvailableMapsScanned())
+			{
+				m_session->RefreshAvailableMaps(*m_cfg);
+			}
+			const std::vector<std::string>& recents =
+				prefs::UserPrefsStore::Instance().GetRecentMaps();
+			const std::vector<std::string>& mapIds = m_session->AvailableMapIds();
+			size_t shown = 0;
+			for (const std::string& zoneId : recents)
+			{
+				if (shown >= 5u) break;
+				const bool available =
+					std::find(mapIds.begin(), mapIds.end(), zoneId) != mapIds.end();
+				if (ImGui::Selectable(zoneId.c_str(), false,
+					available ? ImGuiSelectableFlags_None : ImGuiSelectableFlags_Disabled)
+					&& available
+					&& m_session->ActionLoadMapByZoneId(*m_cfg, zoneId))
+				{
+					prefs::UserPrefsStore::Instance().PushRecentMap(zoneId);
+				}
+				++shown;
+			}
+			if (shown == 0u)
+			{
+				ImGui::TextDisabled("Aucune carte récente.");
+			}
+		}
+
+		ImGui::Spacing();
+		ImGui::TextDisabled("Créer une carte vide : panneau « Carte » (à droite),");
+		ImGui::TextDisabled("section « Nouvelle carte ». Toutes les actions : Ctrl+P.");
+		ImGui::Spacing();
+		if (ImGui::Button("Fermer"))
+		{
+			m_welcomeDismissed = true;
 		}
 
 		ImGui::End();

--- a/src/world_editor/ui/WorldEditorImGui.h
+++ b/src/world_editor/ui/WorldEditorImGui.h
@@ -338,6 +338,21 @@ namespace engine::editor
 		bool m_paletteFocusQuery = false;
 		/// Visibilité de la fenêtre « Raccourcis clavier » (lecture seule).
 		bool m_showShortcutsWindow = false;
+		/// Polish UI 2026-07-17 — true après la vérification (une fois par
+		/// session) de `UserPrefs::editorLayoutVersion` contre la constante
+		/// code : une version différente déclenche la reconstruction
+		/// automatique de la disposition (cf. BuildUi / ResetDockLayout).
+		bool m_layoutVersionChecked = false;
+		/// Polish UI 2026-07-17 — true quand l'utilisateur a fermé l'écran
+		/// d'accueil « aucune carte » pour la session courante (non persisté).
+		bool m_welcomeDismissed = false;
+
+		/// Polish UI 2026-07-17 — Rend l'écran d'accueil centré tant
+		/// qu'aucune carte n'est chargée (heightmap du document vide) :
+		/// bouton « Nouvelle zone (assistant)… », cartes récentes cliquables,
+		/// renvoi vers le panneau Carte. Fermable (`m_welcomeDismissed`),
+		/// disparaît automatiquement dès qu'une carte est chargée.
+		void RenderWelcomeOverlay();
 
 		/// Ouvre la palette de commandes : réinitialise requête + sélection
 		/// et arme le focus clavier sur le champ de recherche.


### PR DESCRIPTION
## Contexte

Suite directe des PRs #976/#977/#979 : le premier build merge montrait des fenetres flottantes superposees, le theme ImGui par defaut et des lettres en guise d''icones (retour utilisateur avec capture). Boussole de ce lot : **simple au premier regard, complet via les menus**.

Spec : `docs/superpowers/specs/2026-07-17-editor-ui-polish-design.md`

## Contenu

1. **Disposition versionnee et unifiee**
   - `editorLayoutVersion` dans user_prefs.json : au boot, une version differente de la constante code declenche la **reconstruction automatique** de la disposition (suppression des DEUX .ini + re-pose) — plus jamais de fenetres eparpillees apres une mise a jour d''UI.
   - La disposition par defaut docke desormais AUSSI les panneaux du shell (fin des deux systemes de disposition superposes) : gauche = Palette d''outils (+ Outils), droite = Carte / Affichage / Atmosphere / Import / Objets / Outliner / Inspector / Tool Properties en onglets, bas = Statut.
   - **Demarrage epure** : Asset Browser, Console, History, Surface Table, Collision Editor, Building Editor, Quest Editor, Routines masques par defaut — reouvrables via le menu Fenetre (ou Ctrl+P), pre-dockes au bon endroit.
2. **Theme sombre type UE** (`EditorTheme`) : anthracite + accent dore LCDLLN, arrondis, paddings genereux, onglets avec surlignage — applique uniquement au binaire editeur.
3. **Icones vectorielles** de la barre d''actions (disquette, fleches undo/redo, coche, export) dessinees via ImDrawList — plus de lettres S/Z/Y/V/E.
4. **Ecran d''accueil** tant qu''aucune carte n''est chargee : Nouvelle zone (assistant), cartes recentes cliquables, renvois panneau Carte / Ctrl+P.

## Tests

- `editor_modes_tests` : + round-trip `editorLayoutVersion`.
- Le reste est du rendu ImGui → **validation visuelle utilisateur demandee** apres merge (la disposition se reconstruira automatiquement au premier lancement).

## Deploiement

**Deploiement** : ✅ client/editeur uniquement, pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)