### PR TITLE
feat(editor): Dupliquer (Ctrl+D) et Supprimer (Suppr) la selection, undoables (lot 5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -401,6 +401,9 @@ add_library(engine_core
   src/world_editor/scene/EditorSceneModel.cpp
   # Sous-projet 1, bloc D — commande undoable d'edition de transform.
   src/world_editor/inspector/SetEntityTransformCommand.cpp
+  # Lot 5 (2026-07-18) — dupliquer/supprimer la selection (undoables).
+  src/world_editor/scene/DeleteEntityCommand.cpp
+  src/world_editor/scene/DuplicateEntityCommand.cpp
   src/world_editor/terrain/TerrainDocument.cpp
   src/world_editor/terrain/TerrainBrush.cpp
   src/world_editor/terrain/TerrainRaycast.cpp
@@ -1481,6 +1484,17 @@ if(MSVC)
   target_compile_options(set_entity_transform_command_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
 endif()
 add_test(NAME set_entity_transform_command_tests COMMAND set_entity_transform_command_tests)
+
+# Lot 5 (2026-07-18) — Tests CPU pour DeleteEntityCommand / DuplicateEntityCommand
+# (Execute/Undo/Redo via foncteurs factices, integration CommandStack). Pur CPU,
+# non gate WIN32 (execute aussi par le ctest de build-linux).
+add_executable(entity_edit_commands_tests src/world_editor/tests/EntityEditCommandsTests.cpp)
+target_include_directories(entity_edit_commands_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(entity_edit_commands_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(entity_edit_commands_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME entity_edit_commands_tests COMMAND entity_edit_commands_tests)
 
 # Sous-projet 1, bloc H — Tests CPU pour Config::SaveToFile (round-trip JSON
 # plat des 4 types scalaires + echappement). Pur CPU + E/S, non gate WIN32.

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8004,6 +8004,25 @@ namespace engine
 				if (ctrl && buildMode) bp->Redo();
 				else m_worldEditorShell->HandleShortcut('Y', ctrl, shift);
 			}
+			// Lot 5 (2026-07-18) — Ctrl+D (dupliquer la sélection) et Suppr
+			// (supprimer la sélection). Ignorés quand ImGui édite du texte
+			// (champ de saisie actif) : Suppr/Ctrl+D y ont leur sens d'édition
+			// de texte et ne doivent pas toucher la scène.
+			const bool imguiTextInput =
+				(ImGui::GetCurrentContext() != nullptr) && ImGui::GetIO().WantTextInput;
+			if (!imguiTextInput)
+			{
+				if (ctrl && m_input.WasPressed(engine::platform::Key::D))
+				{
+					// shift transmis tel quel : Ctrl+Shift+D reste l'outil
+					// Dungeon Portal (géré par le shell).
+					m_worldEditorShell->HandleShortcut('D', true, shift);
+				}
+				if (!ctrl && !shift && m_input.WasPressed(engine::platform::Key::Delete))
+				{
+					m_worldEditorShell->HandleShortcut(0x2E, false, false);
+				}
+			}
 		}
 
 		m_shaderHotReload.Poll(m_cfg);
@@ -9318,6 +9337,144 @@ namespace engine
 							}
 						}
 					});
+
+				// Lot 5 (2026-07-18) — Foncteurs d'édition STRUCTURELLE des
+				// entités (Dupliquer/Supprimer undoables). Même pattern que le
+				// TransformWriter ci-dessus : l'Engine capture [this] pour
+				// atteindre le doc layout (session) que le shell ne possède
+				// pas. Réinstallés chaque frame (comme le writer) — les
+				// commandes gardent leur PROPRE copie des foncteurs au Push.
+				{
+					using engine::editor::scene::EntityId;
+					using engine::editor::scene::EntityKind;
+					using engine::editor::scene::EntitySnapshot;
+					engine::editor::scene::EntityEditOps ops;
+
+					// Copie l'entité (kind+index scène) en snapshot à guid
+					// stable, sans la retirer. false si index hors bornes ou
+					// kind non éditable.
+					ops.capture = [this](EntityId id, EntitySnapshot& out) -> bool
+					{
+						if (id.kind == EntityKind::LayoutInstance && m_worldEditorSession)
+						{
+							const auto& insts = m_worldEditorSession->Doc().layoutInstances;
+							if (id.index >= insts.size()) return false;
+							out.kind = id.kind;
+							out.layout = insts[id.index];
+							out.layoutIndex = id.index;
+							return true;
+						}
+						if (id.kind == EntityKind::MeshInsert && m_worldEditorShell)
+						{
+							const auto& all = m_worldEditorShell->GetMeshInsertDocument().All();
+							if (id.index >= all.size()) return false;
+							out.kind = id.kind;
+							out.meshInsert = all[id.index];
+							return true;
+						}
+						if (id.kind == EntityKind::DungeonPortal && m_worldEditorShell)
+						{
+							const auto& all = m_worldEditorShell->GetDungeonPortalDocument().All();
+							if (id.index >= all.size()) return false;
+							out.kind = id.kind;
+							out.portal = all[id.index];
+							return true;
+						}
+						return false;
+					};
+
+					// Retire l'entité du snapshot — par guid (stable), jamais
+					// par index (instable après édition structurelle).
+					ops.remove = [this](const EntitySnapshot& s) -> bool
+					{
+						if (s.kind == EntityKind::LayoutInstance && m_worldEditorSession)
+						{
+							auto& insts = m_worldEditorSession->MutableDoc().layoutInstances;
+							for (size_t i = 0; i < insts.size(); ++i)
+							{
+								if (insts[i].guid == s.layout.guid)
+								{
+									insts.erase(insts.begin() + static_cast<ptrdiff_t>(i));
+									return true;
+								}
+							}
+							return false;
+						}
+						if (s.kind == EntityKind::MeshInsert && m_worldEditorShell)
+							return m_worldEditorShell->MutableMeshInsertDocument().Remove(s.meshInsert.guid);
+						if (s.kind == EntityKind::DungeonPortal && m_worldEditorShell)
+							return m_worldEditorShell->MutableDungeonPortalDocument().Remove(s.portal.guid);
+						return false;
+					};
+
+					// Réinsère le snapshot : au rang d'origine (borné) pour le
+					// layout, par Add (guid conservé, compteur resynchronisé)
+					// pour les volumes.
+					ops.restore = [this](const EntitySnapshot& s) -> bool
+					{
+						if (s.kind == EntityKind::LayoutInstance && m_worldEditorSession)
+						{
+							auto& insts = m_worldEditorSession->MutableDoc().layoutInstances;
+							const size_t at = std::min<size_t>(s.layoutIndex, insts.size());
+							insts.insert(insts.begin() + static_cast<ptrdiff_t>(at), s.layout);
+							return true;
+						}
+						if (s.kind == EntityKind::MeshInsert && m_worldEditorShell)
+						{
+							(void)m_worldEditorShell->MutableMeshInsertDocument().Add(s.meshInsert);
+							return true;
+						}
+						if (s.kind == EntityKind::DungeonPortal && m_worldEditorShell)
+						{
+							(void)m_worldEditorShell->MutableDungeonPortalDocument().Add(s.portal);
+							return true;
+						}
+						return false;
+					};
+
+					// Ajoute une COPIE de src (nouveau guid + décalage +1,5 m
+					// en X pour que la copie soit visible à côté de
+					// l'original) et renvoie son snapshot dans outCopy.
+					ops.duplicate = [this](const EntitySnapshot& src, EntitySnapshot& outCopy) -> bool
+					{
+						constexpr double kDupOffsetM = 1.5;
+						outCopy = src;
+						if (src.kind == EntityKind::LayoutInstance && m_worldEditorSession)
+						{
+							auto& insts = m_worldEditorSession->MutableDoc().layoutInstances;
+							// Préfixe "we_dup_" distinct du "we_inst_" de la
+							// session : aucun risque de collision de guid.
+							static uint64_t s_dupSeq = 1u;
+							char buf[48];
+							std::snprintf(buf, sizeof(buf), "we_dup_%llu",
+								static_cast<unsigned long long>(s_dupSeq++));
+							outCopy.layout.guid = buf;
+							outCopy.layout.worldX += kDupOffsetM;
+							outCopy.layoutIndex = static_cast<uint32_t>(insts.size());
+							insts.push_back(outCopy.layout);
+							return true;
+						}
+						if (src.kind == EntityKind::MeshInsert && m_worldEditorShell)
+						{
+							auto& doc = m_worldEditorShell->MutableMeshInsertDocument();
+							outCopy.meshInsert.guid = 0u; // Add() assigne un nouveau guid
+							outCopy.meshInsert.worldPosition.x += static_cast<float>(kDupOffsetM);
+							outCopy.meshInsert.guid = doc.Add(outCopy.meshInsert);
+							return true;
+						}
+						if (src.kind == EntityKind::DungeonPortal && m_worldEditorShell)
+						{
+							auto& doc = m_worldEditorShell->MutableDungeonPortalDocument();
+							outCopy.portal.guid = 0u; // Add() assigne un nouveau guid
+							outCopy.portal.worldPosition.x += static_cast<float>(kDupOffsetM);
+							outCopy.portal.guid = doc.Add(outCopy.portal);
+							return true;
+						}
+						return false;
+					};
+
+					m_worldEditorShell->SetEntityEditOps(std::move(ops));
+				}
 			}
 			// Aperçu 3D live des bâtiments (brouillon + placements) dans la vue
 			// éditeur. Reconstruit m_props seulement si l'aperçu est « sale ».

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -8007,9 +8007,15 @@ namespace engine
 			// Lot 5 (2026-07-18) — Ctrl+D (dupliquer la sélection) et Suppr
 			// (supprimer la sélection). Ignorés quand ImGui édite du texte
 			// (champ de saisie actif) : Suppr/Ctrl+D y ont leur sens d'édition
-			// de texte et ne doivent pas toucher la scène.
+			// de texte et ne doivent pas toucher la scène. ImGui n'existe que
+			// côté Windows (comme partout dans Engine.cpp) — sur les autres
+			// plateformes l'éditeur n'a pas d'UI, pas de saisie à protéger.
+#if defined(_WIN32)
 			const bool imguiTextInput =
 				(ImGui::GetCurrentContext() != nullptr) && ImGui::GetIO().WantTextInput;
+#else
+			const bool imguiTextInput = false;
+#endif
 			if (!imguiTextInput)
 			{
 				if (ctrl && m_input.WasPressed(engine::platform::Key::D))

--- a/src/shared/platform/Input.h
+++ b/src/shared/platform/Input.h
@@ -56,6 +56,8 @@ namespace engine::platform
 		Space = 0x20,
 		Enter = 0x0D,
 		Backspace = 0x08,
+		/// VK_DELETE — éditeur monde lot 5 (2026-07-18) : supprimer la sélection.
+		Delete = 0x2E,
 		/// US keyboard OEM_2 ('/'); used as chat focus toggle (M29.1).
 		Slash = 0xBF,
 		Shift = 0x10,

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -25,6 +25,8 @@
 #include <utility>
 
 #include "src/world_editor/modes/EditorModeRegistry.h"
+#include "src/world_editor/scene/DeleteEntityCommand.h"    // lot 5
+#include "src/world_editor/scene/DuplicateEntityCommand.h" // lot 5
 #include "src/world_editor/prefs/UserPrefsStore.h"
 #include "src/world_editor/presets/ToolPresetRegistry.h"
 #include "src/world_editor/help/HelpContentStore.h"
@@ -408,6 +410,18 @@ namespace engine::editor::world
 			[this] { return m_commandStack.CanRedo(); }, nullptr,
 			[this] { m_commandStack.Redo(); });
 
+		// Lot 5 (2026-07-18) — Dupliquer / Supprimer l'entité sélectionnée
+		// (Outliner ou Ctrl+clic viewport). Undoables via la pile de commandes ;
+		// grisées tant qu'aucune entité duplicable/supprimable n'est
+		// sélectionnée (Terrain/Water exclus) ou que l'Engine n'a pas installé
+		// les foncteurs d'édition (SetEntityEditOps).
+		add("edit.duplicate", "Dupliquer la sélection", ActionCategory::Edition, "Ctrl+D",
+			[this] { return CanEditSelectedEntity(); }, nullptr,
+			[this] { DuplicateSelectedEntity(); });
+		add("edit.delete", "Supprimer la sélection", ActionCategory::Edition, "Suppr",
+			[this] { return CanEditSelectedEntity(); }, nullptr,
+			[this] { DeleteSelectedEntity(); });
+
 		// Toggle de visibilité par panneau (menu « Fenêtre »). Le panneau
 		// « Scene » est exclu (doublon de la vue 3D principale, cf. menu Vue
 		// historique). Id kebab-case dérivé du nom : "Asset Browser" →
@@ -442,6 +456,53 @@ namespace engine::editor::world
 					[p] { p->SetVisible(!p->IsVisible()); });
 			}
 		}
+	}
+
+	/// Lot 5 (2026-07-18) — true si la sélection courante est duplicable/
+	/// supprimable : foncteurs Engine installés ET kind ∈ {LayoutInstance,
+	/// MeshInsert, DungeonPortal}. Terrain (entité implicite unique), Water
+	/// (pas de transform simple) et None sont exclus.
+	bool WorldEditorShell::CanEditSelectedEntity() const
+	{
+		if (!m_entityEditOps.IsInstalled()) return false;
+		const engine::editor::scene::EntityKind kind = m_selection.Current().kind;
+		using K = engine::editor::scene::EntityKind;
+		return kind == K::LayoutInstance || kind == K::MeshInsert || kind == K::DungeonPortal;
+	}
+
+	/// Lot 5 — Pousse une DuplicateEntityCommand sur la pile undo (Execute
+	/// immédiat : la copie apparaît, décalée, avec un nouveau guid). La
+	/// sélection reste sur l'original : la copie est ajoutée en FIN de liste,
+	/// aucun index existant n'est invalidé.
+	void WorldEditorShell::DuplicateSelectedEntity()
+	{
+		if (!CanEditSelectedEntity())
+		{
+			LOG_INFO(EditorWorld, "Dupliquer : aucune entité duplicable sélectionnée");
+			return;
+		}
+		m_commandStack.Push(std::make_unique<DuplicateEntityCommand>(
+			m_selection.Current(), m_entityEditOps));
+		LOG_INFO(EditorWorld, "Dupliquer la sélection (kind={}, index={})",
+			static_cast<int>(m_selection.Current().kind), m_selection.Current().index);
+	}
+
+	/// Lot 5 — Pousse une DeleteEntityCommand sur la pile undo (Execute
+	/// immédiat : l'entité disparaît) puis VIDE la sélection — après un
+	/// erase, les index des entités suivantes glissent d'un rang et la
+	/// sélection courante pointerait une autre entité.
+	void WorldEditorShell::DeleteSelectedEntity()
+	{
+		if (!CanEditSelectedEntity())
+		{
+			LOG_INFO(EditorWorld, "Supprimer : aucune entité supprimable sélectionnée");
+			return;
+		}
+		const engine::editor::scene::EntityId id = m_selection.Current();
+		m_commandStack.Push(std::make_unique<DeleteEntityCommand>(id, m_entityEditOps));
+		m_selection.Clear();
+		LOG_INFO(EditorWorld, "Supprimer la sélection (kind={}, index={})",
+			static_cast<int>(id.kind), id.index);
 	}
 
 	/// M100.6 — Active un outil et logge la transition. Garde l'API simple :
@@ -740,6 +801,19 @@ namespace engine::editor::world
 			m_commandStack.Redo();
 			LOG_INFO(EditorWorld, "Shortcut Ctrl+Y -> Redo (undoSize={}, redoSize={})",
 				m_commandStack.UndoSize(), m_commandStack.RedoSize());
+			return true;
+		}
+		// Lot 5 (2026-07-18) — Ctrl+D (sans Shift) : dupliquer la sélection.
+		// Ctrl+Shift+D reste l'activation de l'outil Dungeon Portal (plus bas).
+		if (ctrl && !shift && virtualKey == 'D')
+		{
+			DuplicateSelectedEntity();
+			return true;
+		}
+		// Lot 5 — Suppr (VK_DELETE, sans modifiers) : supprimer la sélection.
+		if (!ctrl && !shift && virtualKey == 0x2E)
+		{
+			DeleteSelectedEntity();
 			return true;
 		}
 		// M100.6 — Raccourci 'B' (sans modifiers) active la sculpture terrain.

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -26,6 +26,7 @@
 #include "src/world_editor/terrain/ValleyChainTool.h"
 #include "src/world_editor/water/WaterDocument.h"
 #include "src/world_editor/scene/EditorSceneModel.h" // sous-projet 1, bloc B (selection + scene)
+#include "src/world_editor/scene/EntityEditOps.h"    // lot 5 (2026-07-18) : dupliquer/supprimer
 
 #include <functional>
 #include <memory>
@@ -290,6 +291,36 @@ namespace engine::editor::world
 		/// Installe le foncteur d'écriture de transform (appelé par l'Engine).
 		void SetTransformWriter(TransformWriter w) { m_transformWriter = std::move(w); }
 
+		/// Lot 5 (2026-07-18) — Installe les foncteurs d'édition structurelle
+		/// (capture / remove / restore / duplicate) des entités de scène.
+		/// Appelé par l'Engine (qui capture les documents mutables) au même
+		/// point que `SetTransformWriter`. Consommé par les actions
+		/// `edit.duplicate` / `edit.delete` et les raccourcis Ctrl+D / Suppr.
+		void SetEntityEditOps(engine::editor::scene::EntityEditOps ops)
+		{
+			m_entityEditOps = std::move(ops);
+		}
+
+		/// Lot 5 — true si la sélection courante est duplicable/supprimable :
+		/// foncteurs installés ET kind ∈ {LayoutInstance, MeshInsert,
+		/// DungeonPortal} (Terrain/Water/None exclus). Pilote `enabled` des
+		/// actions `edit.duplicate` / `edit.delete`.
+		bool CanEditSelectedEntity() const;
+
+		/// Lot 5 — Duplique l'entité sélectionnée via une
+		/// `DuplicateEntityCommand` poussée sur la pile undo (nouveau guid +
+		/// léger décalage de position ; la sélection reste sur l'original,
+		/// dont l'index n'est pas invalidé par un ajout en fin de liste).
+		/// No-op (log) si `CanEditSelectedEntity()` est false.
+		void DuplicateSelectedEntity();
+
+		/// Lot 5 — Supprime l'entité sélectionnée via une
+		/// `DeleteEntityCommand` poussée sur la pile undo, puis VIDE la
+		/// sélection (les index d'entités suivant la supprimée glissent d'un
+		/// rang — garder la sélection pointerait une autre entité).
+		/// No-op (log) si `CanEditSelectedEntity()` est false.
+		void DeleteSelectedEntity();
+
 		/// M100.6 — Accès mutable à l'outil de sculpt. Le panneau Tool
 		/// Properties l'utilise pour lire/écrire les paramètres de brosse
 		/// quand `m_activeTool == TerrainSculpt`.
@@ -460,6 +491,7 @@ namespace engine::editor::world
 		engine::editor::scene::EditorSelection  m_selection;  // sous-projet 1, bloc B
 		engine::editor::scene::EditorSceneModel m_sceneModel; // sous-projet 1, bloc B
 		TransformWriter m_transformWriter;                    // sous-projet 1, bloc D
+		engine::editor::scene::EntityEditOps m_entityEditOps; // lot 5 : dupliquer/supprimer
 		TerrainSculptTool m_sculptTool;
 		TerrainStampTool m_stampTool;
 		SplatPaintTool m_splatPaintTool;

--- a/src/world_editor/scene/DeleteEntityCommand.cpp
+++ b/src/world_editor/scene/DeleteEntityCommand.cpp
@@ -1,0 +1,55 @@
+// Lot 5 (2026-07-18) — implémentation de DeleteEntityCommand. Voir le header.
+
+#include "src/world_editor/scene/DeleteEntityCommand.h"
+
+#include <utility>
+
+namespace engine::editor::world
+{
+	DeleteEntityCommand::DeleteEntityCommand(scene::EntityId id, scene::EntityEditOps ops)
+		: m_id(id)
+		, m_ops(std::move(ops))
+	{
+	}
+
+	/// Empreinte approx. : la commande + les chaînes du snapshot (chemins glTF,
+	/// guid string, noms). Stable entre Execute et Undo (le snapshot ne change
+	/// plus après la 1re capture).
+	size_t DeleteEntityCommand::GetMemoryFootprint() const
+	{
+		return sizeof(DeleteEntityCommand)
+			+ m_snapshot.layout.guid.size()
+			+ m_snapshot.layout.gltfContentRelativePath.size()
+			+ m_snapshot.layout.speciesId.size()
+			+ m_snapshot.meshInsert.gltfRelativePath.size()
+			+ m_snapshot.meshInsert.insertCategory.size()
+			+ m_snapshot.meshInsert.displayName.size()
+			+ m_snapshot.portal.dungeonTemplateId.size()
+			+ m_snapshot.portal.displayName.size()
+			+ m_snapshot.portal.decorativeMeshPath.size();
+	}
+
+	/// 1er appel : capture le snapshot (index → données + guid stable) puis
+	/// retire l'entité. Redo : retire le snapshot mémorisé (par guid).
+	void DeleteEntityCommand::Execute()
+	{
+		if (!m_ops.IsInstalled()) return;
+		if (!m_captured)
+		{
+			m_captured = m_ops.capture(m_id, m_snapshot);
+		}
+		if (m_captured)
+		{
+			(void)m_ops.remove(m_snapshot);
+		}
+	}
+
+	/// Réinsère le snapshot capturé (no-op si le 1er Execute avait échoué).
+	void DeleteEntityCommand::Undo()
+	{
+		if (m_captured && m_ops.IsInstalled())
+		{
+			(void)m_ops.restore(m_snapshot);
+		}
+	}
+}

--- a/src/world_editor/scene/DeleteEntityCommand.h
+++ b/src/world_editor/scene/DeleteEntityCommand.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/scene/EntityEditOps.h"
+
+namespace engine::editor::world
+{
+	/// Lot 5 (2026-07-18) — Commande undoable de SUPPRESSION de l'entité de
+	/// scène sélectionnée (LayoutInstance / MeshInsert / DungeonPortal).
+	/// Découplée des documents concrets via les foncteurs `EntityEditOps`
+	/// installés par l'Engine (pattern `SetEntityTransformCommand::Writer`).
+	///
+	/// `Execute` (1er appel) capture un snapshot complet de l'entité puis la
+	/// retire ; les appels suivants (Redo) retirent le snapshot mémorisé (par
+	/// guid stable). `Undo` réinsère le snapshot (au rang d'origine pour les
+	/// layout instances, par guid pour les volumes).
+	///
+	/// Contrainte thread : main thread (comme tout `ICommand`).
+	class DeleteEntityCommand final : public ICommand
+	{
+	public:
+		/// \param id  Entité à supprimer (kind + index de scène AU MOMENT du
+		///        Push — l'index n'est utilisé qu'au 1er Execute, la capture
+		///        immédiate le convertit en snapshot à guid stable).
+		/// \param ops Foncteurs d'édition structurelle (doivent survivre à la
+		///        commande dans la pile undo — capture Engine `[this]`).
+		DeleteEntityCommand(scene::EntityId id, scene::EntityEditOps ops);
+
+		const char* GetLabel() const override { return "Supprimer l'entité"; }
+		size_t GetMemoryFootprint() const override;
+		void Execute() override;
+		void Undo() override;
+
+	private:
+		scene::EntityId       m_id;
+		scene::EntityEditOps  m_ops;
+		scene::EntitySnapshot m_snapshot;
+		/// true dès que le 1er Execute a capturé le snapshot avec succès ;
+		/// tant que false, Undo est un no-op (rien n'a été supprimé).
+		bool m_captured = false;
+	};
+}

--- a/src/world_editor/scene/DuplicateEntityCommand.cpp
+++ b/src/world_editor/scene/DuplicateEntityCommand.cpp
@@ -1,0 +1,58 @@
+// Lot 5 (2026-07-18) — implémentation de DuplicateEntityCommand. Voir le header.
+
+#include "src/world_editor/scene/DuplicateEntityCommand.h"
+
+#include <utility>
+
+namespace engine::editor::world
+{
+	DuplicateEntityCommand::DuplicateEntityCommand(scene::EntityId id, scene::EntityEditOps ops)
+		: m_id(id)
+		, m_ops(std::move(ops))
+	{
+	}
+
+	/// Empreinte approx. : la commande + les chaînes du snapshot de la copie.
+	/// Stable entre Execute et Undo (la copie ne change plus après création).
+	size_t DuplicateEntityCommand::GetMemoryFootprint() const
+	{
+		return sizeof(DuplicateEntityCommand)
+			+ m_copy.layout.guid.size()
+			+ m_copy.layout.gltfContentRelativePath.size()
+			+ m_copy.layout.speciesId.size()
+			+ m_copy.meshInsert.gltfRelativePath.size()
+			+ m_copy.meshInsert.insertCategory.size()
+			+ m_copy.meshInsert.displayName.size()
+			+ m_copy.portal.dungeonTemplateId.size()
+			+ m_copy.portal.displayName.size()
+			+ m_copy.portal.decorativeMeshPath.size();
+	}
+
+	/// 1er appel : capture la source puis crée la copie (nouveau guid +
+	/// décalage). Redo : réinsère la même copie (guid conservé).
+	void DuplicateEntityCommand::Execute()
+	{
+		if (!m_ops.IsInstalled()) return;
+		if (!m_created)
+		{
+			scene::EntitySnapshot src;
+			if (m_ops.capture(m_id, src))
+			{
+				m_created = m_ops.duplicate(src, m_copy);
+			}
+		}
+		else
+		{
+			(void)m_ops.restore(m_copy);
+		}
+	}
+
+	/// Retire la copie créée (no-op si le 1er Execute avait échoué).
+	void DuplicateEntityCommand::Undo()
+	{
+		if (m_created && m_ops.IsInstalled())
+		{
+			(void)m_ops.remove(m_copy);
+		}
+	}
+}

--- a/src/world_editor/scene/DuplicateEntityCommand.h
+++ b/src/world_editor/scene/DuplicateEntityCommand.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/scene/EntityEditOps.h"
+
+namespace engine::editor::world
+{
+	/// Lot 5 (2026-07-18) — Commande undoable de DUPLICATION de l'entité de
+	/// scène sélectionnée (LayoutInstance / MeshInsert / DungeonPortal).
+	/// Découplée des documents concrets via les foncteurs `EntityEditOps`
+	/// installés par l'Engine (pattern `SetEntityTransformCommand::Writer`).
+	///
+	/// `Execute` (1er appel) capture l'entité source puis crée une copie
+	/// (nouveau guid + léger décalage de position, cf. le foncteur
+	/// `duplicate`) et mémorise le snapshot de la copie ; les Redo suivants
+	/// réinsèrent LA MÊME copie (guid conservé — historique stable). `Undo`
+	/// retire la copie (par guid).
+	///
+	/// Contrainte thread : main thread (comme tout `ICommand`).
+	class DuplicateEntityCommand final : public ICommand
+	{
+	public:
+		/// \param id  Entité source à dupliquer (kind + index de scène AU
+		///        MOMENT du Push — converti en snapshot au 1er Execute).
+		/// \param ops Foncteurs d'édition structurelle (doivent survivre à la
+		///        commande dans la pile undo — capture Engine `[this]`).
+		DuplicateEntityCommand(scene::EntityId id, scene::EntityEditOps ops);
+
+		const char* GetLabel() const override { return "Dupliquer l'entité"; }
+		size_t GetMemoryFootprint() const override;
+		void Execute() override;
+		void Undo() override;
+
+	private:
+		scene::EntityId       m_id;
+		scene::EntityEditOps  m_ops;
+		/// Snapshot de la COPIE créée au 1er Execute (guid définitif — les
+		/// Redo réinsèrent ce snapshot tel quel).
+		scene::EntitySnapshot m_copy;
+		/// true dès que le 1er Execute a créé la copie avec succès ; tant que
+		/// false, Undo est un no-op (rien n'a été ajouté).
+		bool m_created = false;
+	};
+}

--- a/src/world_editor/scene/EntityEditOps.h
+++ b/src/world_editor/scene/EntityEditOps.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "src/world_editor/scene/EditorSelection.h"
+#include "src/world_editor/ui/WorldMapEditDocument.h"
+#include "src/world_editor/volumes/MeshInsertInstance.h"
+#include "src/world_editor/volumes/dungeons/DungeonPortalInstance.h"
+
+#include <functional>
+
+namespace engine::editor::scene
+{
+	/// Lot 5 (2026-07-18) — Instantané complet d'une entité de scène
+	/// supprimable/duplicable. Capturé AVANT une suppression (pour pouvoir la
+	/// réinsérer au Undo) ou APRÈS une duplication (pour pouvoir retirer la
+	/// copie au Undo, et la réinsérer à l'identique au Redo). Un seul des
+	/// trois membres « payload » est significatif, discriminé par `kind` :
+	///   - LayoutInstance → `layout` (+ `layoutIndex`, position d'origine dans
+	///     `WorldMapEditDocument::layoutInstances` pour réinsérer au même rang) ;
+	///   - MeshInsert     → `meshInsert` (guid uint64 stable) ;
+	///   - DungeonPortal  → `portal` (guid uint64 stable).
+	struct EntitySnapshot
+	{
+		EntityKind kind = EntityKind::None;
+
+		engine::editor::WorldMapEditLayoutInstance layout{};
+		/// Position d'origine dans `layoutInstances` (réinsertion au même rang
+		/// par `restore` — bornée à la taille courante du vecteur).
+		uint32_t layoutIndex = 0u;
+
+		engine::editor::world::volumes::MeshInsertInstance meshInsert{};
+		engine::editor::world::volumes::dungeons::DungeonPortalInstance portal{};
+	};
+
+	/// Lot 5 (2026-07-18) — Foncteurs d'édition STRUCTURELLE des entités de
+	/// scène (suppression / réinsertion / duplication), installés par l'Engine
+	/// sur le shell (même pattern que `WorldEditorShell::TransformWriter` :
+	/// l'Engine capture les documents mutables — session layout, mesh inserts,
+	/// portails — que le shell ne possède pas tous). Consommés par
+	/// `DeleteEntityCommand` / `DuplicateEntityCommand`.
+	///
+	/// Contrainte thread : main thread (comme tout `ICommand`). Les foncteurs
+	/// doivent rester valides tant que des commandes vivent dans la pile undo
+	/// (capture typique : `[this]` Engine, qui survit à l'éditeur).
+	struct EntityEditOps
+	{
+		/// Copie l'entité `id` (kind + index de scène courant) dans `out`,
+		/// SANS la retirer du document. \return false si l'entité n'existe pas
+		/// ou n'est pas d'un kind éditable (Terrain / Water / None).
+		std::function<bool(EntityId, EntitySnapshot&)> capture;
+
+		/// Retire du document l'entité décrite par le snapshot — par guid
+		/// (stable), jamais par index (instable après édition structurelle).
+		/// \return false si l'entité n'est plus présente.
+		std::function<bool(const EntitySnapshot&)> remove;
+
+		/// Réinsère le snapshot dans son document : au rang `layoutIndex`
+		/// (borné) pour LayoutInstance, par `Add` (guid conservé) pour les
+		/// volumes. \return false si le document cible n'est pas disponible.
+		std::function<bool(const EntitySnapshot&)> restore;
+
+		/// Ajoute au document une COPIE du snapshot `src` avec un nouveau guid
+		/// et un léger décalage de position (visibilité de la copie), et écrit
+		/// dans `outCopy` le snapshot de la copie créée (pour Undo/Redo).
+		/// \return false si le document cible n'est pas disponible.
+		std::function<bool(const EntitySnapshot&, EntitySnapshot&)> duplicate;
+
+		/// true si les quatre foncteurs sont installés (l'Engine a câblé les
+		/// documents) — condition d'activation des actions Dupliquer/Supprimer.
+		bool IsInstalled() const { return capture && remove && restore && duplicate; }
+	};
+}

--- a/src/world_editor/tests/EntityEditCommandsTests.cpp
+++ b/src/world_editor/tests/EntityEditCommandsTests.cpp
@@ -1,0 +1,191 @@
+/// Tests unitaires CPU pour DeleteEntityCommand / DuplicateEntityCommand
+/// (lot 5, 2026-07-18). Simulent les foncteurs EntityEditOps de l'Engine sur
+/// un vecteur de layout instances en mémoire : Execute/Undo/Redo, réinsertion
+/// au rang d'origine, duplication à guid neuf, intégration CommandStack, et
+/// no-op propre quand l'entité n'existe pas. Pur CPU, ctest (non gate WIN32).
+
+#include "src/world_editor/scene/DeleteEntityCommand.h"
+#include "src/world_editor/scene/DuplicateEntityCommand.h"
+#include "src/world_editor/core/CommandStack.h"
+
+#include <cstddef>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using namespace engine::editor::world;
+	using engine::editor::scene::EntityEditOps;
+	using engine::editor::scene::EntityId;
+	using engine::editor::scene::EntityKind;
+	using engine::editor::scene::EntitySnapshot;
+	using engine::editor::WorldMapEditLayoutInstance;
+
+	/// Fabrique une instance de layout minimale (guid + position X).
+	WorldMapEditLayoutInstance MakeInst(const char* guid, double x)
+	{
+		WorldMapEditLayoutInstance i;
+		i.guid = guid;
+		i.gltfContentRelativePath = "zones/zone_test/rock.gltf";
+		i.worldX = x;
+		return i;
+	}
+
+	/// Construit des EntityEditOps factices opérant sur \p insts, avec la même
+	/// sémantique que les foncteurs Engine : capture par index, remove par
+	/// guid, restore au rang d'origine (borné), duplicate = guid neuf + +1,5 m.
+	EntityEditOps MakeLayoutOps(std::vector<WorldMapEditLayoutInstance>& insts)
+	{
+		EntityEditOps ops;
+		ops.capture = [&insts](EntityId id, EntitySnapshot& out) -> bool
+		{
+			if (id.kind != EntityKind::LayoutInstance || id.index >= insts.size()) return false;
+			out.kind = id.kind;
+			out.layout = insts[id.index];
+			out.layoutIndex = id.index;
+			return true;
+		};
+		ops.remove = [&insts](const EntitySnapshot& s) -> bool
+		{
+			if (s.kind != EntityKind::LayoutInstance) return false;
+			for (size_t i = 0; i < insts.size(); ++i)
+			{
+				if (insts[i].guid == s.layout.guid)
+				{
+					insts.erase(insts.begin() + static_cast<ptrdiff_t>(i));
+					return true;
+				}
+			}
+			return false;
+		};
+		ops.restore = [&insts](const EntitySnapshot& s) -> bool
+		{
+			if (s.kind != EntityKind::LayoutInstance) return false;
+			const size_t at = s.layoutIndex < insts.size() ? s.layoutIndex : insts.size();
+			insts.insert(insts.begin() + static_cast<ptrdiff_t>(at), s.layout);
+			return true;
+		};
+		ops.duplicate = [&insts](const EntitySnapshot& src, EntitySnapshot& outCopy) -> bool
+		{
+			if (src.kind != EntityKind::LayoutInstance) return false;
+			static int s_seq = 1;
+			outCopy = src;
+			outCopy.layout.guid = std::string("dup_") + std::to_string(s_seq++);
+			outCopy.layout.worldX += 1.5;
+			outCopy.layoutIndex = static_cast<uint32_t>(insts.size());
+			insts.push_back(outCopy.layout);
+			return true;
+		};
+		return ops;
+	}
+
+	void Test_DeleteExecuteUndoRedo()
+	{
+		std::vector<WorldMapEditLayoutInstance> insts{
+			MakeInst("a", 0.0), MakeInst("b", 1.0), MakeInst("c", 2.0) };
+		EntityEditOps ops = MakeLayoutOps(insts);
+
+		DeleteEntityCommand cmd(EntityId{EntityKind::LayoutInstance, 1u}, ops);
+		cmd.Execute();
+		REQUIRE(insts.size() == 2u);
+		REQUIRE(insts[0].guid == "a");
+		REQUIRE(insts[1].guid == "c");
+
+		// Undo : "b" revient à SON rang d'origine (index 1), pas en fin.
+		cmd.Undo();
+		REQUIRE(insts.size() == 3u);
+		REQUIRE(insts[1].guid == "b");
+
+		// Redo : re-suppression par guid (les index ont pu bouger entre-temps).
+		cmd.Execute();
+		REQUIRE(insts.size() == 2u);
+		REQUIRE(insts[1].guid == "c");
+	}
+
+	void Test_DeleteInvalidIndexIsNoop()
+	{
+		std::vector<WorldMapEditLayoutInstance> insts{ MakeInst("a", 0.0) };
+		EntityEditOps ops = MakeLayoutOps(insts);
+
+		DeleteEntityCommand cmd(EntityId{EntityKind::LayoutInstance, 7u}, ops);
+		cmd.Execute();
+		REQUIRE(insts.size() == 1u); // rien supprimé
+		cmd.Undo();
+		REQUIRE(insts.size() == 1u); // rien réinséré non plus
+	}
+
+	void Test_DuplicateExecuteUndoRedo()
+	{
+		std::vector<WorldMapEditLayoutInstance> insts{ MakeInst("a", 10.0) };
+		EntityEditOps ops = MakeLayoutOps(insts);
+
+		DuplicateEntityCommand cmd(EntityId{EntityKind::LayoutInstance, 0u}, ops);
+		cmd.Execute();
+		REQUIRE(insts.size() == 2u);
+		REQUIRE(insts[1].guid != "a");            // guid neuf
+		REQUIRE(insts[1].worldX == 11.5);          // décalage +1,5 m
+		const std::string copyGuid = insts[1].guid;
+
+		cmd.Undo();
+		REQUIRE(insts.size() == 1u);
+		REQUIRE(insts[0].guid == "a");
+
+		// Redo : la MÊME copie revient (guid conservé, pas un 2e clone).
+		cmd.Execute();
+		REQUIRE(insts.size() == 2u);
+		REQUIRE(insts[1].guid == copyGuid);
+	}
+
+	void Test_ViaCommandStack()
+	{
+		std::vector<WorldMapEditLayoutInstance> insts{
+			MakeInst("a", 0.0), MakeInst("b", 1.0) };
+		EntityEditOps ops = MakeLayoutOps(insts);
+		CommandStack stack;
+
+		stack.Push(std::make_unique<DuplicateEntityCommand>(
+			EntityId{EntityKind::LayoutInstance, 0u}, ops));
+		REQUIRE(insts.size() == 3u);
+		stack.Push(std::make_unique<DeleteEntityCommand>(
+			EntityId{EntityKind::LayoutInstance, 1u}, ops)); // supprime "b"
+		REQUIRE(insts.size() == 2u);
+		REQUIRE(stack.UndoSize() == 2u); // pas de coalescing entre ces commandes
+
+		stack.Undo(); // "b" revient
+		REQUIRE(insts.size() == 3u);
+		REQUIRE(insts[1].guid == "b");
+		stack.Undo(); // la copie disparaît
+		REQUIRE(insts.size() == 2u);
+		stack.Redo();
+		stack.Redo();
+		REQUIRE(insts.size() == 2u);
+		REQUIRE(insts[0].guid == "a");
+	}
+}
+
+int main()
+{
+	Test_DeleteExecuteUndoRedo();
+	Test_DeleteInvalidIndexIsNoop();
+	Test_DuplicateExecuteUndoRedo();
+	Test_ViaCommandStack();
+
+	if (g_failed == 0)
+	{
+		std::printf("[PASS] EntityEditCommandsTests\n");
+		return 0;
+	}
+	std::printf("[FAIL] EntityEditCommandsTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -3065,6 +3065,11 @@ namespace engine::editor
 			MenuItemForAction("edit.redo");
 			MenuItemForAction("edit.history");
 			ImGui::Separator();
+			// Lot 5 (2026-07-18) — édition structurelle de la sélection
+			// (Outliner / Ctrl+clic viewport). Grisées sans sélection éditable.
+			MenuItemForAction("edit.duplicate");
+			MenuItemForAction("edit.delete");
+			ImGui::Separator();
 			MenuItemForAction("app.command-palette");
 			MenuItemForAction("edit.preferences");
 			MenuItemForAction("help.shortcuts");
@@ -3499,6 +3504,9 @@ namespace engine::editor
 			{ "Panneaux du shell",               "F1..F12" },
 			{ "Annuler / Rétablir",              "Ctrl+Z / Ctrl+Y" },
 			{ "Palette de commandes",            "Ctrl+P" },
+			// Lot 5 (2026-07-18) — la sélection d'entité alimente
+			// Dupliquer (Ctrl+D) / Supprimer (Suppr), listés en Édition.
+			{ "Sélectionner une entité (viewport)", "Ctrl+clic gauche" },
 		};
 		ImGui::SeparatorText("Caméra & navigation");
 		for (const StaticShortcut& s : kStaticShortcuts)


### PR DESCRIPTION
## Objectif

L editeur monde ne permettait pas de dupliquer ni de supprimer l entite selectionnee (Ctrl+clic viewport ou Outliner) de facon undoable : les seules suppressions passaient par des boutons legacy non undoables. Ce lot branche les deux operations sur la vraie selection (EditorSelection) et la pile undo/redo.

## Changements

- **EntityEditOps** (scene/, nouveau) : snapshot d entite + 4 foncteurs capture / remove / restore / duplicate installes par l Engine (meme pattern que le TransformWriter). Remove/restore par **guid stable**, jamais par index (les index de scene glissent apres toute edition structurelle).
- **DeleteEntityCommand / DuplicateEntityCommand** (nouveaux, undoables) : Undo d une suppression reinsere au rang d origine ; Redo d une duplication reinsere la meme copie (guid conserve, pas un 2e clone).
- **Kinds supportes** : LayoutInstance (props/arbres), MeshInsert (grottes/arches/surplombs), DungeonPortal. Terrain et Water exclus (actions grisees).
- **Duplication** : nouveau guid + decalage +1,5 m en X (copie visible a cote de l original) ; la selection reste sur l original. **Suppression** : la selection est videe (sinon elle pointerait une autre entite apres glissement d index).
- **UI** : actions edit.duplicate / edit.delete au registre → menu Edition, palette Ctrl+P et fenetre Raccourcis (auto). Raccourcis **Ctrl+D** / **Suppr** routes par Engine, ignores quand un champ de texte ImGui est actif ; **Ctrl+Shift+D reste l outil Dungeon Portal**.
- **Key::Delete** (VK 0x2E) ajoute a l enum partage Input.h.
- **Tests** : EntityEditCommandsTests (Execute/Undo/Redo, rang d origine, guid neuf, no-op index invalide, integration CommandStack) — pur CPU, execute par le ctest Linux.

## Limites connues (dette existante, hors scope)

Le placement legacy de props (clic terrain via la session) reste non-undoable ; seule la duplication/suppression via ces nouvelles commandes entre dans l historique.

## Validation

- CI : build Windows + ctest Linux (nouveaux tests).
- En jeu (editeur) : Ctrl+clic sur un arbre/prop → menu Edition ou Ctrl+D duplique (copie decalee de 1,5 m), Suppr supprime, Ctrl+Z/Ctrl+Y font le tour complet.

**Deploiement** : ✅ client uniquement (editeur), pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)