### PR TITLE
perf(render): nuages en demi-resolution + composite pleine resolution (lot 1)

### DIFF
--- a/config.json
+++ b/config.json
@@ -64,7 +64,9 @@
             "_comment_fade": "fade_distance_m : distance (m) de début d'estompage des nuages lointains (perspective aérienne). Évite le mur blanc à l'horizon ; baisser (1500) pour dégager plus l'horizon, monter (5000) pour des nuages visibles plus loin. 0 = désactivé.",
             "fade_distance_m": 2500.0,
             "_comment_maxlum": "max_luminance : plafond de luminosité des nuages. Empêche le flamboiement en gros blobs blancs quand on regarde vers le soleil. Baisser (1.0, 0.8) si encore trop éclatant ; 0 = pas de plafond.",
-            "max_luminance": 1.3
+            "max_luminance": 1.3,
+            "_comment_resdiv": "resolution_divider : la marche des nuages tourne en résolution réduite (1 = pleine, 2 = demi, 4 = quart) puis est upsamplée bilinéairement. 2 = ~x4 moins de fragments marchés, quasi sans perte visuelle (nuages = basses fréquences). Lu au boot (rebuild du frame graph requis).",
+            "resolution_divider": 2
         },
         "auth_ui": {
             "background_path": "ui/login/background.png",

--- a/game/data/shaders/clouds.frag
+++ b/game/data/shaders/clouds.frag
@@ -77,8 +77,14 @@ float cloudDensity(vec3 p)
 
 	// Seuil de couverture : coverage 0 -> ciel quasi vide, 1 -> couvert.
 	// Plage choisie pour la distribution du baseShape remappé (moyenne ~0.5).
+	// Fix crépuscule 2026-07-18 — variation basse fréquence anti-répétition :
+	// vu de loin (rayons rasants), le motif 5,2 km se répétait visiblement
+	// (retour utilisateur, capture crépuscule). On module le seuil par un
+	// échantillon très basse fréquence (~tuile 40 km, décalé) : les paquets
+	// de nuages varient d'une tuile à l'autre, la répétition disparaît.
 	float coverage = pc.sunDir.w;
-	float threshold = mix(0.72, 0.28, coverage);
+	float covVar = texture(uNoiseBase, sp * 0.13 + vec3(0.17, 0.0, 0.31)).g;
+	float threshold = mix(0.72, 0.28, coverage) + (covVar - 0.5) * 0.16;
 	float d = smoothstep(threshold, threshold + 0.14, baseShape);
 
 	// Érosion de détail : texture 32³ tuilée sur ~800 m. Bords effilochés
@@ -200,9 +206,21 @@ void main()
 	float transmittance = 1.0;
 	vec3  scattered     = vec3(0.0);
 
-	vec3 sunCol = pc.sunColor.rgb;
-	// Ambiant : moyenne des teintes ciel (déjà colorées par l'apparence météo).
+	// Fix crépuscule 2026-07-18 — facteur jour continu (1 = soleil haut,
+	// 0 = nuit, transition douce autour de l'horizon). Le DayNightCycle
+	// bascule sunColor vers ~0.02 dès le coucher alors que le ciel
+	// analytique reste lumineux (crépuscule) : les nuages devenaient des
+	// silhouettes NOIRES sur fond mauve (retour utilisateur, capture).
+	float dayFactor = smoothstep(-0.08, 0.12, sun.y);
+	// Couleur « soleil » effective : soleil le jour, clair de lune bleuté
+	// la nuit (les nuages nocturnes restent lisibles, jamais noirs).
+	vec3 sunCol = pc.sunColor.rgb * dayFactor
+		+ vec3(0.10, 0.12, 0.18) * (1.0 - dayFactor);
+	// Ambiant : moyenne des teintes ciel (déjà colorées par l'apparence météo)
+	// + plancher crépuscule/nuit pour rester cohérent avec le fond analytique
+	// encore lumineux après le coucher.
 	vec3 skyAmb = mix(pc.horizonColor.rgb, pc.zenithColor.rgb, 0.5) * pc.stepParams.w;
+	skyAmb = max(skyAmb, vec3(0.045, 0.05, 0.07) * (1.0 - dayFactor));
 
 	for (int i = 0; i < steps; ++i)
 	{
@@ -210,15 +228,19 @@ void main()
 		float dens = cloudDensity(p);
 		if (dens > 0.001)
 		{
-			// Transmittance vers le soleil (marche courte).
+			// Transmittance vers le soleil (marche courte). Perf 2026-07-18 :
+			// sautée la nuit (le soleil sous l'horizon n'éclaire plus la
+			// dalle — la marche coûtait ~lightSteps échantillons par point
+			// pour rien) et coupée dès que l'auto-ombrage sature (< 0.05).
 			float lt = 0.0;
 			float lightTrans = 1.0;
 			float ldt = (topAlt - baseAlt) / float(max(lightSteps, 1));
-			for (int j = 0; j < lightSteps; ++j)
+			for (int j = 0; j < lightSteps && dayFactor > 0.02; ++j)
 			{
 				lt += ldt;
 				float ld = cloudDensity(p + sun * lt);
 				lightTrans *= exp(-ld * ldt * 0.02);
+				if (lightTrans < 0.05) break;
 			}
 			// Powder (auto-ombrage des bords).
 			float powder = 1.0 - exp(-dens * 2.0);

--- a/game/data/shaders/clouds.frag
+++ b/game/data/shaders/clouds.frag
@@ -6,25 +6,28 @@
 // horizontale [baseAlt, topAlt], accumule densité (textures 3D Perlin-Worley
 // pré-cuites, chantier ciel 2026-07-17 — ex-bruit FBM in-shader) et
 // éclairage (Beer + Powder + phase Henyey-Greenstein vers le soleil), puis
-// composite par-dessus la scène déjà brouillardée. Le depth scène borne la
-// marche (un relief proche occulte les nuages).
+// écrit le résultat PRÉ-MULTIPLIÉ dans une cible RÉDUITE (lot 1,
+// 2026-07-18) que clouds_composite.frag upsample et compose sur la scène.
+// Le depth scène borne la marche (un relief proche occulte les nuages).
 //
 // Entrées (descriptor set 0) :
-//   binding 0 = scene color HDR post-fog (sampler linéaire clamp)
+//   binding 0 = réservé (l'ex-scene color ; plus échantillonné depuis le
+//               passage en cible réduite — la composition est faite par
+//               clouds_composite.frag en pleine résolution)
 //   binding 1 = depth scene (D32_SFLOAT, sampler nearest clamp, lu en .r)
 //   binding 2 = bruit 3D base 64³ (R=Perlin fBm, G/B/A=Worley 8/16/32,
 //               sampler linéaire REPEAT) — chantier ciel 2026-07-17
 //   binding 3 = bruit 3D détail 32³ (R/G/B=Worley 4/8/16, REPEAT)
 //
-// Sortie :
-//   outColor (location 0) — scene + nuages composités.
+// Sortie (cible réduite RGBA16F) :
+//   rgb = couleur nuages pré-multipliée (scattered * fade)
+//   a   = visibilité scène = (1 - opacité nuages) * ombre de nuages au sol
 //
 // Push constants (192 octets, fragment) — cf. CloudPushConstants (CloudPass.h).
 
 layout(location = 0) in  vec2 inUV;
 layout(location = 0) out vec4 outColor;
 
-layout(set = 0, binding = 0) uniform sampler2D uSceneColor; // HDR post-fog
 layout(set = 0, binding = 1) uniform sampler2D uSceneDepth; // depth, .r = [0,1]
 layout(set = 0, binding = 2) uniform sampler3D uNoiseBase;   // Perlin-Worley base
 layout(set = 0, binding = 3) uniform sampler3D uNoiseDetail; // Worley détail
@@ -97,9 +100,7 @@ float cloudDensity(vec3 p)
 
 void main()
 {
-	// Couleur de scène existante (déjà brouillardée par la passe fog amont).
-	vec3 sceneCol = texture(uSceneColor, inUV).rgb;
-	float depth   = texture(uSceneDepth, inUV).r;
+	float depth = texture(uSceneDepth, inUV).r;
 
 	// Reconstruit le rayon monde de la caméra vers ce pixel (NDC xy [-1,1]).
 	vec2 ndc = inUV * 2.0 - 1.0;
@@ -109,9 +110,11 @@ void main()
 	vec3 rd = normalize(farWorld - ro);
 
 	// --- Ombres de nuages au sol (Phase 2) ---
-	// Pour les pixels de géométrie (depth < 1), marche le rayon SOLEIL à travers
-	// la dalle de nuages depuis la position monde du sol et assombrit la scène.
-	// Réutilise cloudDensity() (même champ de densité que la dalle vue).
+	// Pour les pixels de géométrie (depth < 1), marche le rayon SOLEIL à
+	// travers la dalle depuis la position monde du sol. Le facteur d'ombre
+	// est REPORTÉ dans l'alpha de sortie (visibilité scène) et appliqué par
+	// clouds_composite.frag — la scène n'est plus lue ici (cible réduite).
+	float shadowVis = 1.0;
 	float shadowStrength = pc.shadowParams.x;
 	if (depth < 1.0 && shadowStrength > 0.001)
 	{
@@ -134,7 +137,7 @@ void main()
 				float st  = te;
 				for (int i = 0; i < ss; ++i) { sum += cloudDensity(P + sunS * st) * sdt; st += sdt; }
 				float shadowTrans = exp(-sum * 0.04);
-				sceneCol *= mix(1.0, shadowTrans, shadowStrength);
+				shadowVis = mix(1.0, shadowTrans, shadowStrength);
 			}
 		}
 	}
@@ -145,7 +148,7 @@ void main()
 	if (abs(rd.y) < 1e-4)
 	{
 		// Rayon quasi-horizontal : pas d'intersection nette de la dalle.
-		outColor = vec4(sceneCol, 1.0);
+		outColor = vec4(0.0, 0.0, 0.0, shadowVis);
 		return;
 	}
 	float tBase = (baseAlt - ro.y) / rd.y;
@@ -157,7 +160,7 @@ void main()
 	// Pas de dalle visible (rayon regarde le sol / dalle derrière la caméra).
 	if (tExit <= tEnter)
 	{
-		outColor = vec4(sceneCol, 1.0);
+		outColor = vec4(0.0, 0.0, 0.0, shadowVis);
 		return;
 	}
 
@@ -171,7 +174,7 @@ void main()
 		tExit = min(tExit, gDist);
 		if (tExit <= tEnter)
 		{
-			outColor = vec4(sceneCol, 1.0);
+			outColor = vec4(0.0, 0.0, 0.0, shadowVis);
 			return;
 		}
 	}
@@ -179,7 +182,7 @@ void main()
 	tExit = min(tExit, pc.stepParams.z); // distMax
 	if (tExit <= tEnter)
 	{
-		outColor = vec4(sceneCol, 1.0);
+		outColor = vec4(0.0, 0.0, 0.0, shadowVis);
 		return;
 	}
 
@@ -250,6 +253,7 @@ void main()
 	float fadeStart = pc.shadowParams.z;
 	float fade = (fadeStart > 0.0) ? (1.0 - smoothstep(fadeStart, fadeStart * 3.0, tEnter)) : 1.0;
 	float opacity = (1.0 - transmittance) * fade;
-	vec3 finalCol = sceneCol * (1.0 - opacity) + scattered * fade;
-	outColor = vec4(finalCol, 1.0);
+	// Sortie pré-multipliée (lot 1) : la composition sur la scène est faite
+	// par clouds_composite.frag en pleine résolution.
+	outColor = vec4(scattered * fade, (1.0 - opacity) * shadowVis);
 }

--- a/game/data/shaders/clouds_composite.frag
+++ b/game/data/shaders/clouds_composite.frag
@@ -1,0 +1,23 @@
+#version 450
+
+// Composite des nuages basse résolution sur la scène (lot 1, 2026-07-18).
+// La passe Clouds_March écrit dans une cible RÉDUITE (1/2 ou 1/4 de la
+// swapchain, cf. render.clouds.resolution_divider) :
+//   rgb = couleur nuages PRÉ-MULTIPLIÉE (scattered * fade)
+//   a   = visibilité de la scène = (1 - opacité nuages) * ombre au sol
+// Cette passe pleine résolution upsample (bilinéaire) et compose :
+//   final = scene * clouds.a + clouds.rgb
+// Fullscreen triangle partagé (lighting.vert).
+
+layout(location = 0) in  vec2 inUV;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 0, binding = 0) uniform sampler2D uSceneColor; // HDR post-fog (pleine rés.)
+layout(set = 0, binding = 1) uniform sampler2D uClouds;     // nuages basse rés. (premult + visibilité)
+
+void main()
+{
+	vec3 scene  = texture(uSceneColor, inUV).rgb;
+	vec4 clouds = texture(uClouds, inUV);
+	outColor = vec4(scene * clouds.a + clouds.rgb, 1.0);
+}

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -4152,6 +4152,24 @@ namespace engine
 										// Fogged (R16G16B16A16_SFLOAT, extent swapchain). Lu en aval par Bloom
 										// (Prefilter / Combine) quand la passe nuages est active.
 										m_fgCloudsId = m_frameGraph.createImage("SceneColor_HDR_Clouds", sceneColorHDRDesc);
+											// Lot 1 (2026-07-18) — Clouds_Half : cible RÉDUITE de la marche des
+											// nuages (raymarch coûteux → 1/2 ou 1/4 de la swapchain, cf.
+											// render.clouds.resolution_divider). rgb = couleur pré-multipliée,
+											// a = visibilité scène ; upsamplée par Clouds_Composite.
+											{
+												int cloudDivider = m_cfg.GetInt("render.clouds.resolution_divider", 2);
+												if (cloudDivider != 1 && cloudDivider != 2 && cloudDivider != 4)
+												{
+													LOG_WARN(Render, "render.clouds.resolution_divider={} invalide (1/2/4), repli sur 2", cloudDivider);
+													cloudDivider = 2;
+												}
+												m_cloudsExtentPower = (cloudDivider == 4) ? 2u : (cloudDivider == 2 ? 1u : 0u);
+												engine::render::ImageDesc cloudsHalfDesc{};
+												cloudsHalfDesc.format           = VK_FORMAT_R16G16B16A16_SFLOAT;
+												cloudsHalfDesc.usage            = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
+												cloudsHalfDesc.extentScalePower = m_cloudsExtentPower;
+												m_fgCloudsHalfId = m_frameGraph.createImage("Clouds_Half", cloudsHalfDesc);
+											}
 										// M45.3 — SceneColor_HDR_Dof : cible de la passe DepthOfField (bokeh),
 										// ou copie passthrough si la passe DoF est invalide. Meme desc que
 										// WithBloom/Fogged (qui inclut deja TRANSFER_DST pour le passthrough
@@ -6583,11 +6601,14 @@ namespace engine
 										}
 										if (cloudsEnabled && m_pipeline && m_pipeline->IsCloudPassReady())
 										{
-											m_frameGraph.addPass("Clouds",
+											// Lot 1 (2026-07-18) — la marche des nuages (raymarch coûteux) tourne
+											// en RÉSOLUTION RÉDUITE (Clouds_Half) et ne lit plus la scène : le
+											// shader écrit couleur pré-multipliée (rgb) + visibilité (a). La
+											// composition pleine résolution est une 2e passe (Clouds_Composite).
+											m_frameGraph.addPass("Clouds_March",
 												[this](engine::render::PassBuilder& b) {
-													b.read(m_fgSceneColorFoggedId, engine::render::ImageUsage::SampledRead);
-													b.read(m_fgDepthId,            engine::render::ImageUsage::SampledRead);
-													b.write(m_fgCloudsId,          engine::render::ImageUsage::ColorWrite);
+													b.read(m_fgDepthId,       engine::render::ImageUsage::SampledRead);
+													b.write(m_fgCloudsHalfId, engine::render::ImageUsage::ColorWrite);
 												},
 												[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
 													if (!m_pipeline->GetCloudPass().IsValid()) return;
@@ -6686,9 +6707,33 @@ namespace engine
 													pc.shadowParams[2] = static_cast<float>(m_cfg.GetDouble("render.clouds.fade_distance_m", 2500.0));
 													pc.shadowParams[3] = 0.0f;
 
-													m_pipeline->GetCloudPass().Record(
+													// Extent réduit — même calcul que FrameGraph pour Clouds_Half
+													// (shift + clamp à 1) afin que viewport == framebuffer.
+													const VkExtent2D fullExt = m_vkSwapchain.GetExtent();
+													VkExtent2D scaledExt{
+														fullExt.width  >> m_cloudsExtentPower,
+														fullExt.height >> m_cloudsExtentPower };
+													if (scaledExt.width  < 1u) scaledExt.width  = 1u;
+													if (scaledExt.height < 1u) scaledExt.height = 1u;
+													m_pipeline->GetCloudPass().RecordMarch(
+														m_vkDeviceContext.GetDevice(), cmd, reg, scaledExt,
+														m_fgDepthId, m_fgCloudsHalfId, pc, m_currentFrame % 2);
+												});
+
+											// Composition pleine résolution : upsample bilinéaire de Clouds_Half
+											// sur la scène brouillardée → SceneColor_HDR_Clouds (consommée par
+											// Bloom via sceneAfterClouds, inchangé).
+											m_frameGraph.addPass("Clouds_Composite",
+												[this](engine::render::PassBuilder& b) {
+													b.read(m_fgSceneColorFoggedId, engine::render::ImageUsage::SampledRead);
+													b.read(m_fgCloudsHalfId,       engine::render::ImageUsage::SampledRead);
+													b.write(m_fgCloudsId,          engine::render::ImageUsage::ColorWrite);
+												},
+												[this](VkCommandBuffer cmd, engine::render::Registry& reg) {
+													if (!m_pipeline->GetCloudPass().IsValid()) return;
+													m_pipeline->GetCloudPass().RecordComposite(
 														m_vkDeviceContext.GetDevice(), cmd, reg, m_vkSwapchain.GetExtent(),
-														m_fgSceneColorFoggedId, m_fgDepthId, m_fgCloudsId, pc, m_currentFrame % 2);
+														m_fgSceneColorFoggedId, m_fgCloudsHalfId, m_fgCloudsId, m_currentFrame % 2);
 												});
 										}
 

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -432,6 +432,13 @@ namespace engine
 		/// (Prefilter + Combine) lorsque la passe nuages est active. Même desc que
 		/// Fogged (R16G16B16A16_SFLOAT, extent swapchain).
 		engine::render::ResourceId m_fgCloudsId = engine::render::kInvalidResourceId;
+		/// Lot 1 (2026-07-18) — Clouds_Half : cible RÉDUITE de la marche des nuages
+		/// (RGBA16F, extent swapchain >> m_cloudsExtentPower). rgb = couleur
+		/// pré-multipliée, a = visibilité scène. Lue par Clouds_Composite.
+		engine::render::ResourceId m_fgCloudsHalfId = engine::render::kInvalidResourceId;
+		/// Puissance de réduction de la cible nuages (extentScalePower FrameGraph) :
+		/// render.clouds.resolution_divider 1/2/4 → 0/1/2. Défaut 1 (demi-résolution).
+		uint32_t m_cloudsExtentPower = 1;
 
 		/// Temps réel cumulé (secondes) pour l'advection des nuages par le vent
 		/// (push-constant CloudPass). Avancé chaque frame par le dt d'Update.

--- a/src/client/render/CloudPass.cpp
+++ b/src/client/render/CloudPass.cpp
@@ -45,11 +45,13 @@ namespace engine::render
 		VkFormat sceneColorHDRFormat,
 		const uint32_t* vertSpirv, size_t vertWordCount,
 		const uint32_t* fragSpirv, size_t fragWordCount,
+		const uint32_t* compositeFragSpirv, size_t compositeFragWordCount,
 		VkQueue uploadQueue, uint32_t uploadQueueFamilyIndex,
 		uint32_t maxFrames, VkPipelineCache pipelineCache)
 	{
 		if (device == VK_NULL_HANDLE || !vertSpirv || !fragSpirv
 			|| vertWordCount == 0 || fragWordCount == 0
+			|| !compositeFragSpirv || compositeFragWordCount == 0
 			|| uploadQueue == VK_NULL_HANDLE)
 		{
 			LOG_ERROR(Render, "CloudPass::Init: invalid arguments");
@@ -125,16 +127,39 @@ namespace engine::render
 			}
 		}
 
-		// 3. Descriptor pool.
+		// 2b. Lot 1 (2026-07-18) — layout du set de composition : 2 samplers
+		// (scene pleine résolution + nuages basse résolution).
+		{
+			std::array<VkDescriptorSetLayoutBinding, 2> bindings{};
+			for (size_t i = 0; i < bindings.size(); ++i)
+			{
+				bindings[i].binding         = static_cast<uint32_t>(i);
+				bindings[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+				bindings[i].descriptorCount = 1;
+				bindings[i].stageFlags      = VK_SHADER_STAGE_FRAGMENT_BIT;
+			}
+			VkDescriptorSetLayoutCreateInfo layoutInfo{};
+			layoutInfo.sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
+			layoutInfo.bindingCount = static_cast<uint32_t>(bindings.size());
+			layoutInfo.pBindings    = bindings.data();
+			if (vkCreateDescriptorSetLayout(device, &layoutInfo, nullptr, &m_compositeSetLayout) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkCreateDescriptorSetLayout (composite) failed");
+				Destroy(device); return false;
+			}
+		}
+
+		// 3. Descriptor pool (marche : 4 bindings + composite : 2 bindings,
+		// un set de chaque par frame).
 		{
 			VkDescriptorPoolSize poolSize{};
 			poolSize.type            = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-			poolSize.descriptorCount = 4 * m_maxFrames;
+			poolSize.descriptorCount = 6 * m_maxFrames;
 			VkDescriptorPoolCreateInfo poolInfo{};
 			poolInfo.sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
 			poolInfo.poolSizeCount = 1;
 			poolInfo.pPoolSizes    = &poolSize;
-			poolInfo.maxSets       = m_maxFrames;
+			poolInfo.maxSets       = 2 * m_maxFrames;
 			if (vkCreateDescriptorPool(device, &poolInfo, nullptr, &m_descriptorPool) != VK_SUCCESS)
 			{
 				LOG_ERROR(Render, "CloudPass: vkCreateDescriptorPool failed");
@@ -142,7 +167,7 @@ namespace engine::render
 			}
 		}
 
-		// 4. Alloue un descriptor set par frame.
+		// 4. Alloue les descriptor sets (marche + composite) par frame.
 		{
 			std::vector<VkDescriptorSetLayout> layouts(m_maxFrames, m_descriptorSetLayout);
 			VkDescriptorSetAllocateInfo allocInfo{};
@@ -154,6 +179,14 @@ namespace engine::render
 			if (vkAllocateDescriptorSets(device, &allocInfo, m_descriptorSets.data()) != VK_SUCCESS)
 			{
 				LOG_ERROR(Render, "CloudPass: vkAllocateDescriptorSets failed");
+				Destroy(device); return false;
+			}
+			std::vector<VkDescriptorSetLayout> compLayouts(m_maxFrames, m_compositeSetLayout);
+			allocInfo.pSetLayouts = compLayouts.data();
+			m_compositeSets.resize(m_maxFrames, VK_NULL_HANDLE);
+			if (vkAllocateDescriptorSets(device, &allocInfo, m_compositeSets.data()) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkAllocateDescriptorSets (composite) failed");
 				Destroy(device); return false;
 			}
 		}
@@ -251,6 +284,18 @@ namespace engine::render
 				LOG_ERROR(Render, "CloudPass: vkCreatePipelineLayout failed");
 				Destroy(device); return false;
 			}
+
+			// Lot 1 — layout du pipeline de composition (set composite, pas
+			// de push constants).
+			VkPipelineLayoutCreateInfo compLayoutInfo{};
+			compLayoutInfo.sType          = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+			compLayoutInfo.setLayoutCount = 1;
+			compLayoutInfo.pSetLayouts    = &m_compositeSetLayout;
+			if (vkCreatePipelineLayout(device, &compLayoutInfo, nullptr, &m_compositePipelineLayout) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkCreatePipelineLayout (composite) failed");
+				Destroy(device); return false;
+			}
 		}
 
 		// 7. Pipeline graphique fullscreen triangle (pas de vertex input, pas de depth test).
@@ -324,11 +369,39 @@ namespace engine::render
 			AssertPipelineCreationAllowed();
 			PipelineCache::RegisterWarmupKey(HashGraphicsPsoKey(m_renderPass, 0, m_pipelineLayout, sceneColorHDRFormat, VK_FORMAT_UNDEFINED));
 			VkResult res = vkCreateGraphicsPipelines(device, pipelineCache, 1, &gpInfo, nullptr, &m_pipeline);
-			vkDestroyShaderModule(device, vertMod, nullptr);
-			vkDestroyShaderModule(device, fragMod, nullptr);
 			if (res != VK_SUCCESS)
 			{
+				vkDestroyShaderModule(device, vertMod, nullptr);
+				vkDestroyShaderModule(device, fragMod, nullptr);
 				LOG_ERROR(Render, "CloudPass: vkCreateGraphicsPipelines failed: {}", static_cast<int>(res));
+				Destroy(device); return false;
+			}
+
+			// Lot 1 (2026-07-18) — pipeline de composition : mêmes états
+			// (fullscreen triangle, pas de depth, pas de blend — l'équation
+			// de composition est dans le shader), fragment
+			// clouds_composite.frag, layout composite. Même render pass
+			// (format RGBA16F identique pour la cible réduite et la scène).
+			VkShaderModule compFragMod = CreateShaderModule(device,
+				compositeFragSpirv, compositeFragWordCount);
+			if (compFragMod == VK_NULL_HANDLE)
+			{
+				vkDestroyShaderModule(device, vertMod, nullptr);
+				vkDestroyShaderModule(device, fragMod, nullptr);
+				LOG_ERROR(Render, "CloudPass: composite shader module creation failed");
+				Destroy(device); return false;
+			}
+			stages[1].module = compFragMod;
+			gpInfo.layout    = m_compositePipelineLayout;
+			AssertPipelineCreationAllowed();
+			PipelineCache::RegisterWarmupKey(HashGraphicsPsoKey(m_renderPass, 0, m_compositePipelineLayout, sceneColorHDRFormat, VK_FORMAT_UNDEFINED));
+			res = vkCreateGraphicsPipelines(device, pipelineCache, 1, &gpInfo, nullptr, &m_compositePipeline);
+			vkDestroyShaderModule(device, vertMod, nullptr);
+			vkDestroyShaderModule(device, fragMod, nullptr);
+			vkDestroyShaderModule(device, compFragMod, nullptr);
+			if (res != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass: vkCreateGraphicsPipelines (composite) failed: {}", static_cast<int>(res));
 				Destroy(device); return false;
 			}
 		}
@@ -337,26 +410,29 @@ namespace engine::render
 		return true;
 	}
 
-	void CloudPass::Record(VkDevice device, VkCommandBuffer cmd, Registry& registry,
-		VkExtent2D extent, ResourceId idSceneColorIn, ResourceId idDepth,
-		ResourceId idSceneColorOut, const CloudPushConstants& params, uint32_t frameIndex)
+	void CloudPass::RecordMarch(VkDevice device, VkCommandBuffer cmd, Registry& registry,
+		VkExtent2D scaledExtent, ResourceId idDepth,
+		ResourceId idCloudsOut, const CloudPushConstants& params, uint32_t frameIndex)
 	{
+		const VkExtent2D extent = scaledExtent;
 		if (!IsValid() || extent.width == 0 || extent.height == 0) return;
 
-		VkImageView viewSceneIn = registry.getImageView(idSceneColorIn);
-		VkImageView viewDepth   = registry.getImageView(idDepth);
-		VkImageView viewOut     = registry.getImageView(idSceneColorOut);
-		if (viewSceneIn == VK_NULL_HANDLE || viewDepth == VK_NULL_HANDLE || viewOut == VK_NULL_HANDLE)
+		VkImageView viewDepth = registry.getImageView(idDepth);
+		VkImageView viewOut   = registry.getImageView(idCloudsOut);
+		if (viewDepth == VK_NULL_HANDLE || viewOut == VK_NULL_HANDLE)
 		{
-			LOG_WARN(Render, "CloudPass::Record: missing image views, skipping");
+			LOG_WARN(Render, "CloudPass::RecordMarch: missing image views, skipping");
 			return;
 		}
 
 		const uint32_t setIdx = frameIndex % m_maxFrames;
 		VkDescriptorSet ds = m_descriptorSets[setIdx];
 
+		// Binding 0 (ex-scene color) : plus échantillonné par clouds.frag
+		// (lot 1) mais toujours présent au layout — on y lie le depth en
+		// « bouche-trou » déclaré au FrameGraph (layout SHADER_READ_ONLY).
 		std::array<VkDescriptorImageInfo, 4> imageInfos{};
-		imageInfos[0] = { m_linearSampler,  viewSceneIn,       VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		imageInfos[0] = { m_nearestSampler, viewDepth,         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[1] = { m_nearestSampler, viewDepth,         VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[2] = { m_noiseSampler,   m_noiseBaseView,   VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
 		imageInfos[3] = { m_noiseSampler,   m_noiseDetailView, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
@@ -423,6 +499,98 @@ namespace engine::render
 
 		vkCmdPushConstants(cmd, m_pipelineLayout, VK_SHADER_STAGE_FRAGMENT_BIT,
 			0, static_cast<uint32_t>(sizeof(CloudPushConstants)), &params);
+		vkCmdDraw(cmd, 3, 1, 0, 0);
+		vkCmdEndRenderPass(cmd);
+	}
+
+	void CloudPass::RecordComposite(VkDevice device, VkCommandBuffer cmd, Registry& registry,
+		VkExtent2D extent, ResourceId idSceneColorIn, ResourceId idCloudsIn,
+		ResourceId idSceneColorOut, uint32_t frameIndex)
+	{
+		if (!IsValid() || m_compositePipeline == VK_NULL_HANDLE
+			|| extent.width == 0 || extent.height == 0)
+		{
+			return;
+		}
+
+		VkImageView viewSceneIn = registry.getImageView(idSceneColorIn);
+		VkImageView viewClouds  = registry.getImageView(idCloudsIn);
+		VkImageView viewOut     = registry.getImageView(idSceneColorOut);
+		if (viewSceneIn == VK_NULL_HANDLE || viewClouds == VK_NULL_HANDLE
+			|| viewOut == VK_NULL_HANDLE)
+		{
+			LOG_WARN(Render, "CloudPass::RecordComposite: missing image views, skipping");
+			return;
+		}
+
+		const uint32_t setIdx = frameIndex % m_maxFrames;
+		VkDescriptorSet ds = m_compositeSets[setIdx];
+
+		std::array<VkDescriptorImageInfo, 2> imageInfos{};
+		imageInfos[0] = { m_linearSampler, viewSceneIn, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		imageInfos[1] = { m_linearSampler, viewClouds,  VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL };
+		std::array<VkWriteDescriptorSet, 2> writes{};
+		for (size_t i = 0; i < writes.size(); ++i)
+		{
+			writes[i].sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+			writes[i].dstSet          = ds;
+			writes[i].dstBinding      = static_cast<uint32_t>(i);
+			writes[i].descriptorCount = 1;
+			writes[i].descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+			writes[i].pImageInfo      = &imageInfos[i];
+		}
+		vkUpdateDescriptorSets(device, static_cast<uint32_t>(writes.size()), writes.data(), 0, nullptr);
+
+		// Framebuffer mis en cache (même pattern que la marche : la clé
+		// inclut la vue de sortie et la taille).
+		FramebufferKey fbKey{ viewOut, extent.width, extent.height };
+		VkFramebuffer fb = VK_NULL_HANDLE;
+		auto fbIt = m_framebufferCache.find(fbKey);
+		if (fbIt != m_framebufferCache.end())
+		{
+			fb = fbIt->second;
+		}
+		else
+		{
+			VkFramebufferCreateInfo fbInfo{};
+			fbInfo.sType           = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+			fbInfo.renderPass      = m_renderPass;
+			fbInfo.attachmentCount = 1;
+			fbInfo.pAttachments    = &viewOut;
+			fbInfo.width           = extent.width;
+			fbInfo.height          = extent.height;
+			fbInfo.layers          = 1;
+			if (vkCreateFramebuffer(device, &fbInfo, nullptr, &fb) != VK_SUCCESS)
+			{
+				LOG_ERROR(Render, "CloudPass::RecordComposite: vkCreateFramebuffer failed");
+				return;
+			}
+			m_framebufferCache[fbKey] = fb;
+		}
+
+		VkClearValue clearVal{};
+		clearVal.color = { { 0.0f, 0.0f, 0.0f, 1.0f } };
+		VkRenderPassBeginInfo rpBegin{};
+		rpBegin.sType           = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+		rpBegin.renderPass      = m_renderPass;
+		rpBegin.framebuffer     = fb;
+		rpBegin.renderArea      = { { 0, 0 }, extent };
+		rpBegin.clearValueCount = 1;
+		rpBegin.pClearValues    = &clearVal;
+		vkCmdBeginRenderPass(cmd, &rpBegin, VK_SUBPASS_CONTENTS_INLINE);
+
+		vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_compositePipeline);
+		vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS,
+			m_compositePipelineLayout, 0, 1, &ds, 0, nullptr);
+
+		VkViewport viewport{};
+		viewport.width = static_cast<float>(extent.width);
+		viewport.height = static_cast<float>(extent.height);
+		viewport.minDepth = 0.0f; viewport.maxDepth = 1.0f;
+		vkCmdSetViewport(cmd, 0, 1, &viewport);
+		VkRect2D scissor = { { 0, 0 }, extent };
+		vkCmdSetScissor(cmd, 0, 1, &scissor);
+
 		vkCmdDraw(cmd, 3, 1, 0, 0);
 		vkCmdEndRenderPass(cmd);
 	}
@@ -622,6 +790,11 @@ namespace engine::render
 		InvalidateFramebufferCache(device);
 		if (m_pipeline)            { vkDestroyPipeline(device, m_pipeline, nullptr); m_pipeline = VK_NULL_HANDLE; }
 		if (m_pipelineLayout)      { vkDestroyPipelineLayout(device, m_pipelineLayout, nullptr); m_pipelineLayout = VK_NULL_HANDLE; }
+		// Lot 1 — pipeline de composition.
+		if (m_compositePipeline)       { vkDestroyPipeline(device, m_compositePipeline, nullptr); m_compositePipeline = VK_NULL_HANDLE; }
+		if (m_compositePipelineLayout) { vkDestroyPipelineLayout(device, m_compositePipelineLayout, nullptr); m_compositePipelineLayout = VK_NULL_HANDLE; }
+		m_compositeSets.clear();
+		if (m_compositeSetLayout)      { vkDestroyDescriptorSetLayout(device, m_compositeSetLayout, nullptr); m_compositeSetLayout = VK_NULL_HANDLE; }
 		if (m_nearestSampler)      { vkDestroySampler(device, m_nearestSampler, nullptr); m_nearestSampler = VK_NULL_HANDLE; }
 		if (m_linearSampler)       { vkDestroySampler(device, m_linearSampler, nullptr); m_linearSampler = VK_NULL_HANDLE; }
 		// Chantier ciel 2026-07-17 — textures 3D de bruit + sampler REPEAT.

--- a/src/client/render/CloudPass.h
+++ b/src/client/render/CloudPass.h
@@ -53,20 +53,34 @@ namespace engine::render
 		/// \param uploadQueue        Queue graphics pour l'upload one-shot des textures
 		///        de bruit (vkQueueWaitIdle interne — boot uniquement, jamais en frame).
 		/// \param uploadQueueFamilyIndex Famille de \p uploadQueue (command pool).
+		/// \param compositeFragSpirv/compositeFragWordCount SPIR-V de
+		///        clouds_composite.frag (lot 1 : upsample + composition pleine
+		///        résolution des nuages marchés en cible réduite).
 		/// \param maxFrames frames en vol (un descriptor set par frame).
 		bool Init(VkDevice device, VkPhysicalDevice physicalDevice,
 			VkFormat sceneColorHDRFormat,
 			const uint32_t* vertSpirv, size_t vertWordCount,
 			const uint32_t* fragSpirv, size_t fragWordCount,
+			const uint32_t* compositeFragSpirv, size_t compositeFragWordCount,
 			VkQueue uploadQueue, uint32_t uploadQueueFamilyIndex,
 			uint32_t maxFrames = 2,
 			VkPipelineCache pipelineCache = VK_NULL_HANDLE);
 
-		/// Enregistre la passe. Lit scene color (idSceneColorIn) + depth (idDepth),
-		/// composite les nuages, écrit dans idSceneColorOut.
-		void Record(VkDevice device, VkCommandBuffer cmd, Registry& registry, VkExtent2D extent,
-			ResourceId idSceneColorIn, ResourceId idDepth,
-			ResourceId idSceneColorOut, const CloudPushConstants& params, uint32_t frameIndex);
+		/// Lot 1 (2026-07-18) — Enregistre la MARCHE des nuages dans la cible
+		/// réduite \p idCloudsOut (RGBA16F, extent \p scaledExtent = swapchain
+		/// divisée par render.clouds.resolution_divider). Lit uniquement le
+		/// depth (pleine résolution, échantillonné) ; sortie pré-multipliée
+		/// (rgb) + visibilité scène (a), cf. clouds.frag.
+		void RecordMarch(VkDevice device, VkCommandBuffer cmd, Registry& registry,
+			VkExtent2D scaledExtent, ResourceId idDepth,
+			ResourceId idCloudsOut, const CloudPushConstants& params, uint32_t frameIndex);
+
+		/// Lot 1 (2026-07-18) — Compose (pleine résolution) la cible nuages
+		/// réduite \p idCloudsIn sur la scène \p idSceneColorIn et écrit
+		/// \p idSceneColorOut : final = scene * clouds.a + clouds.rgb.
+		void RecordComposite(VkDevice device, VkCommandBuffer cmd, Registry& registry,
+			VkExtent2D extent, ResourceId idSceneColorIn, ResourceId idCloudsIn,
+			ResourceId idSceneColorOut, uint32_t frameIndex);
 
 		void Destroy(VkDevice device);
 
@@ -115,6 +129,13 @@ namespace engine::render
 		VkDescriptorPool      m_descriptorPool      = VK_NULL_HANDLE;
 		VkPipelineLayout      m_pipelineLayout      = VK_NULL_HANDLE;
 		VkPipeline            m_pipeline            = VK_NULL_HANDLE;
+		// Lot 1 (2026-07-18) — pipeline de composition pleine résolution
+		// (clouds_composite.frag : scene * clouds.a + clouds.rgb). Réutilise
+		// m_renderPass (même format RGBA16F que la cible réduite).
+		VkDescriptorSetLayout m_compositeSetLayout      = VK_NULL_HANDLE;
+		VkPipelineLayout      m_compositePipelineLayout = VK_NULL_HANDLE;
+		VkPipeline            m_compositePipeline       = VK_NULL_HANDLE;
+		std::vector<VkDescriptorSet> m_compositeSets;
 		VkSampler             m_linearSampler       = VK_NULL_HANDLE;
 		VkSampler             m_nearestSampler      = VK_NULL_HANDLE;
 		// Chantier ciel 2026-07-17 — textures 3D de bruit Perlin-Worley

--- a/src/client/render/DeferredPipeline.cpp
+++ b/src/client/render/DeferredPipeline.cpp
@@ -340,12 +340,16 @@ namespace engine::render
 		{
 			std::vector<uint32_t> cloudVert = loadSpirv("shaders/lighting.vert.spv");
 			std::vector<uint32_t> cloudFrag = loadSpirv("shaders/clouds.frag.spv");
-			if (!cloudVert.empty() && !cloudFrag.empty())
+			// Lot 1 (2026-07-18) — shader de composition pleine résolution
+			// (upsample de la cible nuages réduite sur la scène).
+			std::vector<uint32_t> cloudCompFrag = loadSpirv("shaders/clouds_composite.frag.spv");
+			if (!cloudVert.empty() && !cloudFrag.empty() && !cloudCompFrag.empty())
 			{
 				// Chantier ciel 2026-07-17 — la queue graphics sert à l'upload
 				// one-shot des textures 3D de bruit Perlin-Worley au boot.
 				if (m_cloudPass.Init(device, physicalDevice, VK_FORMAT_R16G16B16A16_SFLOAT,
 						cloudVert.data(), cloudVert.size(), cloudFrag.data(), cloudFrag.size(),
+						cloudCompFrag.data(), cloudCompFrag.size(),
 						graphicsQueue, graphicsQueueFamilyIndex,
 						2u, pipelineCacheHandle))
 					LOG_INFO(Render, "[Boot] DeferredPipeline CloudPass OK");
@@ -354,7 +358,7 @@ namespace engine::render
 			}
 			else
 			{
-				LOG_WARN(Render, "clouds: SPIR-V manquant (lighting.vert.spv / clouds.frag.spv)");
+				LOG_WARN(Render, "clouds: SPIR-V manquant (lighting.vert.spv / clouds.frag.spv / clouds_composite.frag.spv)");
 			}
 		}
 


### PR DESCRIPTION
## Objectif

Le raymarch des nuages (jusqu'a 64 pas vue x 6 pas lumiere par pixel) etait le cout dominant de la passe Clouds. Ce lot le fait tourner en **resolution reduite** (defaut : demi-resolution = ~4x moins de fragments marches) puis compose en pleine resolution. Les nuages etant des basses frequences, la perte visuelle est quasi nulle. Objectif : 60 fps (dernier releve : 51-54 fps apres #983).

## Changements

- **clouds.frag** : ne lit plus la scene. Sortie pre-multipliee : rgb = couleur nuages, a = visibilite scene = (1 - opacite) x ombre au sol. Binding 0 (ex-scene color) reserve.
- **clouds_composite.frag** (nouveau) : upsample bilineaire + composition pleine resolution final = scene x a + rgb.
- **CloudPass** : Record scinde en RecordMarch (cible reduite) + RecordComposite (pleine res, nouveau pipeline + set 2 samplers, meme render pass RGBA16F).
- **Engine** : image FrameGraph Clouds_Half (extentScalePower) ; passe Clouds scindee en Clouds_March + Clouds_Composite ; sceneAfterClouds inchange.
- **config.json** : nouvelle cle render.clouds.resolution_divider (1 = pleine, 2 = demi defaut, 4 = quart), lue au boot.

## Dependance de merge

⚠️ Cette branche **contient les commits de #983** (correctifs crepuscule, meme shader) : **merger #983 d'abord**, puis celle-ci (le diff se reduira au lot 1 seul ; la fusion restera propre car contenu identique).

## Validation

Shaders compiles au runtime (glslangValidator) : la CI ne valide pas le GLSL → **validation visuelle en jeu requise** (apparence des nuages inchangee + FPS, tester aussi resolution_divider 1 et 4). Repli : render.clouds.resolution_divider = 1 (comportement plein res), ou render.clouds.enabled = false.

**Deploiement** : ✅ client uniquement, pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)