### PR TITLE
feat(render): capture IBL alignee sur le ciel analytique (lot 2)

### DIFF
--- a/game/data/shaders/sky_capture.comp
+++ b/game/data/shaders/sky_capture.comp
@@ -24,7 +24,7 @@ layout(binding = 0, rgba16f) writeonly uniform image2D uOut;
 layout(push_constant, std430) uniform PC {
 	uint  face;
 	uint  faceSize;
-	float pad0;
+	float skyModel;      // lot 2 (2026-07-18) : 0 = dégradé legacy, 1 = analytique
 	float pad1;
 	vec4  lightDir;
 	vec4  zenithColor;
@@ -32,6 +32,89 @@ layout(push_constant, std430) uniform PC {
 	vec4  moonDir;
 	vec4  moonParams;
 } pc;
+
+// -------------------------------------------------------------------------
+// Ciel analytique (lot 2, 2026-07-18) — MÊME modèle que sky.frag (diffusion
+// simple Rayleigh + Mie, 8×4 échantillons, constantes physiques Terre) :
+// l'ambiance IBL (prefilter spéculaire + irradiance) reste alignée sur le
+// ciel réellement affiché quand client.sky.analytic est actif.
+// -------------------------------------------------------------------------
+const float kPi       = 3.14159265358979;
+const float kPlanetR  = 6360.0e3;
+const float kAtmoR    = 6420.0e3;
+const vec3  kBetaR    = vec3(5.8e-6, 13.5e-6, 33.1e-6);
+const float kBetaM    = 21.0e-6;
+const float kHR       = 8000.0;
+const float kHM       = 1200.0;
+
+float RaySphereFar(vec3 o, vec3 d, float r)
+{
+	float b = dot(o, d);
+	float c = dot(o, o) - r * r;
+	float disc = b * b - c;
+	if (disc < 0.0) return -1.0;
+	return -b + sqrt(disc);
+}
+
+vec3 AnalyticSky(vec3 viewDir, vec3 sunDir)
+{
+	vec3 o = vec3(0.0, kPlanetR + 200.0, 0.0);
+	vec3 d = normalize(vec3(viewDir.x, max(viewDir.y, -0.03), viewDir.z));
+	float tMax = RaySphereFar(o, d, kAtmoR);
+	if (tMax <= 0.0) return vec3(0.0);
+
+	float mu = dot(d, sunDir);
+	float phaseR = 3.0 / (16.0 * kPi) * (1.0 + mu * mu);
+	const float g = 0.76;
+	float phaseM = 3.0 / (8.0 * kPi) * ((1.0 - g * g) * (1.0 + mu * mu))
+		/ ((2.0 + g * g) * pow(1.0 + g * g - 2.0 * g * mu, 1.5));
+
+	const int kSteps      = 8;
+	const int kLightSteps = 4;
+	float dt = tMax / float(kSteps);
+	float t  = 0.5 * dt;
+	vec3  sumR = vec3(0.0);
+	vec3  sumM = vec3(0.0);
+	float odR = 0.0;
+	float odM = 0.0;
+	for (int i = 0; i < kSteps; ++i)
+	{
+		vec3 p = o + d * t;
+		float h = max(length(p) - kPlanetR, 0.0);
+		float dR = exp(-h / kHR) * dt;
+		float dM = exp(-h / kHM) * dt;
+		odR += dR;
+		odM += dM;
+
+		float tSun = RaySphereFar(p, sunDir, kAtmoR);
+		float sdt = tSun / float(kLightSteps);
+		float st = 0.5 * sdt;
+		float sOdR = 0.0;
+		float sOdM = 0.0;
+		bool inShadow = (tSun <= 0.0);
+		for (int j = 0; j < kLightSteps && !inShadow; ++j)
+		{
+			vec3 sp = p + sunDir * st;
+			float sh = length(sp) - kPlanetR;
+			if (sh < 0.0) { inShadow = true; break; }
+			sOdR += exp(-sh / kHR) * sdt;
+			sOdM += exp(-sh / kHM) * sdt;
+			st += sdt;
+		}
+		if (!inShadow)
+		{
+			vec3 tau = kBetaR * (odR + sOdR) + vec3(kBetaM * 1.1) * (odM + sOdM);
+			vec3 att = exp(-tau);
+			sumR += att * dR;
+			sumM += att * dM;
+		}
+		t += dt;
+	}
+
+	const float kSunIntensity = 20.0;
+	vec3 col = kSunIntensity * (sumR * kBetaR * phaseR + sumM * vec3(kBetaM) * phaseM);
+	return max(col, vec3(0.0015, 0.002, 0.0045));
+}
 
 // (face 0..5, u,v in [-1,1]) -> direction from cube center.
 // Copié À L'IDENTIQUE depuis specular_prefilter.comp (orientation cohérente).
@@ -136,13 +219,22 @@ void main()
 	vec3 zenithColor  = pc.zenithColor.xyz;
 	vec3 horizonColor = pc.horizonColor.xyz;
 
-	// ---- Sky gradient via view-zenith angle ---------------------------------
-	// viewDir.y is the sine of the elevation angle.
-	float t = clamp(viewDir.y, 0.0, 1.0);
-
-	// Rayleigh approximation: non-linear blend (slightly exponential).
-	float blendFactor = pow(t, 0.6);
-	vec3 skyColor = mix(horizonColor, zenithColor, blendFactor);
+	// ---- Fond de ciel : analytique OU dégradé legacy ------------------------
+	// Lot 2 (2026-07-18) : même bascule que sky.frag (pc.skyModel, alimenté
+	// par client.sky.analytic côté Engine).
+	vec3 skyColor;
+	if (pc.skyModel > 0.5)
+	{
+		skyColor = AnalyticSky(viewDir, normalize(lightDir));
+	}
+	else
+	{
+		// Dégradé legacy via l'angle vue-zénith (pow(t,0.6) élargit
+		// la bande d'horizon).
+		float t = clamp(viewDir.y, 0.0, 1.0);
+		float blendFactor = pow(t, 0.6);
+		skyColor = mix(horizonColor, zenithColor, blendFactor);
+	}
 
 	// ---- Mie-scatter-like sun glow ------------------------------------------
 	float sunDot = max(dot(viewDir, lightDir), 0.0);

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4279,6 +4279,10 @@ namespace engine
 											iblSky.moonIntensity    = dnIbl.isDaytime ? 0.0f : 1.0f;
 											iblSky.moonPhase        = static_cast<float>(dnIbl.moonPhase);
 											iblSky.moonIllumination = dnIbl.moonIllumination;
+											// Lot 2 (2026-07-18) — la capture IBL suit le même
+											// modèle de ciel que sky.frag (client.sky.analytic).
+											iblSky.skyModel =
+												m_cfg.GetBool("client.sky.analytic", true) ? 1.0f : 0.0f;
 										}
 
 										bool pipelineOk = m_pipeline->Init(
@@ -8608,6 +8612,8 @@ namespace engine
 			iblSky.moonIntensity    = dn.isDaytime ? 0.0f : 1.0f;
 			iblSky.moonPhase        = static_cast<float>(dn.moonPhase);
 			iblSky.moonIllumination = dn.moonIllumination;
+			// Lot 2 (2026-07-18) — même modèle de ciel que sky.frag.
+			iblSky.skyModel = m_cfg.GetBool("client.sky.analytic", true) ? 1.0f : 0.0f;
 			m_pipeline->RegenerateIbl(m_vkDeviceContext.GetDevice(),
 			                          m_vkDeviceContext.GetGraphicsQueue(), iblSky);
 			m_iblRegenTimer = 0.0f;

--- a/src/client/render/SkyCubeCapturePass.cpp
+++ b/src/client/render/SkyCubeCapturePass.cpp
@@ -343,7 +343,10 @@ namespace engine::render
 		// Construit le push-constant miroir std430 depuis les paramètres ciel.
 		SkyCapturePushConstants pc{};
 		pc.faceSize = m_faceSize;
-		pc.pad0 = 0.0f;
+		// Lot 2 (2026-07-18) — pad0 transporte le sélecteur de modèle de
+		// ciel (0 = dégradé legacy, 1 = analytique) : taille/layout du push
+		// constant inchangés (96 o), miroir du champ `skyModel` du .comp.
+		pc.pad0 = params.skyModel;
 		pc.pad1 = 0.0f;
 		pc.lightDir[0] = params.lightDir[0];
 		pc.lightDir[1] = params.lightDir[1];

--- a/src/client/render/SkyCubeCapturePass.h
+++ b/src/client/render/SkyCubeCapturePass.h
@@ -22,6 +22,12 @@ namespace engine::render
 		float moonIntensity   = 0.0f;
 		float moonPhase       = 0.0f;
 		float moonIllumination = 0.0f;
+		/// Chantier ciel 2026-07-18 (lot 2) — sélecteur de modèle de ciel
+		/// pour la capture IBL : 0 = dégradé legacy, 1 = diffusion
+		/// analytique Rayleigh+Mie (même modèle que sky.frag). Rempli par
+		/// l'Engine depuis `client.sky.analytic` : l'ambiance IBL reste
+		/// alignée sur le ciel réellement affiché.
+		float skyModel        = 0.0f;
 	};
 
 	/// SkyCubeCapturePass (IBL) : capture le ciel procédural dans une cubemap


### PR DESCRIPTION
## Contenu

L'eclairage ambiant IBL (cubemap ciel → prefilter speculaire + irradiance) utilisait encore le degrade legacy alors que le ciel affiche est analytique depuis #982. Cette PR porte le MEME modele Rayleigh+Mie dans `sky_capture.comp` :

- bascule `skyModel` transportee par le pad du push constant (96 o et layout inchanges) ;
- `SkyCaptureParams::skyModel` rempli par l'Engine depuis `client.sky.analytic` aux 2 sites (boot + regeneration periodique jour/nuit) → l'ambiance reflechie sur les objets suit le ciel reel a toute heure ;
- `client.sky.analytic=false` realigne TOUT (fond + IBL) sur le legacy, comme avant.

## Validation

Compute compile au runtime → en jeu, verifier que la teinte ambiante des objets (surtout metaux/surfaces claires) suit les couleurs du ciel au fil de la journee, sans a-coups aux regenerations (log `SkyCubeCapturePass: sky cubemap captured`).

**Deploiement** : ✅ client uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)