### PR TITLE
feat(server): recompenses anniversaire SP1 - exploits fidelite/naissance + courrier cadeau

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,8 @@ add_library(engine_core
   src/shared/core/Clock.cpp
   src/shared/core/Config.cpp
   src/shared/items/ItemCatalog.cpp
+  # Anniversaires (spec 2026-07-18) — logique calendaire pure (tests + master).
+  src/shared/anniversary/AnniversaryMath.cpp
   src/shared/core/ServerEndpoints.cpp
   src/shared/core/Profiler.cpp
   src/shared/core/jobs/JobSystem.cpp
@@ -1506,6 +1508,17 @@ if(MSVC)
   target_compile_options(config_save_to_file_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
 endif()
 add_test(NAME config_save_to_file_tests COMMAND config_save_to_file_tests)
+
+# Anniversaires (spec 2026-07-18) — Tests CPU pour AnniversaryMath (parse
+# strict yyyy-mm-dd, années révolues, 29/02→28/02, jour J, validation
+# naissance). Pur CPU, non gate WIN32 (ctest build-linux).
+add_executable(anniversary_math_tests src/shared/anniversary/tests/AnniversaryMathTests.cpp)
+target_include_directories(anniversary_math_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(anniversary_math_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(anniversary_math_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME anniversary_math_tests COMMAND anniversary_math_tests)
 
 # PR1 — Tests CPU pour Config::LoadServerConfig (éclatement config.json).
 # Vérifie la fusion des clés serveur (db/accounts/chat) et le renvoi false

--- a/deploy/docker/sql/migrations/0074_anniversary_exploits.sql
+++ b/deploy/docker/sql/migrations/0074_anniversary_exploits.sql
@@ -1,0 +1,67 @@
+-- Migration 0074 — Récompenses d'anniversaire (inscription & naissance).
+--
+-- Deux familles d'exploits scope=account, débloquées par le master
+-- (AnniversaryService, cf. docs/superpowers/specs/2026-07-18-anniversary-
+-- rewards-design.md) :
+--   * signup_anniv_N  : « Fidèle depuis N an(s) » — années révolues depuis
+--                       accounts.created_at ; crédité à la connexion suivante
+--                       (jamais perdu, rattrapage automatique).
+--   * birthday_N      : « N anniversaire(s) fêté(s) » — connexion le jour J
+--                       (UTC) de accounts.birth_date (jour strict).
+--
+-- Table de garde account_anniversary_rewards : idempotence des OCTROIS
+-- annuels (exploit naissance + courrier cadeau) — une seule ligne par
+-- (compte, année, type), même en cas de reconnexions multiples le jour J.
+-- (Les exploits eux-mêmes sont déjà idempotents par la PK
+--  (account_id, exploit_id) de account_exploit_unlocks.)
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+START TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS account_anniversary_rewards (
+  account_id   BIGINT UNSIGNED NOT NULL,
+  reward_year  SMALLINT UNSIGNED NOT NULL
+               COMMENT 'année civile UTC de l''octroi (ex. 2026)',
+  kind         VARCHAR(32)     NOT NULL
+               COMMENT 'birthday_exploit | birthday_gift',
+  granted_at   TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (account_id, reward_year, kind),
+  KEY ix_anniv_rewards_kind (kind)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Garde d''idempotence des octrois annuels d''anniversaire (naissance)';
+
+-- Paliers « fidélité » (anniversaire d'inscription). metric_source
+-- signup_years = années révolues depuis accounts.created_at.
+INSERT IGNORE INTO exploits (code, title, description, scope, metric_source, threshold_value, sort_order)
+VALUES
+  ('signup_anniv_1',  'Fidèle depuis 1 an',    'Un an de jeu depuis l''inscription du compte.',      'account', 'signup_years',  1, 201),
+  ('signup_anniv_2',  'Fidèle depuis 2 ans',   'Deux ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  2, 202),
+  ('signup_anniv_3',  'Fidèle depuis 3 ans',   'Trois ans de jeu depuis l''inscription du compte.',  'account', 'signup_years',  3, 203),
+  ('signup_anniv_4',  'Fidèle depuis 4 ans',   'Quatre ans de jeu depuis l''inscription du compte.', 'account', 'signup_years',  4, 204),
+  ('signup_anniv_5',  'Fidèle depuis 5 ans',   'Cinq ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  5, 205),
+  ('signup_anniv_6',  'Fidèle depuis 6 ans',   'Six ans de jeu depuis l''inscription du compte.',    'account', 'signup_years',  6, 206),
+  ('signup_anniv_7',  'Fidèle depuis 7 ans',   'Sept ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  7, 207),
+  ('signup_anniv_8',  'Fidèle depuis 8 ans',   'Huit ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  8, 208),
+  ('signup_anniv_9',  'Fidèle depuis 9 ans',   'Neuf ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  9, 209),
+  ('signup_anniv_10', 'Fidèle depuis 10 ans',  'Dix ans de jeu depuis l''inscription du compte.',    'account', 'signup_years', 10, 210);
+
+-- Paliers « anniversaire fêté en jeu » (date de naissance, jour J strict).
+-- metric_source birthday_years = nombre d'anniversaires fêtés en jeu.
+INSERT IGNORE INTO exploits (code, title, description, scope, metric_source, threshold_value, sort_order)
+VALUES
+  ('birthday_1',  'Premier anniversaire fêté',    'Connecté le jour de son anniversaire — la première fois.', 'account', 'birthday_years',  1, 301),
+  ('birthday_2',  '2 anniversaires fêtés',        'Deux anniversaires fêtés en jeu.',                         'account', 'birthday_years',  2, 302),
+  ('birthday_3',  '3 anniversaires fêtés',        'Trois anniversaires fêtés en jeu.',                        'account', 'birthday_years',  3, 303),
+  ('birthday_4',  '4 anniversaires fêtés',        'Quatre anniversaires fêtés en jeu.',                       'account', 'birthday_years',  4, 304),
+  ('birthday_5',  '5 anniversaires fêtés',        'Cinq anniversaires fêtés en jeu.',                         'account', 'birthday_years',  5, 305),
+  ('birthday_6',  '6 anniversaires fêtés',        'Six anniversaires fêtés en jeu.',                          'account', 'birthday_years',  6, 306),
+  ('birthday_7',  '7 anniversaires fêtés',        'Sept anniversaires fêtés en jeu.',                         'account', 'birthday_years',  7, 307),
+  ('birthday_8',  '8 anniversaires fêtés',        'Huit anniversaires fêtés en jeu.',                         'account', 'birthday_years',  8, 308),
+  ('birthday_9',  '9 anniversaires fêtés',        'Neuf anniversaires fêtés en jeu.',                         'account', 'birthday_years',  9, 309),
+  ('birthday_10', '10 anniversaires fêtés',       'Dix anniversaires fêtés en jeu.',                          'account', 'birthday_years', 10, 310);
+
+COMMIT;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/docs/superpowers/specs/2026-07-18-anniversary-rewards-design.md
+++ b/docs/superpowers/specs/2026-07-18-anniversary-rewards-design.md
@@ -1,0 +1,133 @@
+# Récompenses d'anniversaire (inscription & naissance) — design
+
+Date : 2026-07-18
+Statut : validé par l'utilisateur (approche 1, découpage SP1/SP2/SP3)
+
+## Objectif
+
+Récompenser la fidélité des joueurs à partir de deux dates **immuables** :
+
+1. **Anniversaire d'inscription** (`accounts.created_at`) : un exploit
+   (« Fidèle depuis N an(s) ») par année révolue. **Jamais perdu** : crédité à
+   la connexion suivante, quelle qu'elle soit (rattrapage automatique de tous
+   les paliers manquants).
+2. **Anniversaire de naissance** (`accounts.birth_date`, saisie à
+   l'inscription) : **jour J strict** (UTC). Si le joueur se connecte ET entre
+   en monde le jour même : un exploit annuel (« N anniversaire(s) fêté(s) »)
+   + un courrier cadeau : **50 or + 50 argent + 50 bronze**, **1 gâteau parmi
+   10 (aléatoire)**, **1 cosmétique millésimé**. Pas connecté le jour J =
+   perdu pour l'année.
+
+## Anti-triche (exigence forte)
+
+- `created_at` et `birth_date` sont **immuables** : écrits une seule fois à
+  l'inscription (INSERT), aucun chemin de modification (ni opcode, ni portail
+  web — vérifier et retirer toute édition existante de `birth_date`).
+- `birth_date` est validée côté serveur à l'inscription (format `yyyy-mm-dd`,
+  date réelle, plausible : entre 1900 et aujourd'hui).
+- Toutes les décisions (calcul d'années, éligibilité jour J, octrois) sont
+  côté **master**, en **UTC**. Le client n'envoie jamais de date après
+  l'inscription.
+- Idempotence : exploits par PK `(account_id, exploit_id)` (INSERT IGNORE) ;
+  cadeaux par table de garde `account_anniversary_rewards
+  (account_id, reward_year, kind)` (PK) — une seule livraison par compte/an
+  même en cas de reconnexions multiples le même jour.
+- 29 février : fêté le 28/02 les années non bissextiles.
+
+## Existant réutilisé
+
+- `accounts.created_at` (0001) et `accounts.birth_date` (0023/0066) : déjà en
+  DB ; `birth_date` déjà chargée (`AccountRecord`) ; **`created_at` à ajouter
+  au chargement** (lecture seule).
+- Écran d'inscription client : collecte déjà prénom/nom/date de
+  naissance/pays.
+- Schéma exploits (0008/0015) : `exploits` (catalogue) +
+  `account_exploit_unlocks` — lu par le portail web ; **aucun writer C++**
+  (à créer).
+- Courrier in-game (opcodes 49-58, `MysqlMailStore::Insert`) : pièces jointes
+  objets (`mail_items`) + or (`copper_gold`) → canal de livraison des cadeaux.
+- Chat relay (opcode 46) : notification système « Exploit débloqué : … ».
+- Système d'auras/buffs shard (Wave 23) : support du buff du gâteau.
+- Groupes (LFG) et guildes : cibles du partage du gâteau.
+
+## Architecture (approche 1 — détection à la connexion)
+
+Nouveau `AnniversaryService` côté master, sans scheduler :
+
+- **À l'AUTH** : années révolues depuis `created_at` → débloque tous les
+  `signup_anniv_*` manquants. Si jour UTC == jour/mois de `birth_date` →
+  débloque `birthday_N` avec N = (nombre de paliers `birthday_*` déjà
+  débloqués dans `account_exploit_unlocks`) + 1 ; l'idempotence intra-jour
+  est assurée par la garde `(account_id, year, 'birthday_exploit')`.
+- **Au premier EnterWorld du jour J de naissance** : dépose le courrier
+  cadeau au personnage entrant (il faut un destinataire personnage). Garde
+  `(account_id, year, 'birthday_gift')`. Pas d'EnterWorld le jour J = pas de
+  cadeaux.
+- La logique de dates vit dans un module pur (`AnniversaryMath`) avec horloge
+  injectée (testable).
+
+## Données
+
+- Migration `0074_anniversary_exploits.sql` :
+  - seed `exploits` : `signup_anniv_1..10` (metric_source `signup_years`,
+    threshold N) et `birthday_1..10` (metric_source `birthday_years`),
+    scope `account`, titres FR ;
+  - table `account_anniversary_rewards (account_id, reward_year, kind,
+    granted_at)` PK `(account_id, reward_year, kind)`.
+- `game/data/items/items.json` : 10 gâteaux (`anniv_cake_01..10`, un buff
+  distinct chacun) + cosmétiques millésimés (`anniv_keepsake_<slot>_<année>`,
+  bonus réels modestes, slot tournant par année de fidélité : an 1 = cape/dos,
+  an 2 = anneau, an 3 = amulette…). Les cadeaux arrivent dans l'inventaire
+  via le courrier, **jamais auto-équipés**.
+- Or du courrier : montant encodé dans l'unité de base de la monnaie
+  (50 or + 50 argent + 50 bronze, mapping vérifié sur la convention 100:1 de
+  l'affichage client).
+
+## Le gâteau (gameplay, SP3)
+
+- Reçu le jour J, le gâteau est un objet d'inventaire. Le joueur le place
+  **lui-même** dans la barre d'action (qui accepte désormais des objets en
+  plus des sorts du Grimoire).
+- Activé, il applique une aura de buff aux membres du **groupe ou de la
+  guilde** dans un rayon configurable (défaut 30 m). L'aura est entretenue
+  par le shard **tant que le gâteau reste slotté** ; retiré du slot, elle
+  tombe immédiatement.
+- 10 gâteaux = 10 buffs distincts (data), pour éviter que tout le monde
+  compte sur le même.
+- À minuit UTC de la fin du jour J, le gâteau est « mangé » : retiré de
+  l'inventaire et de la barre (expiration par pile d'objet, nouveau champ).
+
+## UI (SP2)
+
+- Deux opcodes additifs (pattern Grimoire 88/89) : « liste de mes exploits »
+  → (code, titre, débloqué le / verrouillé ; les `is_secret` non débloqués
+  sont omis).
+- Nouvel onglet **Exploits** dans la fenêtre Personnage (F1) : débloqués avec
+  date, puis verrouillés grisés.
+- Le portail web continue de lire les mêmes tables (zéro changement).
+
+## Découpage & déploiement
+
+| PR | Contenu | Déploiement |
+|---|---|---|
+| SP1 | created_at chargé + validation/gel birth_date + migration 0074 + MysqlExploitStore + AnniversaryService (AUTH + EnterWorld) + courrier cadeaux + items data + notifications chat | ⚠️ master + DB (migration au boot) |
+| SP2 | opcodes liste exploits + onglet F1 Exploits | ⚠️ lock-step client + master |
+| SP3 | objets dans la barre d'action + activation gâteau + aura de zone groupe/guilde + expiration minuit | ⚠️ lock-step client + shard (bump protocole probable) |
+
+Ordre de merge : SP1 → SP2 → SP3 (SP2/SP3 portent les commits de leurs
+prédécesseurs, PRs base main).
+
+## Tests
+
+- `AnniversaryMath` pur (années révolues, 29/02, éligibilité jour J, UTC) —
+  ctest Linux.
+- Round-trip des payloads des nouveaux opcodes (SP2/SP3).
+- Idempotence du service avec stores factices (double AUTH le même jour = un
+  seul octroi).
+
+## Hors périmètre (dettes notées)
+
+- Transmog/apparence pure (le cosmétique utilise l'équipement à stats).
+- Persistance MySQL du portefeuille shard (`player_wallet` reste orpheline ;
+  l'or transite par le courrier).
+- Fenêtre de grâce pour l'anniversaire de naissance (choix : jour strict).

--- a/game/data/items/items.json
+++ b/game/data/items/items.json
@@ -89,6 +89,177 @@
       "type": "accessory",
       "slot": "ring1",
       "bonus": { "damage": 4 }
+    },
+    {
+      "_comment": "Anniversaires (spec 2026-07-18) — 10 gateaux (5101-5110, un buff distinct chacun, active en SP3 : partage groupe/guilde en rayon, valable le jour J seulement) + 10 souvenirs millesimes (5121-5130, An 1..10, slots tournants, bonus reels modestes). Plage 5101-5130 RESERVEE anniversaires.",
+      "id": 5101,
+      "name": "Gateau des braves",
+      "description": "Un gateau d'anniversaire a partager : +force pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_braves.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5102,
+      "name": "Gateau du colosse",
+      "description": "Un gateau d'anniversaire a partager : +endurance pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_colosse.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5103,
+      "name": "Gateau du zephyr",
+      "description": "Un gateau d'anniversaire a partager : +vitesse pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_zephyr.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5104,
+      "name": "Gateau du sage",
+      "description": "Un gateau d'anniversaire a partager : +esprit pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_sage.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5105,
+      "name": "Gateau du guetteur",
+      "description": "Un gateau d'anniversaire a partager : +perception pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_guetteur.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5106,
+      "name": "Gateau du duelliste",
+      "description": "Un gateau d'anniversaire a partager : +precision pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_duelliste.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5107,
+      "name": "Gateau du gardien",
+      "description": "Un gateau d'anniversaire a partager : +points de vie pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_gardien.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5108,
+      "name": "Gateau de l'erudit",
+      "description": "Un gateau d'anniversaire a partager : +ressource pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_erudit.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5109,
+      "name": "Gateau du chasseur",
+      "description": "Un gateau d'anniversaire a partager : +degats pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_chasseur.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5110,
+      "name": "Gateau du vagabond",
+      "description": "Un gateau d'anniversaire a partager : +recuperation pour le groupe. Ne se conserve pas au-dela du jour J.",
+      "icon": "items/gateau_vagabond.png",
+      "type": "consumable",
+      "slot": "none"
+    },
+    {
+      "id": 5121,
+      "name": "Amulette des fideles - An 1",
+      "description": "Souvenir du premier anniversaire fete en jeu. Une vraie recompense, pas un gadget.",
+      "icon": "items/souvenir_an1.png",
+      "type": "accessory",
+      "slot": "amulet",
+      "bonus": { "hp": 20, "resource": 15 }
+    },
+    {
+      "id": 5122,
+      "name": "Anneau des fideles - An 2",
+      "description": "Souvenir du deuxieme anniversaire fete en jeu.",
+      "icon": "items/souvenir_an2.png",
+      "type": "accessory",
+      "slot": "ring1",
+      "bonus": { "damage": 5, "accuracy": 3 }
+    },
+    {
+      "id": 5123,
+      "name": "Couronne des fideles - An 3",
+      "description": "Souvenir du troisieme anniversaire fete en jeu.",
+      "icon": "items/souvenir_an3.png",
+      "type": "armor",
+      "slot": "head",
+      "bonus": { "hp": 25, "perception": 4 }
+    },
+    {
+      "id": 5124,
+      "name": "Gantelets des fideles - An 4",
+      "description": "Souvenir du quatrieme anniversaire fete en jeu.",
+      "icon": "items/souvenir_an4.png",
+      "type": "armor",
+      "slot": "hands",
+      "bonus": { "hp": 15, "accuracy": 4, "damage": 3 }
+    },
+    {
+      "id": 5125,
+      "name": "Bottes des fideles - An 5",
+      "description": "Souvenir du cinquieme anniversaire fete en jeu.",
+      "icon": "items/souvenir_an5.png",
+      "type": "armor",
+      "slot": "feet",
+      "bonus": { "hp": 15, "speedWalk": 0.3, "speedRun": 0.4 }
+    },
+    {
+      "id": 5126,
+      "name": "Plastron des fideles - An 6",
+      "description": "Souvenir du sixieme anniversaire fete en jeu.",
+      "icon": "items/souvenir_an6.png",
+      "type": "armor",
+      "slot": "chest",
+      "bonus": { "hp": 40, "stamina": 6 }
+    },
+    {
+      "id": 5127,
+      "name": "Jambieres des fideles - An 7",
+      "description": "Souvenir du septieme anniversaire fete en jeu.",
+      "icon": "items/souvenir_an7.png",
+      "type": "armor",
+      "slot": "legs",
+      "bonus": { "hp": 30, "stamina": 5 }
+    },
+    {
+      "id": 5128,
+      "name": "Egide des fideles - An 8",
+      "description": "Souvenir du huitieme anniversaire fete en jeu.",
+      "icon": "items/souvenir_an8.png",
+      "type": "armor",
+      "slot": "offhand",
+      "bonus": { "hp": 30, "stamina": 4 }
+    },
+    {
+      "id": 5129,
+      "name": "Sceau des fideles - An 9",
+      "description": "Souvenir du neuvieme anniversaire fete en jeu.",
+      "icon": "items/souvenir_an9.png",
+      "type": "accessory",
+      "slot": "ring2",
+      "bonus": { "damage": 6, "hp": 15 }
+    },
+    {
+      "id": 5130,
+      "name": "Lame des fideles - An 10",
+      "description": "Souvenir du dixieme anniversaire fete en jeu. Dix ans, deja.",
+      "icon": "items/souvenir_an10.png",
+      "type": "weapon",
+      "slot": "mainhand",
+      "bonus": { "damage": 12, "accuracy": 4 }
     }
   ]
 }

--- a/sql/migrations/0074_anniversary_exploits.sql
+++ b/sql/migrations/0074_anniversary_exploits.sql
@@ -1,0 +1,67 @@
+-- Migration 0074 — Récompenses d'anniversaire (inscription & naissance).
+--
+-- Deux familles d'exploits scope=account, débloquées par le master
+-- (AnniversaryService, cf. docs/superpowers/specs/2026-07-18-anniversary-
+-- rewards-design.md) :
+--   * signup_anniv_N  : « Fidèle depuis N an(s) » — années révolues depuis
+--                       accounts.created_at ; crédité à la connexion suivante
+--                       (jamais perdu, rattrapage automatique).
+--   * birthday_N      : « N anniversaire(s) fêté(s) » — connexion le jour J
+--                       (UTC) de accounts.birth_date (jour strict).
+--
+-- Table de garde account_anniversary_rewards : idempotence des OCTROIS
+-- annuels (exploit naissance + courrier cadeau) — une seule ligne par
+-- (compte, année, type), même en cas de reconnexions multiples le jour J.
+-- (Les exploits eux-mêmes sont déjà idempotents par la PK
+--  (account_id, exploit_id) de account_exploit_unlocks.)
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+START TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS account_anniversary_rewards (
+  account_id   BIGINT UNSIGNED NOT NULL,
+  reward_year  SMALLINT UNSIGNED NOT NULL
+               COMMENT 'année civile UTC de l''octroi (ex. 2026)',
+  kind         VARCHAR(32)     NOT NULL
+               COMMENT 'birthday_exploit | birthday_gift',
+  granted_at   TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (account_id, reward_year, kind),
+  KEY ix_anniv_rewards_kind (kind)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+  COMMENT='Garde d''idempotence des octrois annuels d''anniversaire (naissance)';
+
+-- Paliers « fidélité » (anniversaire d'inscription). metric_source
+-- signup_years = années révolues depuis accounts.created_at.
+INSERT IGNORE INTO exploits (code, title, description, scope, metric_source, threshold_value, sort_order)
+VALUES
+  ('signup_anniv_1',  'Fidèle depuis 1 an',    'Un an de jeu depuis l''inscription du compte.',      'account', 'signup_years',  1, 201),
+  ('signup_anniv_2',  'Fidèle depuis 2 ans',   'Deux ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  2, 202),
+  ('signup_anniv_3',  'Fidèle depuis 3 ans',   'Trois ans de jeu depuis l''inscription du compte.',  'account', 'signup_years',  3, 203),
+  ('signup_anniv_4',  'Fidèle depuis 4 ans',   'Quatre ans de jeu depuis l''inscription du compte.', 'account', 'signup_years',  4, 204),
+  ('signup_anniv_5',  'Fidèle depuis 5 ans',   'Cinq ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  5, 205),
+  ('signup_anniv_6',  'Fidèle depuis 6 ans',   'Six ans de jeu depuis l''inscription du compte.',    'account', 'signup_years',  6, 206),
+  ('signup_anniv_7',  'Fidèle depuis 7 ans',   'Sept ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  7, 207),
+  ('signup_anniv_8',  'Fidèle depuis 8 ans',   'Huit ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  8, 208),
+  ('signup_anniv_9',  'Fidèle depuis 9 ans',   'Neuf ans de jeu depuis l''inscription du compte.',   'account', 'signup_years',  9, 209),
+  ('signup_anniv_10', 'Fidèle depuis 10 ans',  'Dix ans de jeu depuis l''inscription du compte.',    'account', 'signup_years', 10, 210);
+
+-- Paliers « anniversaire fêté en jeu » (date de naissance, jour J strict).
+-- metric_source birthday_years = nombre d'anniversaires fêtés en jeu.
+INSERT IGNORE INTO exploits (code, title, description, scope, metric_source, threshold_value, sort_order)
+VALUES
+  ('birthday_1',  'Premier anniversaire fêté',    'Connecté le jour de son anniversaire — la première fois.', 'account', 'birthday_years',  1, 301),
+  ('birthday_2',  '2 anniversaires fêtés',        'Deux anniversaires fêtés en jeu.',                         'account', 'birthday_years',  2, 302),
+  ('birthday_3',  '3 anniversaires fêtés',        'Trois anniversaires fêtés en jeu.',                        'account', 'birthday_years',  3, 303),
+  ('birthday_4',  '4 anniversaires fêtés',        'Quatre anniversaires fêtés en jeu.',                       'account', 'birthday_years',  4, 304),
+  ('birthday_5',  '5 anniversaires fêtés',        'Cinq anniversaires fêtés en jeu.',                         'account', 'birthday_years',  5, 305),
+  ('birthday_6',  '6 anniversaires fêtés',        'Six anniversaires fêtés en jeu.',                          'account', 'birthday_years',  6, 306),
+  ('birthday_7',  '7 anniversaires fêtés',        'Sept anniversaires fêtés en jeu.',                         'account', 'birthday_years',  7, 307),
+  ('birthday_8',  '8 anniversaires fêtés',        'Huit anniversaires fêtés en jeu.',                         'account', 'birthday_years',  8, 308),
+  ('birthday_9',  '9 anniversaires fêtés',        'Neuf anniversaires fêtés en jeu.',                         'account', 'birthday_years',  9, 309),
+  ('birthday_10', '10 anniversaires fêtés',       'Dix anniversaires fêtés en jeu.',                          'account', 'birthday_years', 10, 310);
+
+COMMIT;
+
+SET FOREIGN_KEY_CHECKS = 1;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,6 +220,10 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/chat/ChatChannelRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/mail/MailManager.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/mail/MysqlMailStore.cpp
+    # Anniversaires (spec 2026-07-18) : exploits fidelite/naissance + courrier cadeau.
+    ${CMAKE_SOURCE_DIR}/src/masterd/exploits/MysqlExploitStore.cpp
+    ${CMAKE_SOURCE_DIR}/src/masterd/anniversary/AnniversaryService.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/anniversary/AnniversaryMath.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/gmtickets/MysqlGmTicketStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/reputation/MysqlReputationStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/social/MysqlIgnoreStore.cpp

--- a/src/masterd/anniversary/AnniversaryService.cpp
+++ b/src/masterd/anniversary/AnniversaryService.cpp
@@ -1,0 +1,165 @@
+// AnniversaryService — implémentation. Voir le header pour les règles.
+
+#include "src/masterd/anniversary/AnniversaryService.h"
+
+#include "src/masterd/exploits/MysqlExploitStore.h"
+#include "src/masterd/mail/MailManager.h"
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/SqlPreparedStatement.h"
+#include "src/shared/core/Log.h"
+
+#include <mysql.h>
+
+#include <chrono>
+#include <cstdio>
+
+namespace engine::server
+{
+	namespace
+	{
+		using engine::anniversary::YmdDate;
+
+		/// Libellé FR du palier fidélité N (aligné sur le seed 0074).
+		std::string SignupTitle(int n)
+		{
+			char buf[64];
+			std::snprintf(buf, sizeof(buf), "Fidèle depuis %d an%s", n, n > 1 ? "s" : "");
+			return std::string(buf);
+		}
+
+		/// Libellé FR du palier anniversaire N (aligné sur le seed 0074).
+		std::string BirthdayTitle(int n)
+		{
+			if (n <= 1) return std::string("Premier anniversaire fêté");
+			char buf[64];
+			std::snprintf(buf, sizeof(buf), "%d anniversaires fêtés", n);
+			return std::string(buf);
+		}
+	}
+
+	AnniversaryService::Result AnniversaryService::OnEnterWorld(uint64_t accountId,
+		const engine::anniversary::YmdDate& todayUtc)
+	{
+		Result result;
+		if (m_pool == nullptr || m_exploits == nullptr || !m_exploits->IsAvailable())
+			return result; // mode no-DB : silencieux (dev local / tests).
+
+		// Lecture ciblée des deux dates IMMUABLES du compte. created_at est un
+		// TIMESTAMP : formaté en date civile par MySQL (session serveur = UTC,
+		// convention déploiement Docker).
+		std::string createdStr;
+		std::string birthStr;
+		{
+			auto guard = m_pool->Acquire();
+			MYSQL* mysql = guard.get();
+			auto* cache = guard.cache();
+			if (!mysql || !cache) return result;
+			auto* stmt = cache->Acquire(mysql,
+				"SELECT DATE_FORMAT(created_at, '%Y-%m-%d'), COALESCE(birth_date, '') "
+				"FROM accounts WHERE id = ?");
+			if (stmt && stmt->Bind(0, accountId) && stmt->Execute() && stmt->FetchRow())
+			{
+				createdStr = stmt->GetString(0);
+				birthStr   = stmt->GetString(1);
+			}
+			else
+			{
+				LOG_WARN(Db, "[AnniversaryService] lecture dates compte {} échouée", accountId);
+				return result;
+			}
+		}
+
+		// ① Fidélité (inscription) — rattrapage de tous les paliers manquants.
+		YmdDate created{};
+		if (engine::anniversary::ParseYmd(createdStr, created))
+		{
+			const int years = engine::anniversary::YearsElapsed(created, todayUtc);
+			const int cap = years < kMaxTier ? years : kMaxTier;
+			for (int n = 1; n <= cap; ++n)
+			{
+				char code[32];
+				std::snprintf(code, sizeof(code), "signup_anniv_%d", n);
+				if (m_exploits->UnlockByCode(accountId, code, "anniversary_service") == 1)
+				{
+					result.unlockedTitles.push_back(SignupTitle(n));
+					LOG_INFO(Db, "[AnniversaryService] compte {} : exploit {} débloqué", accountId, code);
+				}
+			}
+		}
+
+		// ② Naissance — jour J strict uniquement.
+		YmdDate birth{};
+		if (!engine::anniversary::ParseYmd(birthStr, birth)
+			|| !engine::anniversary::IsAnniversaryDay(birth, todayUtc))
+		{
+			return result;
+		}
+		const uint16_t year = static_cast<uint16_t>(todayUtc.year);
+
+		// Exploit annuel (garde intra-jour : reconnexions multiples = 1 seul).
+		if (m_exploits->TryClaimAnnualReward(accountId, year, "birthday_exploit"))
+		{
+			const uint32_t already = m_exploits->CountUnlockedByMetric(accountId, "birthday_years");
+			const int n = static_cast<int>(already) + 1;
+			if (n <= kMaxTier)
+			{
+				char code[32];
+				std::snprintf(code, sizeof(code), "birthday_%d", n);
+				if (m_exploits->UnlockByCode(accountId, code, "anniversary_service") == 1)
+				{
+					result.unlockedTitles.push_back(BirthdayTitle(n));
+					LOG_INFO(Db, "[AnniversaryService] compte {} : exploit {} débloqué", accountId, code);
+				}
+			}
+		}
+
+		// Courrier cadeau (garde dédiée : découplé de l'exploit pour rester
+		// robuste si l'un des deux échoue). La garde est prise AVANT l'envoi :
+		// aucun double-envoi possible ; un échec du mail est loggué en ERROR
+		// (compensation manuelle possible via la table de garde).
+		if (m_mail != nullptr && m_exploits->TryClaimAnnualReward(accountId, year, "birthday_gift"))
+		{
+			const uint32_t celebrated = m_exploits->CountUnlockedByMetric(accountId, "birthday_years");
+			const uint32_t tier = celebrated == 0u ? 1u
+				: (celebrated > static_cast<uint32_t>(kMaxTier) ? static_cast<uint32_t>(kMaxTier) : celebrated);
+
+			// Gâteau : variante déterministe par (compte, année) — stable si
+			// l'envoi devait être rejoué, et répartie entre les 10 buffs.
+			const uint32_t cakeId = kFirstCakeItemId
+				+ static_cast<uint32_t>((accountId + static_cast<uint64_t>(year)) % kCakeVariantCount);
+			const uint32_t keepsakeId = kFirstKeepsakeItemId + (tier - 1u);
+
+			mail::Mail gift;
+			gift.senderAccountId   = 0u; // 0 = système
+			gift.receiverAccountId = accountId;
+			gift.subject = "Joyeux anniversaire !";
+			gift.body =
+				"Toute l'équipe vous souhaite un joyeux anniversaire !\n\n"
+				"Vous trouverez ci-joint un gâteau à partager avec votre groupe "
+				"ou votre guilde (aujourd'hui seulement), un souvenir de fidélité "
+				"et une bourse de 50 or, 50 argent et 50 bronze.\n\n"
+				"Bonne fête et bon jeu !";
+			gift.copperGold = kGiftBronze;
+			gift.items.push_back(mail::MailItemAttachment{ cakeId, 1u });
+			gift.items.push_back(mail::MailItemAttachment{ keepsakeId, 1u });
+			gift.sentTsMs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			gift.expiresTsMs = 0u; // le courrier n'expire pas (le gâteau, si — SP3).
+
+			if (m_mail->Insert(gift) != 0u)
+			{
+				result.birthdayGiftMailed = true;
+				LOG_INFO(Db, "[AnniversaryService] compte {} : courrier cadeau anniversaire envoyé "
+					"(mailId={}, gâteau={}, souvenir={})", accountId, gift.mailId, cakeId, keepsakeId);
+			}
+			else
+			{
+				LOG_ERROR(Db, "[AnniversaryService] compte {} : ÉCHEC envoi courrier cadeau "
+					"(garde {} déjà prise — compensation manuelle requise)", accountId, year);
+			}
+		}
+
+		return result;
+	}
+}

--- a/src/masterd/anniversary/AnniversaryService.h
+++ b/src/masterd/anniversary/AnniversaryService.h
@@ -1,0 +1,85 @@
+#pragma once
+// AnniversaryService — récompenses d'anniversaire (spec docs/superpowers/
+// specs/2026-07-18-anniversary-rewards-design.md). Déclenché par le master à
+// chaque EnterWorld réussi (point d'accroche unique : compte + personnage
+// destinataire + connexion chat disponibles) :
+//
+//   * Inscription (accounts.created_at, IMMUABLE) : débloque tous les paliers
+//     signup_anniv_N manquants (N = années révolues, plafond data 10).
+//     « Jamais perdu » : rattrapage automatique au prochain EnterWorld.
+//   * Naissance (accounts.birth_date, IMMUABLE) : si aujourd'hui (UTC) est le
+//     jour J (29/02 → 28/02 les années non bissextiles), débloque birthday_N
+//     et dépose un courrier cadeau (50 or + 50 argent + 50 bronze, 1 gâteau
+//     parmi 10, 1 souvenir millésimé). Jour strict : pas d'EnterWorld le jour
+//     J = pas de cadeau. Idempotence par account_anniversary_rewards.
+//
+// Anti-triche : les deux dates sont lues en DB côté master, jamais fournies
+// par le client ; tous les octrois sont idempotents par clés primaires.
+
+#include "src/shared/anniversary/AnniversaryMath.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace engine::server::db { class ConnectionPool; }
+namespace engine::server::mail { class IMailStore; }
+
+namespace engine::server
+{
+	class MysqlExploitStore;
+
+	class AnniversaryService
+	{
+	public:
+		/// Résultat d'un passage : libellés FR des exploits NOUVELLEMENT
+		/// débloqués (pour la notification chat « système ») et indicateur
+		/// d'envoi du courrier cadeau.
+		struct Result
+		{
+			std::vector<std::string> unlockedTitles;
+			bool birthdayGiftMailed = false;
+		};
+
+		/// \param pool  accès DB `accounts` (created_at / birth_date).
+		/// \param store store exploits + garde annuelle (peut être no-op si
+		///        DB indisponible — le service ne fait alors rien).
+		/// \param mail  store de courrier (production MySQL ; in-memory en
+		///        mode no-DB).
+		void SetDependencies(engine::server::db::ConnectionPool* pool,
+			MysqlExploitStore* store, engine::server::mail::IMailStore* mail)
+		{
+			m_pool = pool; m_exploits = store; m_mail = mail;
+		}
+
+		/// À appeler après un EnterWorld VALIDÉ. Lit les dates du compte,
+		/// débloque les paliers manquants et, le jour J de naissance, dépose
+		/// le courrier cadeau. \param todayUtc injecté pour les tests
+		/// (production : anniversary::TodayUtc()).
+		/// Effets de bord : écritures DB (unlocks, garde, mail) + logs.
+		Result OnEnterWorld(uint64_t accountId, const engine::anniversary::YmdDate& todayUtc);
+
+		/// Plafond des paliers seedés par la migration 0074 (signup et
+		/// birthday). Au-delà, aucun code d'exploit n'existe : on borne.
+		static constexpr int kMaxTier = 10;
+
+		/// Montant du cadeau : 50 or + 50 argent + 50 bronze, exprimé dans
+		/// l'unité de base (bronze) de l'affichage client (100:1:1, cf.
+		/// CurrencyFormat.h) — le champ mail `copper_gold` est réinterprété
+		/// en bronze par le client.
+		static constexpr uint64_t kGiftBronze = 50ull * 10000ull + 50ull * 100ull + 50ull;
+
+		/// Plage d'ids des gâteaux d'anniversaire dans items.json (10
+		/// variantes, buffs distincts — SP3 branche l'activation).
+		static constexpr uint32_t kFirstCakeItemId = 5101u;
+		static constexpr uint32_t kCakeVariantCount = 10u;
+
+		/// Plage d'ids des souvenirs millésimés (An 1..10, slots tournants).
+		static constexpr uint32_t kFirstKeepsakeItemId = 5121u;
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+		MysqlExploitStore*                  m_exploits = nullptr;
+		engine::server::mail::IMailStore*   m_mail = nullptr;
+	};
+}

--- a/src/masterd/exploits/MysqlExploitStore.cpp
+++ b/src/masterd/exploits/MysqlExploitStore.cpp
@@ -1,0 +1,99 @@
+// MysqlExploitStore — implémentation (prepared statements, pattern N1-D
+// des autres stores masterd). Voir le header.
+
+#include "src/masterd/exploits/MysqlExploitStore.h"
+
+#include "src/shared/db/ConnectionPool.h"
+#include "src/shared/db/SqlPreparedStatement.h"
+#include "src/shared/core/Log.h"
+
+#include <mysql.h>
+
+namespace engine::server
+{
+	bool MysqlExploitStore::IsAvailable() const
+	{
+		return m_pool != nullptr && m_pool->IsInitialized();
+	}
+
+	int MysqlExploitStore::UnlockByCode(uint64_t accountId, std::string_view code,
+		std::string_view sourceDetail)
+	{
+		if (!IsAvailable()) return -1;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return -1;
+
+		// INSERT IGNORE + SELECT sur le catalogue : 0 rang si le code est
+		// inconnu/inactif OU si la PK (account_id, exploit_id) existe déjà.
+		auto* stmt = cache->Acquire(mysql,
+			"INSERT IGNORE INTO account_exploit_unlocks (account_id, exploit_id, source_detail) "
+			"SELECT ?, id, ? FROM exploits WHERE code = ? AND is_active = 1");
+		const bool ok = stmt
+			&& stmt->Bind(0, accountId)
+			&& stmt->Bind(1, sourceDetail)
+			&& stmt->Bind(2, code)
+			&& stmt->Execute();
+		if (!ok)
+		{
+			LOG_WARN(Db, "[MysqlExploitStore] UnlockByCode('{}') failed: {}",
+				std::string(code), mysql_error(mysql));
+			return -1;
+		}
+		return stmt->AffectedRows() > 0 ? 1 : 0;
+	}
+
+	uint32_t MysqlExploitStore::CountUnlockedByMetric(uint64_t accountId,
+		std::string_view metricSource)
+	{
+		if (!IsAvailable()) return 0;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return 0;
+
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT COUNT(*) FROM account_exploit_unlocks u "
+			"JOIN exploits e ON e.id = u.exploit_id "
+			"WHERE u.account_id = ? AND e.metric_source = ?");
+		if (stmt
+			&& stmt->Bind(0, accountId)
+			&& stmt->Bind(1, metricSource)
+			&& stmt->Execute()
+			&& stmt->FetchRow())
+		{
+			return static_cast<uint32_t>(stmt->GetUInt64(0));
+		}
+		LOG_WARN(Db, "[MysqlExploitStore] CountUnlockedByMetric('{}') failed",
+			std::string(metricSource));
+		return 0;
+	}
+
+	bool MysqlExploitStore::TryClaimAnnualReward(uint64_t accountId, uint16_t year,
+		std::string_view kind)
+	{
+		if (!IsAvailable()) return false;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return false;
+
+		auto* stmt = cache->Acquire(mysql,
+			"INSERT IGNORE INTO account_anniversary_rewards (account_id, reward_year, kind) "
+			"VALUES (?, ?, ?)");
+		const uint32_t y = year;
+		const bool ok = stmt
+			&& stmt->Bind(0, accountId)
+			&& stmt->Bind(1, y)
+			&& stmt->Bind(2, kind)
+			&& stmt->Execute();
+		if (!ok)
+		{
+			LOG_WARN(Db, "[MysqlExploitStore] TryClaimAnnualReward({}, '{}') failed: {}",
+				year, std::string(kind), mysql_error(mysql));
+			return false;
+		}
+		return stmt->AffectedRows() > 0;
+	}
+}

--- a/src/masterd/exploits/MysqlExploitStore.h
+++ b/src/masterd/exploits/MysqlExploitStore.h
@@ -1,0 +1,48 @@
+#pragma once
+// MysqlExploitStore — premier writer C++ du système d'exploits (migration
+// 0008 : catalogue `exploits` + `account_exploit_unlocks`, lu par le portail
+// web). Introduit pour les récompenses d'anniversaire (spec 2026-07-18) ;
+// conçu générique : tout futur système (quêtes, exploration…) peut débloquer
+// un exploit par son code.
+//
+// Idempotence par construction : INSERT IGNORE + PK (account_id, exploit_id)
+// pour les unlocks ; PK (account_id, reward_year, kind) pour la garde des
+// octrois annuels (migration 0074).
+
+#include <cstdint>
+#include <string_view>
+
+namespace engine::server::db { class ConnectionPool; }
+
+namespace engine::server
+{
+	class MysqlExploitStore
+	{
+	public:
+		explicit MysqlExploitStore(engine::server::db::ConnectionPool* pool) : m_pool(pool) {}
+
+		/// true si le pool DB est initialisé (mode no-DB : tout no-op).
+		bool IsAvailable() const;
+
+		/// Débloque l'exploit \p code (catalogue `exploits`, is_active=1) pour
+		/// le compte. \param sourceDetail traçabilité libre (colonne
+		/// source_detail), ex. "anniversary_service".
+		/// \return 1 si NOUVELLEMENT débloqué, 0 si déjà débloqué ou code
+		/// inconnu/inactif, -1 en erreur DB.
+		int UnlockByCode(uint64_t accountId, std::string_view code, std::string_view sourceDetail);
+
+		/// Nombre d'exploits déjà débloqués par le compte dont le catalogue
+		/// porte \p metricSource (ex. "birthday_years"). \return 0 en erreur.
+		uint32_t CountUnlockedByMetric(uint64_t accountId, std::string_view metricSource);
+
+		/// Tente de réclamer l'octroi annuel (\p kind ∈ {"birthday_exploit",
+		/// "birthday_gift"}) de l'année \p year pour le compte : INSERT IGNORE
+		/// dans `account_anniversary_rewards`. \return true si la ligne vient
+		/// d'être créée (l'octroi est à effectuer), false si déjà réclamé
+		/// cette année ou en erreur DB.
+		bool TryClaimAnnualReward(uint64_t accountId, uint16_t year, std::string_view kind);
+
+	private:
+		engine::server::db::ConnectionPool* m_pool = nullptr;
+	};
+}

--- a/src/masterd/handlers/auth/AuthRegisterHandler.cpp
+++ b/src/masterd/handlers/auth/AuthRegisterHandler.cpp
@@ -15,6 +15,7 @@
 #include "src/shared/network/NetErrorCode.h"
 #include "src/shared/network/ProtocolV1Constants.h"
 #include "src/shared/auth/Argon2Hash.h"
+#include "src/shared/anniversary/AnniversaryMath.h" // validation birth_date (spec 2026-07-18)
 #include "src/shared/core/Log.h"
 
 #include <chrono>
@@ -171,6 +172,21 @@ namespace engine::server
 			LOG_WARN(Auth, "[AUTH] HandleRegister result={}", "FAIL");
 			if (m_auditLog) m_auditLog->LogRegisterFail(ipKey, "email_taken");
 			auto pkt = BuildRegisterResponseErrorPacket(NetErrorCode::INVALID_EMAIL, requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+		// Anniversaires (spec 2026-07-18) — birth_date devient une donnée de
+		// GAMEPLAY immuable (récompenses du jour J) : validation STRICTE côté
+		// serveur à l'inscription (seul moment où elle peut être écrite).
+		// Format yyyy-mm-dd, date calendaire réelle, >= 1900, pas dans le
+		// futur. Le client valide déjà le format ; un payload forgé est
+		// rejeté ici.
+		if (!parsed->birth_date.empty()
+			&& !engine::anniversary::IsValidBirthDate(parsed->birth_date, engine::anniversary::TodayUtc()))
+		{
+			LOG_WARN(Auth, "[AUTH] HandleRegister result={}", "FAIL");
+			if (m_auditLog) m_auditLog->LogRegisterFail(ipKey, "invalid_birth_date");
+			auto pkt = BuildRegisterResponseErrorPacket(NetErrorCode::REGISTRATION_INVALID, requestId, sessionIdHeader);
 			if (!pkt.empty()) m_server->Send(connId, pkt);
 			return;
 		}

--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
@@ -11,12 +11,16 @@
 #include "src/masterd/session/SessionManager.h"
 #include "src/masterd/shards/ShardRegistry.h"
 #include "src/masterd/account/AccountRole.h"
+#include "src/masterd/anniversary/AnniversaryService.h"
+#include "src/shared/network/ChatPayloads.h"
+#include "src/shared/net/ChatSystem.h"
 #include "src/shared/db/ConnectionPool.h"
 #include "src/shared/db/DbHelpers.h"
 #include "src/shared/db/SqlPreparedStatement.h"
 
 #include <mysql.h>
 
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <string>
@@ -29,6 +33,7 @@ namespace engine::server
 	void CharacterEnterWorldHandler::SetSessionCharacterMap(SessionCharacterMap* charMap) { m_charMap = charMap; }
 	void CharacterEnterWorldHandler::SetConnectionPool(engine::server::db::ConnectionPool* pool) { m_pool = pool; }
 	void CharacterEnterWorldHandler::SetShardRegistry(ShardRegistry* registry) { m_shardRegistry = registry; }
+	void CharacterEnterWorldHandler::SetAnniversaryService(AnniversaryService* service) { m_anniversary = service; }
 
 	void CharacterEnterWorldHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize)
@@ -199,5 +204,37 @@ namespace engine::server
 		auto pkt = BuildCharacterEnterWorldResponsePacket(1u, requestId, sessionIdHeader);
 		if (!pkt.empty())
 			m_server->Send(connId, pkt);
+
+		// Anniversaires (spec 2026-07-18) — après l'admission validée :
+		// paliers fidélité (rattrapage) + jour J de naissance (exploit +
+		// courrier cadeau). Les déblocages sont annoncés au client entrant
+		// par un ChatRelay « système » (même pattern que les notices du
+		// ChatRelayHandler). Le service est idempotent : un re-EnterWorld
+		// (changement de perso) ne double aucun octroi.
+		if (m_anniversary != nullptr)
+		{
+			const auto anniv = m_anniversary->OnEnterWorld(*accountId, engine::anniversary::TodayUtc());
+			const uint64_t nowMs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			for (const std::string& title : anniv.unlockedTitles)
+			{
+				auto notice = BuildChatRelayPacket(nowMs,
+					static_cast<uint8_t>(engine::net::ChatChannel::Server),
+					"system", "Exploit débloqué : " + title, sessionIdHeader);
+				if (!notice.empty())
+					m_server->Send(connId, notice);
+			}
+			if (anniv.birthdayGiftMailed)
+			{
+				auto notice = BuildChatRelayPacket(nowMs,
+					static_cast<uint8_t>(engine::net::ChatChannel::Server),
+					"system",
+					"Joyeux anniversaire ! Un cadeau vous attend dans votre courrier.",
+					sessionIdHeader);
+				if (!notice.empty())
+					m_server->Send(connId, notice);
+			}
+		}
 	}
 }

--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.h
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.h
@@ -15,6 +15,7 @@ namespace engine::server
 	class ConnectionSessionMap;
 	class SessionCharacterMap;
 	class ShardRegistry;
+	class AnniversaryService;
 
 	/// Phase 4 chat — Master-side handler for kOpcodeCharacterEnterWorldRequest.
 	///
@@ -44,6 +45,12 @@ namespace engine::server
 		/// au premier EnterWorld). Permet de tourner sans cette fonctionnalité (tests / dev).
 		void SetShardRegistry(ShardRegistry* registry);
 
+		/// Anniversaires (spec 2026-07-18) — facultatif. Si configuré, chaque
+		/// EnterWorld validé passe par AnniversaryService::OnEnterWorld
+		/// (exploits fidélité/naissance + courrier cadeau le jour J) et les
+		/// déblocages sont notifiés au client par un ChatRelay « système ».
+		void SetAnniversaryService(AnniversaryService* service);
+
 		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 			const uint8_t* payload, size_t payloadSize);
 
@@ -54,5 +61,6 @@ namespace engine::server
 		SessionCharacterMap*                m_charMap  = nullptr;
 		engine::server::db::ConnectionPool* m_pool     = nullptr;
 		ShardRegistry*                      m_shardRegistry = nullptr; ///< TA.3 — lookup connId pour push d'admission.
+		AnniversaryService*                 m_anniversary = nullptr;   ///< Anniversaires — facultatif (nullptr = off).
 	};
 }

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -37,6 +37,8 @@
 #include "src/masterd/handlers/character/CharacterDeleteHandler.h"
 #include "src/masterd/handlers/character/CharacterSavePositionHandler.h"
 #include "src/masterd/handlers/character/CharacterEnterWorldHandler.h"
+#include "src/masterd/anniversary/AnniversaryService.h"
+#include "src/masterd/exploits/MysqlExploitStore.h"
 #include "src/masterd/handlers/dungeon/EnterDungeonHandler.h"
 #include "src/masterd/handlers/chat/ChatRelayHandler.h"
 #include "src/masterd/handlers/mail/MailHandler.h"
@@ -528,6 +530,17 @@ int main(int argc, char** argv)
 	engine::server::MailHandler mailHandler;
 	mailHandler.SetMailManager(&mailManager);
 	mailHandler.SetServer(&server);
+
+	// Anniversaires (spec 2026-07-18) — exploits fidélité/naissance + courrier
+	// cadeau le jour J. Branché sur l'EnterWorld (déclaré plus haut) une fois
+	// le store mail résolu (MySQL ou in-memory). En mode no-DB, le store
+	// d'exploits est indisponible et le service devient un no-op silencieux.
+	engine::server::MysqlExploitStore exploitStore(&dbPool);
+	engine::server::AnniversaryService anniversaryService;
+	anniversaryService.SetDependencies(&dbPool, &exploitStore, mailStoreActive);
+	characterEnterWorldHandler.SetAnniversaryService(&anniversaryService);
+	LOG_INFO(Net, "[ServerMain] AnniversaryService branché (exploits DB {})",
+		exploitStore.IsAvailable() ? "OK" : "INDISPONIBLE — no-op");
 	mailHandler.SetSessionManager(&sessionManager);
 	mailHandler.SetConnectionSessionMap(&connSessionMap);
 	LOG_INFO(Net, "[ServerMain] MailHandler configured (CMANGOS.18 step 3)");

--- a/src/shared/anniversary/AnniversaryMath.cpp
+++ b/src/shared/anniversary/AnniversaryMath.cpp
@@ -1,0 +1,117 @@
+// AnniversaryMath — implémentation. Voir le header pour les conventions
+// (dates civiles UTC, règle 29/02 → 28/02).
+
+#include "src/shared/anniversary/AnniversaryMath.h"
+
+#include <ctime>
+
+namespace engine::anniversary
+{
+	bool IsLeapYear(int year)
+	{
+		return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+	}
+
+	namespace
+	{
+		/// Nombre de jours du mois \p month (1..12) de l'année \p year.
+		int DaysInMonth(int year, int month)
+		{
+			static constexpr int kDays[12] = { 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
+			if (month < 1 || month > 12) return 0;
+			if (month == 2 && IsLeapYear(year)) return 29;
+			return kDays[month - 1];
+		}
+
+		/// true si les 10 caractères de \p s ont la forme "dddd-dd-dd".
+		bool HasYmdShape(std::string_view s)
+		{
+			if (s.size() != 10) return false;
+			for (size_t i = 0; i < 10; ++i)
+			{
+				if (i == 4 || i == 7)
+				{
+					if (s[i] != '-') return false;
+				}
+				else if (s[i] < '0' || s[i] > '9')
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+
+		/// Jour/mois effectifs où l'anniversaire de \p birth est fêté l'année
+		/// \p inYear : identiques à la naissance, sauf 29/02 → 28/02 si
+		/// \p inYear n'est pas bissextile.
+		void CelebratedDayMonth(const YmdDate& birth, int inYear, int& outMonth, int& outDay)
+		{
+			outMonth = birth.month;
+			outDay   = birth.day;
+			if (birth.month == 2 && birth.day == 29 && !IsLeapYear(inYear))
+				outDay = 28;
+		}
+	}
+
+	bool ParseYmd(std::string_view text, YmdDate& out)
+	{
+		if (!HasYmdShape(text)) return false;
+		const auto digit = [&](size_t i) { return static_cast<int>(text[i] - '0'); };
+		const int y = digit(0) * 1000 + digit(1) * 100 + digit(2) * 10 + digit(3);
+		const int m = digit(5) * 10 + digit(6);
+		const int d = digit(8) * 10 + digit(9);
+		if (m < 1 || m > 12) return false;
+		if (d < 1 || d > DaysInMonth(y, m)) return false;
+		out.year = y; out.month = m; out.day = d;
+		return true;
+	}
+
+	bool IsValidBirthDate(std::string_view text, const YmdDate& todayUtc)
+	{
+		YmdDate b{};
+		if (!ParseYmd(text, b)) return false;
+		if (b.year < 1900) return false;
+		// Pas dans le futur (comparaison lexicographique (y, m, d)).
+		if (b.year > todayUtc.year) return false;
+		if (b.year == todayUtc.year && b.month > todayUtc.month) return false;
+		if (b.year == todayUtc.year && b.month == todayUtc.month && b.day > todayUtc.day) return false;
+		return true;
+	}
+
+	int YearsElapsed(const YmdDate& from, const YmdDate& today)
+	{
+		if (from.year <= 0) return 0;
+		int years = today.year - from.year;
+		if (years <= 0) return 0;
+		// L'anniversaire de cette année est-il déjà passé (ou aujourd'hui) ?
+		int celMonth = 0, celDay = 0;
+		CelebratedDayMonth(from, today.year, celMonth, celDay);
+		if (today.month < celMonth || (today.month == celMonth && today.day < celDay))
+			--years;
+		return years < 0 ? 0 : years;
+	}
+
+	bool IsAnniversaryDay(const YmdDate& birth, const YmdDate& today)
+	{
+		if (birth.year <= 0 || today.year <= birth.year) return false;
+		int celMonth = 0, celDay = 0;
+		CelebratedDayMonth(birth, today.year, celMonth, celDay);
+		return today.month == celMonth && today.day == celDay;
+	}
+
+	YmdDate TodayUtc()
+	{
+		std::time_t now = std::time(nullptr);
+		std::tm tmv{};
+#if defined(_WIN32)
+		gmtime_s(&tmv, &now);
+#else
+		gmtime_r(&now, &tmv);
+#endif
+		YmdDate d;
+		d.year  = tmv.tm_year + 1900;
+		d.month = tmv.tm_mon + 1;
+		d.day   = tmv.tm_mday;
+		return d;
+	}
+}

--- a/src/shared/anniversary/AnniversaryMath.h
+++ b/src/shared/anniversary/AnniversaryMath.h
@@ -1,0 +1,54 @@
+#pragma once
+// AnniversaryMath — logique calendaire PURE des récompenses d'anniversaire
+// (spec docs/superpowers/specs/2026-07-18-anniversary-rewards-design.md).
+// Aucune dépendance DB/réseau : consommé par le master (AnniversaryService,
+// validation d'inscription) et testé par ctest (Linux inclus).
+//
+// Convention : toutes les dates sont des dates CIVILES UTC (le serveur ne
+// gère aucun fuseau). Le 29 février est fêté le 28/02 les années non
+// bissextiles.
+
+#include <cstdint>
+#include <string_view>
+
+namespace engine::anniversary
+{
+	/// Date civile (année/mois/jour), sans heure ni fuseau.
+	struct YmdDate
+	{
+		int year  = 0; ///< ex. 2026
+		int month = 0; ///< 1..12
+		int day   = 0; ///< 1..31
+	};
+
+	/// true si \p year est bissextile (calendrier grégorien).
+	bool IsLeapYear(int year);
+
+	/// Parse STRICT du format "yyyy-mm-dd" (10 caractères exactement, chiffres
+	/// et tirets aux bonnes positions) et vérifie que la date existe dans le
+	/// calendrier (mois 1-12, jour borné par le mois, 29/02 seulement si
+	/// bissextile). \return false si le format ou la date est invalide.
+	bool ParseYmd(std::string_view text, YmdDate& out);
+
+	/// Validation d'une date de naissance à l'inscription : date parsable,
+	/// année >= 1900, et pas dans le futur par rapport à \p todayUtc.
+	/// (Aucune exigence d'âge minimum ici — le contrôle parental existant
+	/// reste la référence pour ça.)
+	bool IsValidBirthDate(std::string_view text, const YmdDate& todayUtc);
+
+	/// Années RÉVOLUES entre \p from et \p today (0 si moins d'un an, ou si
+	/// today < from). Ex. inscrit le 2024-07-18 : 1 le 2025-07-18, encore 1
+	/// le 2026-07-17, 2 le 2026-07-18. Le 29/02 compte comme révolu le 28/02
+	/// des années non bissextiles.
+	int YearsElapsed(const YmdDate& from, const YmdDate& today);
+
+	/// true si \p today est le jour d'anniversaire de \p birth : même
+	/// jour/mois, avec la règle 29/02 → 28/02 les années non bissextiles.
+	/// L'année de naissance elle-même ne compte pas (pas d'anniversaire le
+	/// jour de l'inscription d'un nouveau-né du jour).
+	bool IsAnniversaryDay(const YmdDate& birth, const YmdDate& today);
+
+	/// Date civile UTC du jour, depuis l'horloge système. Séparée pour que
+	/// les tests injectent leurs propres dates sans toucher à l'horloge.
+	YmdDate TodayUtc();
+}

--- a/src/shared/anniversary/tests/AnniversaryMathTests.cpp
+++ b/src/shared/anniversary/tests/AnniversaryMathTests.cpp
@@ -1,0 +1,110 @@
+/// Tests unitaires CPU pour AnniversaryMath (spec 2026-07-18) : parse strict
+/// yyyy-mm-dd, validation de date de naissance, années révolues (dont 29/02),
+/// jour d'anniversaire (dont règle 29/02 → 28/02). Pur CPU, ctest.
+
+#include "src/shared/anniversary/AnniversaryMath.h"
+
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using namespace engine::anniversary;
+
+	YmdDate D(int y, int m, int d) { return YmdDate{ y, m, d }; }
+
+	void Test_ParseYmd()
+	{
+		YmdDate out{};
+		REQUIRE(ParseYmd("1990-05-21", out));
+		REQUIRE(out.year == 1990 && out.month == 5 && out.day == 21);
+		REQUIRE(ParseYmd("2024-02-29", out));   // bissextile
+		REQUIRE(!ParseYmd("2023-02-29", out));  // non bissextile
+		REQUIRE(!ParseYmd("1990-13-01", out));  // mois invalide
+		REQUIRE(!ParseYmd("1990-04-31", out));  // jour invalide
+		REQUIRE(!ParseYmd("1990-00-10", out));
+		REQUIRE(!ParseYmd("1990-5-21", out));   // format non zero-padded
+		REQUIRE(!ParseYmd("21/05/1990", out));  // mauvais séparateurs
+		REQUIRE(!ParseYmd("1990-05-21x", out)); // trop long
+		REQUIRE(!ParseYmd("", out));
+	}
+
+	void Test_IsValidBirthDate()
+	{
+		const YmdDate today = D(2026, 7, 18);
+		REQUIRE(IsValidBirthDate("1990-05-21", today));
+		REQUIRE(IsValidBirthDate("2026-07-18", today));  // aujourd'hui : accepté
+		REQUIRE(!IsValidBirthDate("2026-07-19", today)); // futur
+		REQUIRE(!IsValidBirthDate("1899-12-31", today)); // < 1900
+		REQUIRE(IsValidBirthDate("1900-01-01", today));
+		REQUIRE(!IsValidBirthDate("n/a", today));
+	}
+
+	void Test_YearsElapsed()
+	{
+		// Inscrit le 2024-07-18.
+		const YmdDate from = D(2024, 7, 18);
+		REQUIRE(YearsElapsed(from, D(2024, 12, 31)) == 0);
+		REQUIRE(YearsElapsed(from, D(2025, 7, 17)) == 0);
+		REQUIRE(YearsElapsed(from, D(2025, 7, 18)) == 1); // jour anniversaire compte
+		REQUIRE(YearsElapsed(from, D(2026, 7, 17)) == 1);
+		REQUIRE(YearsElapsed(from, D(2026, 7, 18)) == 2);
+		REQUIRE(YearsElapsed(from, D(2020, 1, 1)) == 0);  // avant l'inscription
+
+		// Inscrit un 29/02 : révolu le 28/02 des années non bissextiles.
+		const YmdDate leap = D(2024, 2, 29);
+		REQUIRE(YearsElapsed(leap, D(2025, 2, 27)) == 0);
+		REQUIRE(YearsElapsed(leap, D(2025, 2, 28)) == 1);
+		REQUIRE(YearsElapsed(leap, D(2028, 2, 28)) == 3);
+		REQUIRE(YearsElapsed(leap, D(2028, 2, 29)) == 4); // bissextile : vrai jour
+	}
+
+	void Test_IsAnniversaryDay()
+	{
+		const YmdDate birth = D(1990, 5, 21);
+		REQUIRE(IsAnniversaryDay(birth, D(2026, 5, 21)));
+		REQUIRE(!IsAnniversaryDay(birth, D(2026, 5, 20)));
+		REQUIRE(!IsAnniversaryDay(birth, D(2026, 6, 21)));
+		REQUIRE(!IsAnniversaryDay(birth, D(1990, 5, 21))); // année de naissance
+
+		// 29/02 → fêté le 28/02 hors bissextile, le 29/02 sinon.
+		const YmdDate leapBirth = D(2000, 2, 29);
+		REQUIRE(IsAnniversaryDay(leapBirth, D(2023, 2, 28)));
+		REQUIRE(!IsAnniversaryDay(leapBirth, D(2023, 3, 1)));
+		REQUIRE(IsAnniversaryDay(leapBirth, D(2024, 2, 29)));
+		REQUIRE(!IsAnniversaryDay(leapBirth, D(2024, 2, 28)));
+	}
+
+	void Test_IsLeapYear()
+	{
+		REQUIRE(IsLeapYear(2024));
+		REQUIRE(!IsLeapYear(2023));
+		REQUIRE(IsLeapYear(2000));  // divisible par 400
+		REQUIRE(!IsLeapYear(1900)); // divisible par 100, pas 400
+	}
+}
+
+int main()
+{
+	Test_ParseYmd();
+	Test_IsValidBirthDate();
+	Test_YearsElapsed();
+	Test_IsAnniversaryDay();
+	Test_IsLeapYear();
+
+	if (g_failed == 0)
+	{
+		std::printf("[PASS] AnniversaryMathTests\n");
+		return 0;
+	}
+	std::printf("[FAIL] AnniversaryMathTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/web-portal/app/api/player/account/route.ts
+++ b/web-portal/app/api/player/account/route.ts
@@ -12,6 +12,10 @@ export async function PATCH(request: Request) {
 
   try {
     const body = await request.json() as Record<string, string>
+    // GARDE anti-triche (spec 2026-07-18, récompenses d'anniversaire) :
+    // birth_date et created_at sont IMMUABLES — ils conditionnent des
+    // récompenses annuelles côté serveur. Ne JAMAIS les ajouter à ce
+    // fieldMap ni créer un autre chemin d'édition.
     const fieldMap: Record<string, string> = {
       firstName: 'first_name',
       lastName: 'last_name',


### PR DESCRIPTION
## Objectif (spec docs/superpowers/specs/2026-07-18-anniversary-rewards-design.md)

Recompenser la fidelite a partir de deux dates **immuables** du compte :
- **Anniversaire d'inscription** (accounts.created_at) : un exploit « Fidele depuis N an(s) » par annee revolue — **jamais perdu**, credite au prochain EnterWorld (rattrapage automatique de tous les paliers manquants).
- **Anniversaire de naissance** (accounts.birth_date, saisie a l'inscription) : **jour J strict (UTC)**. Entrer en monde le jour meme debloque l'exploit « N anniversaire(s) fete(s) » ET depose un courrier cadeau : **50 or + 50 argent + 50 bronze**, **1 gateau parmi 10** (choisi par (compte, annee)), **1 souvenir millesime An N** (slot d'equipement tournant). Pas connecte le jour J = perdu pour l'annee.

## Contenu

- **Migration 0074** : seed du catalogue exploits (2 familles x 10 paliers, scope account) + table de garde account_anniversary_rewards (PK (account_id, reward_year, kind)) — synchronisee dans deploy/docker/sql/.
- **AnniversaryMath** (shared, pur) : parse strict yyyy-mm-dd, annees revolues, jour J avec regle 29/02→28/02, validation de naissance. Teste (anniversary_math_tests, ctest Linux).
- **MysqlExploitStore** : premier writer C++ du systeme d'exploits (INSERT IGNORE par code — idempotent par PK ; le portail web lit les memes tables et affichera les deblocages sans changement).
- **AnniversaryService** (master) : accroche a l'EnterWorld valide ; notifications chat « systeme » (Exploit debloque… / Joyeux anniversaire…).
- **Anti-triche** : birth_date validee cote serveur a l'inscription (seul point d'ecriture, payload forge rejete) ; created_at/birth_date sans AUCUN chemin de modification (garde documentee dans l'API profil du portail) ; toutes les decisions en DB cote master, UTC ; octrois idempotents par cles primaires.
- **items.json** : 10 gateaux (5101-5110 — l'activation buff groupe/guilde arrive en SP3) + 10 souvenirs millesimes (5121-5130, bonus reels modestes).

## Suites (PRs séparées)

SP2 : opcodes « liste de mes exploits » + onglet Exploits (F1). SP3 : gameplay du gateau (barre d'action, buff de zone, expiration minuit).

## Validation

- CI : build Linux (master) + ctest (anniversary_math_tests) + parite migrations Docker.
- Test manuel : compte avec created_at ancien → paliers fidelite au premier EnterWorld ; compte avec birth_date = aujourd'hui → exploit + courrier avec or et 2 objets.

**Deploiement** : ⚠️ **redeploiement serveur MASTER requis** (nouveau service + migration 0074 appliquee au boot). Shard non concerne. Le client actuel affiche deja le courrier et ses pieces jointes (aucun changement de protocole).

🤖 Generated with [Claude Code](https://claude.com/claude-code)