### PR TITLE
feat(render): Ciel A - nuages volumetriques sur textures 3D Perlin-Worley

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,6 +672,9 @@ add_library(engine_core
   src/client/render/SkyPass.cpp
   src/client/render/WeatherSystem.cpp
   src/client/render/clouds/CloudWeatherMapper.cpp
+  # Chantier ciel 2026-07-17 — générateur CPU des textures 3D Perlin-Worley
+  # (consommé par CloudPass::Init au boot, testé par cloud_noise_generator_tests).
+  src/client/render/clouds/CloudNoiseGenerator.cpp
   src/client/render/DynamicLightSystem.cpp
   src/client/render/CascadedShadowMaps.cpp
   src/client/render/BrdfLutPass.cpp

--- a/docs/superpowers/specs/2026-07-17-sky-clouds-upgrade-design.md
+++ b/docs/superpowers/specs/2026-07-17-sky-clouds-upgrade-design.md
@@ -1,0 +1,85 @@
+# Amélioration du ciel — nuages Perlin-Worley + ciel analytique
+
+Date : 2026-07-17
+Statut : validé (suite du comparatif UE 5.8 ; lancement demandé en séance
+après le lot polish UI).
+Périmètre : 100 % client (rendu Vulkan) — aucun redéploiement serveur.
+
+## Constat (comparatif UE)
+
+Le ciel d'UE vient d'un empilement SkyAtmosphere (diffusion physique) +
+VolumetricCloud (bruit Perlin-Worley 3D pré-cuit + érosion). Chez nous :
+
+- `clouds.frag` (PR #853) : ray-march correct mais **bruit value-noise FBM
+  calculé in-shader** (hash) → nuages mous/patateux sans bords érodés.
+- `sky.frag` : **dégradé 2 couleurs** zénith/horizon (poussé par
+  DayNightCycle) → ciel plat, ne réagit pas physiquement au soleil.
+
+Levier n°1 = qualité du bruit des nuages ; levier n°2 = modèle de ciel.
+Deux PRs **indépendantes** (fichiers disjoints, mergeables dans n'importe
+quel ordre — leçon des piles + squash) :
+
+## PR A — `claude/sky-clouds-noise` : textures 3D Perlin-Worley
+
+- **Générateur CPU pur** `src/client/render/clouds/CloudNoiseGenerator.{h,cpp}`
+  (testable ctest Linux) :
+  - bruit de **Worley 3D périodique** (points caractéristiques par cellule,
+    distance min sur 27 voisins avec wrap, inversé → « cotonneux ») ;
+  - **fBm de Perlin 3D périodique** (gradients sur lattice wrap, fade
+    quintique) ;
+  - `GenerateCloudNoise(seed)` → 2 textures RGBA8 :
+    - **base 64³** : R = fBm Perlin, G/B/A = Worley 8/16/32 cellules ;
+    - **détail 32³** : R/G/B = Worley 4/8/16 cellules.
+  - Déterministe (hash entier maison, pas de rand()), génération au boot
+    (< 1 s, loguée).
+- **CloudPass** : `Init` reçoit queue + queue family (upload one-shot via
+  staging + command pool transitoire) ; 2 images 3D R8G8B8A8 + sampler
+  linéaire REPEAT (tuilage) ; descriptor set layout passe à 4 bindings
+  (2 = base, 3 = détail), écrits avec 0/1 à chaque Record.
+- **clouds.frag** : `cloudDensity` échantillonne les textures — forme de
+  base = dilatation Schneider `remap(perlin, worleyFbm-1, 1, 0, 1)`
+  (tuile ~5,2 km), seuil piloté par coverage (inchangé côté CPU), érosion
+  de détail (tuile ~800 m, wispy en bas / billowy en haut). Push constants
+  **inchangés** (192 o) → zéro changement d'API météo/CPU.
+- Échec de création des textures → Init false → passe désactivée (même
+  passthrough qu'un shader manquant, boot jamais bloqué).
+
+## PR B — `claude/sky-analytic` : modèle de ciel analytique
+
+- **sky.frag** : la couleur du ciel devient une **diffusion simple
+  Rayleigh + Mie** calculée par pixel (ray-march léger : 8 échantillons le
+  long du rayon vue dans une atmosphère exponentielle, transmittance vers
+  le soleil sur 4 échantillons ; constantes physiques standard β_R/β_M,
+  H_R=8 km, H_M=1,2 km, planète 6360/6420 km). Résultat : bleu profond au
+  zénith, blanchiment à l'horizon, orangés au lever/coucher, nuit qui
+  tombe naturellement quand le soleil descend.
+- **Bascule sûre** : le float de padding `_pad3[0]` des push constants
+  (160 o inchangés) devient `skyModel` (0 = dégradé legacy, 1 = analytique).
+  Config `client.sky.analytic` (défaut **true**) lue par Engine au
+  remplissage des push constants. Un problème visuel en jeu se contourne
+  en 1 clé de config sans rebuild.
+- Soleil (disque net + couronne), lune (phases) et bande sous-horizon :
+  **conservés tels quels** par-dessus le nouveau fond.
+- Les teintes zénith/horizon de DayNightCycle restent envoyées (mode
+  legacy + ambiant des nuages) — la météo continue de teinter les nuages.
+
+## Hors périmètre
+
+- `sky_capture.comp` (IBL) : garde le dégradé (la capture ciel sert
+  d'ambiance basse fréquence ; à aligner dans un ticket ultérieur).
+- Perspective aérienne sur le terrain lointain (ticket futur).
+- Étoiles nocturnes.
+
+## Tests
+
+- `cloud_noise_generator_tests` (ctest Linux, pattern
+  `lcdlln_add_simple_test`) : déterminisme par seed, périodicité du Worley
+  et du Perlin (f(0)==f(période)), tailles/format, distribution non
+  dégénérée (min/max/moyenne).
+- Shaders : compilés au runtime (glslangValidator) — la CI ne les valide
+  pas ; relecture rigoureuse + bascule config comme filet. **Validation
+  visuelle utilisateur requise.**
+
+## Déploiement
+
+✅ client uniquement (aucun opcode/migration/config serveur).

--- a/game/data/shaders/clouds.frag
+++ b/game/data/shaders/clouds.frag
@@ -3,7 +3,8 @@
 // Nuages volumétriques ray-marchés (client). Passe GRAPHIQUE plein écran
 // (fullscreen triangle partagé avec volumetric_fog.frag via lighting.vert).
 // Pour chaque pixel : reconstruit le rayon caméra->pixel, ray-marche une dalle
-// horizontale [baseAlt, topAlt], accumule densité (bruit FBM in-shader) et
+// horizontale [baseAlt, topAlt], accumule densité (textures 3D Perlin-Worley
+// pré-cuites, chantier ciel 2026-07-17 — ex-bruit FBM in-shader) et
 // éclairage (Beer + Powder + phase Henyey-Greenstein vers le soleil), puis
 // composite par-dessus la scène déjà brouillardée. Le depth scène borne la
 // marche (un relief proche occulte les nuages).
@@ -11,6 +12,9 @@
 // Entrées (descriptor set 0) :
 //   binding 0 = scene color HDR post-fog (sampler linéaire clamp)
 //   binding 1 = depth scene (D32_SFLOAT, sampler nearest clamp, lu en .r)
+//   binding 2 = bruit 3D base 64³ (R=Perlin fBm, G/B/A=Worley 8/16/32,
+//               sampler linéaire REPEAT) — chantier ciel 2026-07-17
+//   binding 3 = bruit 3D détail 32³ (R/G/B=Worley 4/8/16, REPEAT)
 //
 // Sortie :
 //   outColor (location 0) — scene + nuages composités.
@@ -22,6 +26,8 @@ layout(location = 0) out vec4 outColor;
 
 layout(set = 0, binding = 0) uniform sampler2D uSceneColor; // HDR post-fog
 layout(set = 0, binding = 1) uniform sampler2D uSceneDepth; // depth, .r = [0,1]
+layout(set = 0, binding = 2) uniform sampler3D uNoiseBase;   // Perlin-Worley base
+layout(set = 0, binding = 3) uniform sampler3D uNoiseDetail; // Worley détail
 
 layout(push_constant) uniform CloudPC
 {
@@ -38,50 +44,16 @@ layout(push_constant) uniform CloudPC
 
 const float PI = 3.14159265358979;
 
-// ---- Bruit value-noise 3D + FBM (hash, sans texture) ----
-float hash13(vec3 p)
+// Remap borné [0,1] — dilatation de Schneider (Horizon Zero Dawn) et
+// érosion de détail (chantier ciel 2026-07-17).
+float remap01(float v, float lo, float hi)
 {
-	p = fract(p * 0.1031);
-	p += dot(p, p.yzx + 33.33);
-	return fract((p.x + p.y) * p.z);
+	return clamp((v - lo) / max(hi - lo, 1e-5), 0.0, 1.0);
 }
 
-float valueNoise(vec3 p)
-{
-	vec3 i = floor(p);
-	vec3 f = fract(p);
-	f = f * f * (3.0 - 2.0 * f);
-	float n000 = hash13(i + vec3(0,0,0));
-	float n100 = hash13(i + vec3(1,0,0));
-	float n010 = hash13(i + vec3(0,1,0));
-	float n110 = hash13(i + vec3(1,1,0));
-	float n001 = hash13(i + vec3(0,0,1));
-	float n101 = hash13(i + vec3(1,0,1));
-	float n011 = hash13(i + vec3(0,1,1));
-	float n111 = hash13(i + vec3(1,1,1));
-	float nx00 = mix(n000, n100, f.x);
-	float nx10 = mix(n010, n110, f.x);
-	float nx01 = mix(n001, n101, f.x);
-	float nx11 = mix(n011, n111, f.x);
-	float nxy0 = mix(nx00, nx10, f.y);
-	float nxy1 = mix(nx01, nx11, f.y);
-	return mix(nxy0, nxy1, f.z);
-}
-
-float fbm(vec3 p)
-{
-	float a = 0.5;
-	float sum = 0.0;
-	for (int i = 0; i < 5; ++i)
-	{
-		sum += a * valueNoise(p);
-		p *= 2.02;
-		a *= 0.5;
-	}
-	return sum;
-}
-
-// Densité de nuage en un point monde p.
+// Densité de nuage en un point monde p (chantier ciel 2026-07-17 : les
+// textures 3D Perlin-Worley pré-cuites remplacent le value-noise FBM
+// in-shader — cf. CloudNoiseGenerator.cpp).
 float cloudDensity(vec3 p)
 {
 	float baseAlt = pc.zenithColor.w;
@@ -94,23 +66,31 @@ float cloudDensity(vec3 p)
 
 	// Animation par le vent.
 	vec3 wind = vec3(pc.windParams.x, 0.0, pc.windParams.y) * pc.windParams.z * pc.cameraPos.w;
-	vec3 sp = (p + wind) * 0.0006;
 
+	// Forme de base : texture 64³ tuilée sur ~5,2 km. R = Perlin fBm,
+	// dilaté par le fBm de Worley (G/B/A) — la « dilatation Schneider »
+	// donne des cumulus à bords nets là où le value-noise donnait des blobs.
+	vec3 sp = (p + wind) / 5200.0;
+	vec4 nb = texture(uNoiseBase, sp);
+	float worleyFbm = nb.g * 0.625 + nb.b * 0.25 + nb.a * 0.125;
+	float baseShape = remap01(nb.r, worleyFbm - 1.0, 1.0);
+
+	// Seuil de couverture : coverage 0 -> ciel quasi vide, 1 -> couvert.
+	// Plage choisie pour la distribution du baseShape remappé (moyenne ~0.5).
 	float coverage = pc.sunDir.w;
-	float base = fbm(sp);
-	// Seuil placé dans la plage RÉELLE du FBM (moyenne ~0.48, max ~0.97) : un seuil
-	// (1-coverage) brut donnait 0.75 à Clear -> densité nulle partout (nuages
-	// invisibles). On remappe : coverage 0 -> seuil 0.55 (ciel quasi vide),
-	// coverage 1 -> seuil 0.10 (couvert). smoothstep pour des bords doux + opacité visible.
-	// Plage relevée (0.68..0.25) : à Clear (coverage~0.25) le seuil ~0.57 reste
-	// au-dessus de la moyenne du FBM (~0.48) -> nuages ÉPARS avec du ciel entre eux
-	// (et non un plafond couvrant). Storm (coverage~0.97) -> seuil ~0.26 -> couvert.
-	float threshold = mix(0.68, 0.25, coverage);
-	float d = smoothstep(threshold, threshold + 0.18, base);
+	float threshold = mix(0.72, 0.28, coverage);
+	float d = smoothstep(threshold, threshold + 0.14, baseShape);
 
-	// Érosion de détail haute fréquence sur les bords.
-	float detail = fbm(sp * 4.0 + wind * 0.01);
-	d = max(d - detail * 0.2 * (1.0 - coverage), 0.0);
+	// Érosion de détail : texture 32³ tuilée sur ~800 m. Bords effilochés
+	// (wispy) vers la base du nuage, cotonneux (billowy) vers le sommet.
+	if (d > 0.001)
+	{
+		vec3 dp = (p + wind * 1.4) / 800.0;
+		vec3 nd = texture(uNoiseDetail, dp).rgb;
+		float detailFbm = nd.r * 0.625 + nd.g * 0.25 + nd.b * 0.125;
+		float erode = mix(detailFbm, 1.0 - detailFbm, clamp(h * 4.0, 0.0, 1.0));
+		d = remap01(d, erode * 0.4, 1.0);
+	}
 
 	return d * heightGrad * pc.sunColor.w * 1.5; // * density, gain d'opacité
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1081,6 +1081,10 @@ elseif(UNIX)
   # CPU ; CloudWeatherMapper.cpp est fourni par engine_core (lie par le helper).
   lcdlln_add_simple_test(cloud_params_tests
     ${CMAKE_SOURCE_DIR}/src/client/render/clouds/CloudParamsTests.cpp)
+  # Chantier ciel 2026-07-17 — générateur de bruit Perlin-Worley des nuages :
+  # déterminisme, périodicité (tuilage sampler REPEAT), distribution.
+  lcdlln_add_simple_test(cloud_noise_generator_tests
+    ${CMAKE_SOURCE_DIR}/src/client/render/clouds/CloudNoiseGeneratorTests.cpp)
   lcdlln_add_simple_test(cloud_weather_mapper_tests
     ${CMAKE_SOURCE_DIR}/src/client/render/clouds/CloudWeatherMapperTests.cpp)
   # WeatherKindMap : conversion WeatherKind serveur (wire 156) -> WeatherState client.

--- a/src/client/render/CloudPass.cpp
+++ b/src/client/render/CloudPass.cpp
@@ -1,8 +1,10 @@
 #include "src/client/render/CloudPass.h"
 #include "src/client/render/PipelineCache.h"
+#include "src/client/render/clouds/CloudNoiseGenerator.h"
 #include "src/shared/core/Log.h"
 
 #include <array>
+#include <chrono>
 #include <cstring>
 
 namespace engine::render
@@ -19,16 +21,36 @@ namespace engine::render
 			vkCreateShaderModule(device, &info, nullptr, &mod);
 			return mod;
 		}
+
+		/// Trouve un type mémoire compatible (pattern standard Vulkan).
+		/// \return l'index du type, ou UINT32_MAX si aucun ne convient.
+		uint32_t FindMemoryType(VkPhysicalDevice physicalDevice,
+			uint32_t typeBits, VkMemoryPropertyFlags props)
+		{
+			VkPhysicalDeviceMemoryProperties memProps{};
+			vkGetPhysicalDeviceMemoryProperties(physicalDevice, &memProps);
+			for (uint32_t i = 0; i < memProps.memoryTypeCount; ++i)
+			{
+				if ((typeBits & (1u << i))
+					&& (memProps.memoryTypes[i].propertyFlags & props) == props)
+				{
+					return i;
+				}
+			}
+			return UINT32_MAX;
+		}
 	}
 
-	bool CloudPass::Init(VkDevice device, VkPhysicalDevice /*physicalDevice*/,
+	bool CloudPass::Init(VkDevice device, VkPhysicalDevice physicalDevice,
 		VkFormat sceneColorHDRFormat,
 		const uint32_t* vertSpirv, size_t vertWordCount,
 		const uint32_t* fragSpirv, size_t fragWordCount,
+		VkQueue uploadQueue, uint32_t uploadQueueFamilyIndex,
 		uint32_t maxFrames, VkPipelineCache pipelineCache)
 	{
 		if (device == VK_NULL_HANDLE || !vertSpirv || !fragSpirv
-			|| vertWordCount == 0 || fragWordCount == 0)
+			|| vertWordCount == 0 || fragWordCount == 0
+			|| uploadQueue == VK_NULL_HANDLE)
 		{
 			LOG_ERROR(Render, "CloudPass::Init: invalid arguments");
 			return false;
@@ -81,9 +103,10 @@ namespace engine::render
 			}
 		}
 
-		// 2. Descriptor set layout : 2 combined image samplers (scene color, depth).
+		// 2. Descriptor set layout : 4 combined image samplers (scene color,
+		// depth, bruit base 3D, bruit détail 3D — chantier ciel 2026-07-17).
 		{
-			std::array<VkDescriptorSetLayoutBinding, 2> bindings{};
+			std::array<VkDescriptorSetLayoutBinding, 4> bindings{};
 			for (size_t i = 0; i < bindings.size(); ++i)
 			{
 				bindings[i].binding         = static_cast<uint32_t>(i);
@@ -106,7 +129,7 @@ namespace engine::render
 		{
 			VkDescriptorPoolSize poolSize{};
 			poolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-			poolSize.descriptorCount = 2 * m_maxFrames;
+			poolSize.descriptorCount = 4 * m_maxFrames;
 			VkDescriptorPoolCreateInfo poolInfo{};
 			poolInfo.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
 			poolInfo.poolSizeCount = 1;
@@ -158,6 +181,57 @@ namespace engine::render
 				LOG_ERROR(Render, "CloudPass: vkCreateSampler (nearest) failed");
 				Destroy(device); return false;
 			}
+			// Sampler des textures de bruit : linéaire + REPEAT (les bruits
+			// sont périodiques, le tuilage doit être sans couture).
+			si.magFilter    = VK_FILTER_LINEAR;
+			si.minFilter    = VK_FILTER_LINEAR;
+			si.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+			si.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+			si.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+			if (vkCreateSampler(device, &si, nullptr, &m_noiseSampler) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkCreateSampler (noise repeat) failed");
+				Destroy(device); return false;
+			}
+		}
+
+		// 5b. Chantier ciel 2026-07-17 — génération CPU + upload des textures
+		// 3D de bruit Perlin-Worley (base 64³ + détail 32³). One-shot au boot
+		// via un command pool transitoire (vkQueueWaitIdle interne).
+		{
+			const auto t0 = std::chrono::steady_clock::now();
+			const clouds::CloudNoiseData noise = clouds::GenerateCloudNoise(1337u);
+
+			VkCommandPool uploadPool = VK_NULL_HANDLE;
+			VkCommandPoolCreateInfo poolInfo{};
+			poolInfo.sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+			poolInfo.flags            = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT;
+			poolInfo.queueFamilyIndex = uploadQueueFamilyIndex;
+			if (vkCreateCommandPool(device, &poolInfo, nullptr, &uploadPool) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkCreateCommandPool (noise upload) failed");
+				Destroy(device); return false;
+			}
+
+			const bool okBase = CreateNoiseTexture3D(device, physicalDevice,
+				uploadPool, uploadQueue, clouds::kBaseNoiseSize,
+				noise.baseRgba.data(),
+				m_noiseBaseImage, m_noiseBaseMemory, m_noiseBaseView);
+			const bool okDetail = okBase && CreateNoiseTexture3D(device, physicalDevice,
+				uploadPool, uploadQueue, clouds::kDetailNoiseSize,
+				noise.detailRgba.data(),
+				m_noiseDetailImage, m_noiseDetailMemory, m_noiseDetailView);
+			vkDestroyCommandPool(device, uploadPool, nullptr);
+			if (!okBase || !okDetail)
+			{
+				LOG_ERROR(Render, "CloudPass: creation des textures de bruit 3D echouee");
+				Destroy(device); return false;
+			}
+			const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+				std::chrono::steady_clock::now() - t0).count();
+			LOG_INFO(Render, "CloudPass: bruit Perlin-Worley genere+uploade en {} ms "
+				"(base {}^3, detail {}^3)", static_cast<long long>(ms),
+				clouds::kBaseNoiseSize, clouds::kDetailNoiseSize);
 		}
 
 		// 6. Pipeline layout : set 0 + push constants (176 o, fragment).
@@ -281,10 +355,12 @@ namespace engine::render
 		const uint32_t setIdx = frameIndex % m_maxFrames;
 		VkDescriptorSet ds = m_descriptorSets[setIdx];
 
-		std::array<VkDescriptorImageInfo, 2> imageInfos{};
-		imageInfos[0] = { m_linearSampler,  viewSceneIn, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
-		imageInfos[1] = { m_nearestSampler, viewDepth,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
-		std::array<VkWriteDescriptorSet, 2> writes{};
+		std::array<VkDescriptorImageInfo, 4> imageInfos{};
+		imageInfos[0] = { m_linearSampler,  viewSceneIn,       VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		imageInfos[1] = { m_nearestSampler, viewDepth,         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		imageInfos[2] = { m_noiseSampler,   m_noiseBaseView,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		imageInfos[3] = { m_noiseSampler,   m_noiseDetailView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		std::array<VkWriteDescriptorSet, 4> writes{};
 		for (size_t i = 0; i < writes.size(); ++i)
 		{
 			writes[i].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
@@ -351,6 +427,181 @@ namespace engine::render
 		vkCmdEndRenderPass(cmd);
 	}
 
+	bool CloudPass::CreateNoiseTexture3D(VkDevice device, VkPhysicalDevice physicalDevice,
+		VkCommandPool cmdPool, VkQueue queue,
+		int size, const uint8_t* rgba,
+		VkImage& outImage, VkDeviceMemory& outMemory, VkImageView& outView)
+	{
+		const VkDeviceSize byteSize =
+			static_cast<VkDeviceSize>(size) * size * size * 4u;
+
+		// 1. Image 3D device-local.
+		{
+			VkImageCreateInfo ii{};
+			ii.sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+			ii.imageType     = VK_IMAGE_TYPE_3D;
+			ii.format        = VK_FORMAT_R8G8B8A8_UNORM;
+			ii.extent        = { static_cast<uint32_t>(size),
+			                     static_cast<uint32_t>(size),
+			                     static_cast<uint32_t>(size) };
+			ii.mipLevels     = 1;
+			ii.arrayLayers   = 1;
+			ii.samples       = VK_SAMPLE_COUNT_1_BIT;
+			ii.tiling        = VK_IMAGE_TILING_OPTIMAL;
+			ii.usage         = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+			ii.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+			if (vkCreateImage(device, &ii, nullptr, &outImage) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkCreateImage (bruit 3D {}^3) failed", size);
+				return false;
+			}
+			VkMemoryRequirements req{};
+			vkGetImageMemoryRequirements(device, outImage, &req);
+			VkMemoryAllocateInfo ai{};
+			ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+			ai.allocationSize  = req.size;
+			ai.memoryTypeIndex = FindMemoryType(physicalDevice, req.memoryTypeBits,
+				VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+			if (ai.memoryTypeIndex == UINT32_MAX
+				|| vkAllocateMemory(device, &ai, nullptr, &outMemory) != VK_SUCCESS
+				|| vkBindImageMemory(device, outImage, outMemory, 0) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: allocation memoire image bruit 3D failed");
+				return false;
+			}
+		}
+
+		// 2. Staging host-visible + copie CPU.
+		VkBuffer stagingBuf = VK_NULL_HANDLE;
+		VkDeviceMemory stagingMem = VK_NULL_HANDLE;
+		{
+			VkBufferCreateInfo bi{};
+			bi.sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+			bi.size        = byteSize;
+			bi.usage       = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+			bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+			if (vkCreateBuffer(device, &bi, nullptr, &stagingBuf) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkCreateBuffer (staging bruit) failed");
+				return false;
+			}
+			VkMemoryRequirements req{};
+			vkGetBufferMemoryRequirements(device, stagingBuf, &req);
+			VkMemoryAllocateInfo ai{};
+			ai.sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+			ai.allocationSize  = req.size;
+			ai.memoryTypeIndex = FindMemoryType(physicalDevice, req.memoryTypeBits,
+				VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+			if (ai.memoryTypeIndex == UINT32_MAX
+				|| vkAllocateMemory(device, &ai, nullptr, &stagingMem) != VK_SUCCESS
+				|| vkBindBufferMemory(device, stagingBuf, stagingMem, 0) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: allocation staging bruit failed");
+				if (stagingBuf) vkDestroyBuffer(device, stagingBuf, nullptr);
+				if (stagingMem) vkFreeMemory(device, stagingMem, nullptr);
+				return false;
+			}
+			void* mapped = nullptr;
+			if (vkMapMemory(device, stagingMem, 0, byteSize, 0, &mapped) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkMapMemory (staging bruit) failed");
+				vkDestroyBuffer(device, stagingBuf, nullptr);
+				vkFreeMemory(device, stagingMem, nullptr);
+				return false;
+			}
+			std::memcpy(mapped, rgba, static_cast<size_t>(byteSize));
+			vkUnmapMemory(device, stagingMem);
+		}
+
+		// 3. Command buffer one-shot : UNDEFINED → TRANSFER_DST, copie,
+		// → SHADER_READ_ONLY (fragment). Submit + wait (boot uniquement).
+		bool ok = false;
+		{
+			VkCommandBufferAllocateInfo cbai{};
+			cbai.sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+			cbai.commandPool        = cmdPool;
+			cbai.level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+			cbai.commandBufferCount = 1;
+			VkCommandBuffer cmd = VK_NULL_HANDLE;
+			if (vkAllocateCommandBuffers(device, &cbai, &cmd) == VK_SUCCESS)
+			{
+				VkCommandBufferBeginInfo bi{};
+				bi.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+				bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+				vkBeginCommandBuffer(cmd, &bi);
+
+				VkImageSubresourceRange range{ VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+				VkImageMemoryBarrier toDst{};
+				toDst.sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+				toDst.srcAccessMask       = 0;
+				toDst.dstAccessMask       = VK_ACCESS_TRANSFER_WRITE_BIT;
+				toDst.oldLayout           = VK_IMAGE_LAYOUT_UNDEFINED;
+				toDst.newLayout           = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+				toDst.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+				toDst.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+				toDst.image               = outImage;
+				toDst.subresourceRange    = range;
+				vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+					VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &toDst);
+
+				VkBufferImageCopy copy{};
+				copy.imageSubresource = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1 };
+				copy.imageExtent      = { static_cast<uint32_t>(size),
+				                          static_cast<uint32_t>(size),
+				                          static_cast<uint32_t>(size) };
+				vkCmdCopyBufferToImage(cmd, stagingBuf, outImage,
+					VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+
+				VkImageMemoryBarrier toRead = toDst;
+				toRead.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+				toRead.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+				toRead.oldLayout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+				toRead.newLayout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+				vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+					VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, 0, nullptr, 0, nullptr, 1, &toRead);
+
+				vkEndCommandBuffer(cmd);
+				VkSubmitInfo si{};
+				si.sType              = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+				si.commandBufferCount = 1;
+				si.pCommandBuffers    = &cmd;
+				if (vkQueueSubmit(queue, 1, &si, VK_NULL_HANDLE) == VK_SUCCESS)
+				{
+					vkQueueWaitIdle(queue);
+					ok = true;
+				}
+				else
+				{
+					LOG_ERROR(Render, "CloudPass: vkQueueSubmit (upload bruit) failed");
+				}
+				vkFreeCommandBuffers(device, cmdPool, 1, &cmd);
+			}
+			else
+			{
+				LOG_ERROR(Render, "CloudPass: vkAllocateCommandBuffers (upload bruit) failed");
+			}
+		}
+		vkDestroyBuffer(device, stagingBuf, nullptr);
+		vkFreeMemory(device, stagingMem, nullptr);
+		if (!ok) return false;
+
+		// 4. Vue 3D.
+		{
+			VkImageViewCreateInfo vi{};
+			vi.sType            = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+			vi.image            = outImage;
+			vi.viewType         = VK_IMAGE_VIEW_TYPE_3D;
+			vi.format           = VK_FORMAT_R8G8B8A8_UNORM;
+			vi.subresourceRange = { VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1 };
+			if (vkCreateImageView(device, &vi, nullptr, &outView) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkCreateImageView (bruit 3D) failed");
+				return false;
+			}
+		}
+		return true;
+	}
+
 	// Audit 2026-06-10 (Lot B2) — détruit les framebuffers cachés (pattern WaterPass).
 	void CloudPass::InvalidateFramebufferCache(VkDevice device)
 	{
@@ -373,6 +624,14 @@ namespace engine::render
 		if (m_pipelineLayout)      { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
 		if (m_nearestSampler)      { vkDestroySampler(device, m_nearestSampler, nullptr); m_nearestSampler = VK_NULL_HANDLE; }
 		if (m_linearSampler)       { vkDestroySampler(device, m_linearSampler, nullptr); m_linearSampler = VK_NULL_HANDLE; }
+		// Chantier ciel 2026-07-17 — textures 3D de bruit + sampler REPEAT.
+		if (m_noiseSampler)        { vkDestroySampler(device, m_noiseSampler, nullptr); m_noiseSampler = VK_NULL_HANDLE; }
+		if (m_noiseBaseView)       { vkDestroyImageView(device, m_noiseBaseView, nullptr); m_noiseBaseView = VK_NULL_HANDLE; }
+		if (m_noiseBaseImage)      { vkDestroyImage(device, m_noiseBaseImage, nullptr); m_noiseBaseImage = VK_NULL_HANDLE; }
+		if (m_noiseBaseMemory)     { vkFreeMemory(device, m_noiseBaseMemory, nullptr); m_noiseBaseMemory = VK_NULL_HANDLE; }
+		if (m_noiseDetailView)     { vkDestroyImageView(device, m_noiseDetailView, nullptr); m_noiseDetailView = VK_NULL_HANDLE; }
+		if (m_noiseDetailImage)    { vkDestroyImage(device, m_noiseDetailImage, nullptr); m_noiseDetailImage = VK_NULL_HANDLE; }
+		if (m_noiseDetailMemory)   { vkFreeMemory(device, m_noiseDetailMemory, nullptr); m_noiseDetailMemory = VK_NULL_HANDLE; }
 		m_descriptorSets.clear();
 		if (m_descriptorPool)      { vkDestroyDescriptorPool(device, m_descriptorPool, nullptr); m_descriptorPool = VK_NULL_HANDLE; }
 		if (m_descriptorSetLayout) { vkDestroyDescriptorSetLayout(device, m_descriptorSetLayout, nullptr); m_descriptorSetLayout = VK_NULL_HANDLE; }

--- a/src/client/render/CloudPass.h
+++ b/src/client/render/CloudPass.h
@@ -43,15 +43,22 @@ namespace engine::render
 		CloudPass(const CloudPass&) = delete;
 		CloudPass& operator=(const CloudPass&) = delete;
 
-		/// Crée render pass, descriptor set layout/pool, samplers, pipeline plein écran.
+		/// Crée render pass, descriptor set layout/pool, samplers, pipeline plein écran
+		/// ET les deux textures 3D de bruit Perlin-Worley (chantier ciel 2026-07-17) :
+		/// génération CPU (CloudNoiseGenerator, ~centaines de ms, une fois au boot)
+		/// puis upload via staging + command pool transitoire sur \p uploadQueue.
 		/// \param sceneColorHDRFormat doit être VK_FORMAT_R16G16B16A16_SFLOAT.
 		/// \param vertSpirv/vertWordCount  SPIR-V du fullscreen triangle (lighting.vert.spv).
 		/// \param fragSpirv/fragWordCount  SPIR-V de clouds.frag.spv.
+		/// \param uploadQueue        Queue graphics pour l'upload one-shot des textures
+		///        de bruit (vkQueueWaitIdle interne — boot uniquement, jamais en frame).
+		/// \param uploadQueueFamilyIndex Famille de \p uploadQueue (command pool).
 		/// \param maxFrames frames en vol (un descriptor set par frame).
 		bool Init(VkDevice device, VkPhysicalDevice physicalDevice,
 			VkFormat sceneColorHDRFormat,
 			const uint32_t* vertSpirv, size_t vertWordCount,
 			const uint32_t* fragSpirv, size_t fragWordCount,
+			VkQueue uploadQueue, uint32_t uploadQueueFamilyIndex,
 			uint32_t maxFrames = 2,
 			VkPipelineCache pipelineCache = VK_NULL_HANDLE);
 
@@ -93,6 +100,16 @@ namespace engine::render
 		};
 		std::unordered_map<FramebufferKey, VkFramebuffer, FramebufferKeyHash> m_framebufferCache;
 
+		/// Chantier ciel 2026-07-17 — Crée une image 3D R8G8B8A8_UNORM de côté
+		/// \p size, y uploade \p rgba (size³×4 octets) via staging + command
+		/// buffer one-shot (submit + wait sur \p queue), et crée la vue 3D.
+		/// \return false (et log) au premier échec Vulkan ; les handles déjà
+		/// créés sont libérés par Destroy.
+		bool CreateNoiseTexture3D(VkDevice device, VkPhysicalDevice physicalDevice,
+			VkCommandPool cmdPool, VkQueue queue,
+			int size, const uint8_t* rgba,
+			VkImage& outImage, VkDeviceMemory& outMemory, VkImageView& outView);
+
 		VkRenderPass          m_renderPass          = VK_NULL_HANDLE;
 		VkDescriptorSetLayout m_descriptorSetLayout = VK_NULL_HANDLE;
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;
@@ -100,6 +117,15 @@ namespace engine::render
 		VkPipeline            m_pipeline            = VK_NULL_HANDLE;
 		VkSampler             m_linearSampler       = VK_NULL_HANDLE;
 		VkSampler             m_nearestSampler      = VK_NULL_HANDLE;
+		// Chantier ciel 2026-07-17 — textures 3D de bruit Perlin-Worley
+		// (base 64³ + détail 32³) et leur sampler linéaire REPEAT (tuilage).
+		VkImage        m_noiseBaseImage    = VK_NULL_HANDLE;
+		VkDeviceMemory m_noiseBaseMemory   = VK_NULL_HANDLE;
+		VkImageView    m_noiseBaseView     = VK_NULL_HANDLE;
+		VkImage        m_noiseDetailImage  = VK_NULL_HANDLE;
+		VkDeviceMemory m_noiseDetailMemory = VK_NULL_HANDLE;
+		VkImageView    m_noiseDetailView   = VK_NULL_HANDLE;
+		VkSampler      m_noiseSampler      = VK_NULL_HANDLE;
 		std::vector<VkDescriptorSet> m_descriptorSets;
 		uint32_t m_maxFrames = 2;
 	};

--- a/src/client/render/DeferredPipeline.cpp
+++ b/src/client/render/DeferredPipeline.cpp
@@ -342,8 +342,11 @@ namespace engine::render
 			std::vector<uint32_t> cloudFrag = loadSpirv("shaders/clouds.frag.spv");
 			if (!cloudVert.empty() && !cloudFrag.empty())
 			{
+				// Chantier ciel 2026-07-17 — la queue graphics sert à l'upload
+				// one-shot des textures 3D de bruit Perlin-Worley au boot.
 				if (m_cloudPass.Init(device, physicalDevice, VK_FORMAT_R16G16B16A16_SFLOAT,
 						cloudVert.data(), cloudVert.size(), cloudFrag.data(), cloudFrag.size(),
+						graphicsQueue, graphicsQueueFamilyIndex,
 						2u, pipelineCacheHandle))
 					LOG_INFO(Render, "[Boot] DeferredPipeline CloudPass OK");
 				else

--- a/src/client/render/clouds/CloudNoiseGenerator.cpp
+++ b/src/client/render/clouds/CloudNoiseGenerator.cpp
@@ -1,0 +1,251 @@
+// CloudNoiseGenerator — implémentation. Voir CloudNoiseGenerator.h.
+
+#include "src/client/render/clouds/CloudNoiseGenerator.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace engine::render::clouds
+{
+	namespace
+	{
+		/// Hash entier 3D + seed → 32 bits décorrélés. Déterministe et
+		/// identique sur toutes plateformes (uint32 wrap défini par la norme).
+		uint32_t Hash3(uint32_t x, uint32_t y, uint32_t z, uint32_t seed)
+		{
+			uint32_t h = x * 0x8da6b343u ^ y * 0xd8163841u ^ z * 0xcb1ab31fu
+				^ seed * 0x9e3779b9u;
+			h ^= h >> 13;
+			h *= 0x85ebca6bu;
+			h ^= h >> 16;
+			return h;
+		}
+
+		/// Extrait un flottant [0,1) des 24 bits hauts d'un hash.
+		float HashToFloat(uint32_t h)
+		{
+			return static_cast<float>(h >> 8) * (1.0f / 16777216.0f);
+		}
+
+		/// Modulo positif (les lattices périodiques wrappen des indices
+		/// potentiellement négatifs).
+		int WrapIndex(int v, int period)
+		{
+			const int m = v % period;
+			return (m < 0) ? m + period : m;
+		}
+
+		/// Fade quintique de Perlin (6t⁵-15t⁴+10t³).
+		float Fade(float t)
+		{
+			return t * t * t * (t * (t * 6.0f - 15.0f) + 10.0f);
+		}
+
+		/// Gradient de Perlin : une des 12 directions d'arêtes de cube,
+		/// choisie par le hash, projetée sur (fx, fy, fz).
+		float Grad(uint32_t h, float fx, float fy, float fz)
+		{
+			switch (h & 15u)
+			{
+				case 0:  return  fx + fy;
+				case 1:  return -fx + fy;
+				case 2:  return  fx - fy;
+				case 3:  return -fx - fy;
+				case 4:  return  fx + fz;
+				case 5:  return -fx + fz;
+				case 6:  return  fx - fz;
+				case 7:  return -fx - fz;
+				case 8:  return  fy + fz;
+				case 9:  return -fy + fz;
+				case 10: return  fy - fz;
+				case 11: return -fy - fz;
+				case 12: return  fx + fy;
+				case 13: return -fx + fy;
+				case 14: return -fy + fz;
+				default: return -fy - fz;
+			}
+		}
+
+		/// Bruit de Perlin 3D périodique, valeur ~[-1,1].
+		float TileablePerlin(float x, float y, float z, int period, uint32_t seed)
+		{
+			const float px = x * static_cast<float>(period);
+			const float py = y * static_cast<float>(period);
+			const float pz = z * static_cast<float>(period);
+			const int ix = static_cast<int>(std::floor(px));
+			const int iy = static_cast<int>(std::floor(py));
+			const int iz = static_cast<int>(std::floor(pz));
+			const float fx = px - static_cast<float>(ix);
+			const float fy = py - static_cast<float>(iy);
+			const float fz = pz - static_cast<float>(iz);
+
+			const float u = Fade(fx);
+			const float v = Fade(fy);
+			const float w = Fade(fz);
+
+			// Hash des 8 coins du cube, indices wrappés sur la période.
+			auto corner = [&](int dx, int dy, int dz)
+			{
+				return Hash3(
+					static_cast<uint32_t>(WrapIndex(ix + dx, period)),
+					static_cast<uint32_t>(WrapIndex(iy + dy, period)),
+					static_cast<uint32_t>(WrapIndex(iz + dz, period)),
+					seed);
+			};
+			const float n000 = Grad(corner(0, 0, 0), fx,        fy,        fz);
+			const float n100 = Grad(corner(1, 0, 0), fx - 1.0f, fy,        fz);
+			const float n010 = Grad(corner(0, 1, 0), fx,        fy - 1.0f, fz);
+			const float n110 = Grad(corner(1, 1, 0), fx - 1.0f, fy - 1.0f, fz);
+			const float n001 = Grad(corner(0, 0, 1), fx,        fy,        fz - 1.0f);
+			const float n101 = Grad(corner(1, 0, 1), fx - 1.0f, fy,        fz - 1.0f);
+			const float n011 = Grad(corner(0, 1, 1), fx,        fy - 1.0f, fz - 1.0f);
+			const float n111 = Grad(corner(1, 1, 1), fx - 1.0f, fy - 1.0f, fz - 1.0f);
+
+			const float nx00 = n000 + u * (n100 - n000);
+			const float nx10 = n010 + u * (n110 - n010);
+			const float nx01 = n001 + u * (n101 - n001);
+			const float nx11 = n011 + u * (n111 - n011);
+			const float nxy0 = nx00 + v * (nx10 - nx00);
+			const float nxy1 = nx01 + v * (nx11 - nx01);
+			return nxy0 + w * (nxy1 - nxy0);
+		}
+
+		/// Quantifie [0,1] → octet.
+		uint8_t ToByte(float v)
+		{
+			const float c = std::clamp(v, 0.0f, 1.0f);
+			return static_cast<uint8_t>(c * 255.0f + 0.5f);
+		}
+	}
+
+	float TileableWorley(float x, float y, float z, int cells, uint32_t seed)
+	{
+		// Coordonnées en unités de cellule ; wrap sur [0, cells).
+		const float cx = (x - std::floor(x)) * static_cast<float>(cells);
+		const float cy = (y - std::floor(y)) * static_cast<float>(cells);
+		const float cz = (z - std::floor(z)) * static_cast<float>(cells);
+		const int ix = static_cast<int>(cx);
+		const int iy = static_cast<int>(cy);
+		const int iz = static_cast<int>(cz);
+
+		float minDistSq = 1e9f;
+		for (int dz = -1; dz <= 1; ++dz)
+		{
+			for (int dy = -1; dy <= 1; ++dy)
+			{
+				for (int dx = -1; dx <= 1; ++dx)
+				{
+					// Cellule voisine (indices wrap pour la périodicité) ; le
+					// point caractéristique vit dans la cellule NON wrappée
+					// (position continue), son offset vient du hash wrappé.
+					const int nx = ix + dx;
+					const int ny = iy + dy;
+					const int nz = iz + dz;
+					const uint32_t h = Hash3(
+						static_cast<uint32_t>(WrapIndex(nx, cells)),
+						static_cast<uint32_t>(WrapIndex(ny, cells)),
+						static_cast<uint32_t>(WrapIndex(nz, cells)),
+						seed);
+					const float ox = HashToFloat(h);
+					const float oy = HashToFloat(Hash3(h, 0x27d4eb2fu, 0x165667b1u, seed));
+					const float oz = HashToFloat(Hash3(h, 0x85ebca6bu, 0xc2b2ae35u, seed));
+					const float px = static_cast<float>(nx) + ox;
+					const float py = static_cast<float>(ny) + oy;
+					const float pz = static_cast<float>(nz) + oz;
+					const float ddx = px - cx;
+					const float ddy = py - cy;
+					const float ddz = pz - cz;
+					const float d2 = ddx * ddx + ddy * ddy + ddz * ddz;
+					minDistSq = std::min(minDistSq, d2);
+				}
+			}
+		}
+		// Distance (en unités de cellule) au point caractéristique le plus
+		// proche, clampée puis inversée : 1 SUR un point, 0 loin de tout —
+		// donne les « boules cotonneuses » attendues pour des cumulus.
+		const float d = std::sqrt(minDistSq);
+		return 1.0f - std::clamp(d, 0.0f, 1.0f);
+	}
+
+	float TileablePerlinFbm(float x, float y, float z, int basePeriod,
+		int octaves, uint32_t seed)
+	{
+		float sum = 0.0f;
+		float amp = 0.5f;
+		float norm = 0.0f;
+		int period = basePeriod;
+		for (int i = 0; i < std::max(octaves, 1); ++i)
+		{
+			// Fréquence ET période doublent : chaque octave reste périodique
+			// sur [0,1) → la somme tuile.
+			sum += amp * TileablePerlin(x, y, z, period,
+				seed + static_cast<uint32_t>(i) * 0x68e31da4u);
+			norm += amp;
+			amp *= 0.5f;
+			period *= 2;
+		}
+		// Normalise ~[-1,1] → [0,1].
+		const float n = (norm > 0.0f) ? sum / norm : 0.0f;
+		return std::clamp(n * 0.5f + 0.5f, 0.0f, 1.0f);
+	}
+
+	CloudNoiseData GenerateCloudNoise(uint32_t seed)
+	{
+		CloudNoiseData out;
+
+		// -- Texture de base 64³ : R = Perlin fBm, G/B/A = Worley 8/16/32. --
+		{
+			const int s = kBaseNoiseSize;
+			out.baseRgba.resize(static_cast<size_t>(s) * s * s * 4u);
+			size_t idx = 0;
+			for (int z = 0; z < s; ++z)
+			{
+				const float fz = (static_cast<float>(z) + 0.5f) / static_cast<float>(s);
+				for (int y = 0; y < s; ++y)
+				{
+					const float fy = (static_cast<float>(y) + 0.5f) / static_cast<float>(s);
+					for (int x = 0; x < s; ++x)
+					{
+						const float fx = (static_cast<float>(x) + 0.5f) / static_cast<float>(s);
+						out.baseRgba[idx++] = ToByte(
+							TileablePerlinFbm(fx, fy, fz, 4, 4, seed));
+						out.baseRgba[idx++] = ToByte(
+							TileableWorley(fx, fy, fz, 8, seed ^ 0xA341316Cu));
+						out.baseRgba[idx++] = ToByte(
+							TileableWorley(fx, fy, fz, 16, seed ^ 0xC8013EA4u));
+						out.baseRgba[idx++] = ToByte(
+							TileableWorley(fx, fy, fz, 32, seed ^ 0xAD90777Du));
+					}
+				}
+			}
+		}
+
+		// -- Texture de détail 32³ : R/G/B = Worley 4/8/16, A = 255. --------
+		{
+			const int s = kDetailNoiseSize;
+			out.detailRgba.resize(static_cast<size_t>(s) * s * s * 4u);
+			size_t idx = 0;
+			for (int z = 0; z < s; ++z)
+			{
+				const float fz = (static_cast<float>(z) + 0.5f) / static_cast<float>(s);
+				for (int y = 0; y < s; ++y)
+				{
+					const float fy = (static_cast<float>(y) + 0.5f) / static_cast<float>(s);
+					for (int x = 0; x < s; ++x)
+					{
+						const float fx = (static_cast<float>(x) + 0.5f) / static_cast<float>(s);
+						out.detailRgba[idx++] = ToByte(
+							TileableWorley(fx, fy, fz, 4, seed ^ 0x7B16763Bu));
+						out.detailRgba[idx++] = ToByte(
+							TileableWorley(fx, fy, fz, 8, seed ^ 0x2F2C58C1u));
+						out.detailRgba[idx++] = ToByte(
+							TileableWorley(fx, fy, fz, 16, seed ^ 0x91E10DA5u));
+						out.detailRgba[idx++] = 255u;
+					}
+				}
+			}
+		}
+
+		return out;
+	}
+}

--- a/src/client/render/clouds/CloudNoiseGenerator.h
+++ b/src/client/render/clouds/CloudNoiseGenerator.h
@@ -1,0 +1,53 @@
+#pragma once
+// CloudNoiseGenerator — génération CPU des textures 3D de bruit des nuages
+// volumétriques (chantier ciel 2026-07-17, spec docs/superpowers/specs/
+// 2026-07-17-sky-clouds-upgrade-design.md, PR A).
+//
+// Remplace le value-noise FBM calculé in-shader (clouds.frag historique) par
+// des textures pré-calculées type Schneider (« The Real-Time Volumetric
+// Cloudscapes of Horizon Zero Dawn ») :
+//   - base 64³ RGBA8 : R = fBm de Perlin, G/B/A = Worley 8/16/32 cellules ;
+//   - détail 32³ RGBA8 : R/G/B = Worley 4/8/16 cellules (érosion des bords).
+// Tous les bruits sont PÉRIODIQUES (la texture tuile sans couture, sampler
+// REPEAT) et DÉTERMINISTES (hash entier maison — aucun rand()).
+//
+// Module 100 % CPU, sans dépendance Vulkan/ImGui : testable sous ctest
+// Linux (cloud_noise_generator_tests).
+
+#include <cstdint>
+#include <vector>
+
+namespace engine::render::clouds
+{
+	/// Côté (texels par axe) de la texture 3D de forme de base.
+	inline constexpr int kBaseNoiseSize = 64;
+	/// Côté (texels par axe) de la texture 3D d'érosion de détail.
+	inline constexpr int kDetailNoiseSize = 32;
+
+	/// Textures générées, prêtes à uploader en R8G8B8A8_UNORM.
+	struct CloudNoiseData
+	{
+		/// kBaseNoiseSize³ × 4 octets (R=Perlin fBm, G/B/A=Worley 8/16/32).
+		std::vector<uint8_t> baseRgba;
+		/// kDetailNoiseSize³ × 4 octets (R/G/B=Worley 4/8/16, A=255).
+		std::vector<uint8_t> detailRgba;
+	};
+
+	/// Bruit de Worley 3D périodique « inversé » (1 au centre des cellules,
+	/// 0 aux frontières) — aspect cotonneux. \param x,y,z coordonnées
+	/// normalisées (période 1 : f(x)==f(x+1)). \param cells nombre de
+	/// cellules par axe. \return valeur dans [0,1]. Pur, thread-safe.
+	float TileableWorley(float x, float y, float z, int cells, uint32_t seed);
+
+	/// fBm de Perlin 3D périodique. \param basePeriod période de la première
+	/// octave (en cellules) ; chaque octave double fréquence ET période
+	/// (le tuilage est préservé). \param octaves nombre d'octaves (≥1).
+	/// \return valeur normalisée ~[0,1]. Pur, thread-safe.
+	float TileablePerlinFbm(float x, float y, float z, int basePeriod,
+		int octaves, uint32_t seed);
+
+	/// Génère les deux textures. Déterministe pour un seed donné (mêmes
+	/// octets sur toutes plateformes). Coût : quelques centaines de ms
+	/// (appelée une fois au boot par CloudPass::Init, hors boucle frame).
+	CloudNoiseData GenerateCloudNoise(uint32_t seed);
+}

--- a/src/client/render/clouds/CloudNoiseGeneratorTests.cpp
+++ b/src/client/render/clouds/CloudNoiseGeneratorTests.cpp
@@ -1,0 +1,127 @@
+/// Tests unitaires CPU du générateur de bruit des nuages volumétriques
+/// (chantier ciel 2026-07-17, PR A).
+///
+/// Pas de Vulkan ni de GPU — la suite tourne sous ctest Linux. On vérifie :
+///   - Déterminisme : même seed → mêmes octets ; seeds différents → données
+///     différentes.
+///   - Périodicité : TileableWorley et TileablePerlinFbm valent la même
+///     chose en x et x+1 (le sampler REPEAT exige un tuilage sans couture).
+///   - Tailles/format des textures générées.
+///   - Distribution non dégénérée (ni constante, ni saturée).
+///
+/// Framework : REQUIRE maison + main monolithique (pattern des autres
+/// suites du repo).
+
+#include "src/client/render/clouds/CloudNoiseGenerator.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdint>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::render::clouds::CloudNoiseData;
+	using engine::render::clouds::GenerateCloudNoise;
+	using engine::render::clouds::kBaseNoiseSize;
+	using engine::render::clouds::kDetailNoiseSize;
+	using engine::render::clouds::TileablePerlinFbm;
+	using engine::render::clouds::TileableWorley;
+
+	/// Test : tailles et format des textures générées.
+	void Test_Generate_SizesAndFormat()
+	{
+		const CloudNoiseData data = GenerateCloudNoise(42u);
+		const size_t baseExpected =
+			static_cast<size_t>(kBaseNoiseSize) * kBaseNoiseSize * kBaseNoiseSize * 4u;
+		const size_t detailExpected =
+			static_cast<size_t>(kDetailNoiseSize) * kDetailNoiseSize * kDetailNoiseSize * 4u;
+		REQUIRE(data.baseRgba.size() == baseExpected);
+		REQUIRE(data.detailRgba.size() == detailExpected);
+		// Canal A du détail : opaque constant (non utilisé par le shader).
+		REQUIRE(data.detailRgba[3] == 255u);
+	}
+
+	/// Test : déterminisme — même seed → octets identiques ; seed différent
+	/// → au moins un octet différent.
+	void Test_Generate_Deterministic()
+	{
+		const CloudNoiseData a = GenerateCloudNoise(1234u);
+		const CloudNoiseData b = GenerateCloudNoise(1234u);
+		REQUIRE(a.baseRgba == b.baseRgba);
+		REQUIRE(a.detailRgba == b.detailRgba);
+
+		const CloudNoiseData c = GenerateCloudNoise(9999u);
+		REQUIRE(a.baseRgba != c.baseRgba);
+	}
+
+	/// Test : périodicité des bruits — f(x) == f(x+1) (à epsilon flottant
+	/// près) sur un échantillon de points, pour chaque axe.
+	void Test_Noises_AreTileable()
+	{
+		const float kEps = 1e-4f;
+		const float pts[][3] = {
+			{ 0.13f, 0.57f, 0.91f },
+			{ 0.02f, 0.98f, 0.50f },
+			{ 0.77f, 0.31f, 0.05f },
+		};
+		for (const auto& p : pts)
+		{
+			const float w0 = TileableWorley(p[0], p[1], p[2], 8, 7u);
+			REQUIRE(std::fabs(w0 - TileableWorley(p[0] + 1.0f, p[1], p[2], 8, 7u)) < kEps);
+			REQUIRE(std::fabs(w0 - TileableWorley(p[0], p[1] + 1.0f, p[2], 8, 7u)) < kEps);
+			REQUIRE(std::fabs(w0 - TileableWorley(p[0], p[1], p[2] + 1.0f, 8, 7u)) < kEps);
+
+			const float n0 = TileablePerlinFbm(p[0], p[1], p[2], 4, 4, 7u);
+			REQUIRE(std::fabs(n0 - TileablePerlinFbm(p[0] + 1.0f, p[1], p[2], 4, 4, 7u)) < kEps);
+			REQUIRE(std::fabs(n0 - TileablePerlinFbm(p[0], p[1] + 1.0f, p[2], 4, 4, 7u)) < kEps);
+			REQUIRE(std::fabs(n0 - TileablePerlinFbm(p[0], p[1], p[2] + 1.0f, 4, 4, 7u)) < kEps);
+		}
+	}
+
+	/// Test : distribution non dégénérée du canal R (forme de base) — ni
+	/// constante ni saturée : min/max écartés, moyenne dans une plage large.
+	void Test_Generate_NonDegenerateDistribution()
+	{
+		const CloudNoiseData data = GenerateCloudNoise(42u);
+		uint8_t mn = 255u, mx = 0u;
+		uint64_t sum = 0u;
+		size_t count = 0u;
+		for (size_t i = 0; i < data.baseRgba.size(); i += 4u)
+		{
+			const uint8_t r = data.baseRgba[i];
+			mn = (r < mn) ? r : mn;
+			mx = (r > mx) ? r : mx;
+			sum += r;
+			++count;
+		}
+		REQUIRE(count > 0u);
+		const double mean = static_cast<double>(sum) / static_cast<double>(count);
+		REQUIRE(mx - mn > 60);           // vraie dynamique
+		REQUIRE(mean > 40.0 && mean < 215.0); // ni noir ni blanc uniforme
+	}
+}
+
+int main()
+{
+	Test_Generate_SizesAndFormat();
+	Test_Generate_Deterministic();
+	Test_Noises_AreTileable();
+	Test_Generate_NonDegenerateDistribution();
+
+	if (g_failed > 0)
+	{
+		std::fprintf(stderr, "[CloudNoiseGeneratorTests] %d failure(s)\n", g_failed);
+		return 1;
+	}
+	std::fprintf(stdout, "[CloudNoiseGeneratorTests] all tests passed\n");
+	return 0;
+}


### PR DESCRIPTION
## Contexte

Chantier ciel (comparatif UE 5.8 — point de depart de toute la serie UI/rendu). Le levier n1 identifie : la QUALITE DU BRUIT des nuages. Le value-noise FBM calcule in-shader (PR #853) donne des nuages mous/patateux ; UE utilise des textures 3D Perlin-Worley pre-cuites + erosion de detail.

PR **independante** de la PR Ciel B (ciel analytique, fichiers disjoints) — mergeables dans n''importe quel ordre.

Spec : `docs/superpowers/specs/2026-07-17-sky-clouds-upgrade-design.md`

## Contenu

- **CloudNoiseGenerator** (CPU pur, `src/client/render/clouds/`) : bruit de Worley 3D **periodique** (points caracteristiques, 27 voisins avec wrap, inverse → cotonneux) + **fBm de Perlin periodique** (gradients sur lattice wrap, fade quintique). Deterministe (hash entier maison). Genere : base 64³ RGBA (R=Perlin fBm, G/B/A=Worley 8/16/32 cellules) + detail 32³ (Worley 4/8/16).
- **CloudPass** : generation + upload one-shot au boot (staging + command pool transitoire sur la queue graphics, ~centaines de ms logees), 2 images 3D R8G8B8A8_UNORM, sampler lineaire REPEAT (tuilage sans couture), descriptor set layout 2 → 4 bindings. Echec de creation → passe desactivee proprement (meme passthrough qu''un shader manquant).
- **clouds.frag** : la forme de base devient la **dilatation Schneider** `remap(perlinFbm, worleyFbm-1, 1, 0, 1)` sur la texture (tuile ~5,2 km), seuil pilote par le coverage meteo (API CPU inchangee), **erosion de detail** (tuile ~800 m) effilochee en bas / cotonneuse en haut du nuage. Push constants inchanges (192 o) → zero impact sur WeatherSystem/DayNightCycle.

## Tests

- `cloud_noise_generator_tests` (ctest Linux) : determinisme par seed, **periodicite** f(x)==f(x+1) sur les 3 axes (exigence du sampler REPEAT), tailles/format, distribution non degeneree.
- Shaders compiles au runtime (glslangValidator) : non couverts par la CI → **validation visuelle en jeu requise** (verifier au passage le log boot `CloudPass: bruit Perlin-Worley genere+uploade en N ms`).

## Deploiement

**Deploiement** : ✅ client uniquement, pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)