### PR TITLE
feat(game): recompenses anniversaire SP2 - opcodes exploits + onglet Exploits (F1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -305,6 +305,8 @@ add_library(engine_core
   src/client/social/IgnoreListUi.cpp
   src/client/gmtickets/GmTicketUi.cpp
   src/client/reputation/ReputationUi.cpp
+  # SP2 anniversaires (2026-07-18) : presenter liste de mes exploits (206/207).
+  src/client/exploits/ExploitsUi.cpp
   src/client/arena/ArenaUi.cpp
   src/client/battleground/BattleGroundUi.cpp
   src/client/outdoorpvp/OutdoorPvpUi.cpp
@@ -651,6 +653,7 @@ add_library(engine_core
   src/client/render/MailImGuiRenderer.cpp
   src/client/render/GmTicketImGuiRenderer.cpp
   src/client/render/ReputationImGuiRenderer.cpp
+  src/client/render/ExploitsImGuiRenderer.cpp
   src/client/render/CharacterSheetImGuiRenderer.cpp
   src/client/render/ArenaImGuiRenderer.cpp
   src/client/render/BattleGroundImGuiRenderer.cpp
@@ -801,6 +804,7 @@ add_library(engine_core
   src/shared/network/MailPayloads.cpp
   src/shared/network/GmTicketPayloads.cpp
   src/shared/network/ReputationPayloads.cpp
+  src/shared/network/ExploitPayloads.cpp
   src/shared/network/ArenaPayloads.cpp
   src/shared/network/BattleGroundPayloads.cpp
   src/shared/network/OutdoorPvpPayloads.cpp
@@ -1240,6 +1244,11 @@ add_test(NAME gm_ticket_payloads_tests COMMAND gm_ticket_payloads_tests)
 add_executable(reputation_payloads_tests src/shared/network/ReputationPayloadsTests.cpp)
 target_link_libraries(reputation_payloads_tests PRIVATE engine_core)
 add_test(NAME reputation_payloads_tests COMMAND reputation_payloads_tests)
+
+# SP2 anniversaires (2026-07-18) — round-trip payloads Exploits (206/207).
+add_executable(exploit_payloads_tests src/shared/network/ExploitPayloadsTests.cpp)
+target_link_libraries(exploit_payloads_tests PRIVATE engine_core)
+add_test(NAME exploit_payloads_tests COMMAND exploit_payloads_tests)
 
 # CMANGOS.33 (Phase 5.33 step 3+4) — Lfg payloads round-trip tests (no DB / no network).
 add_executable(lfg_payloads_tests src/shared/network/LfgPayloadsTests.cpp)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -224,6 +224,9 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/masterd/exploits/MysqlExploitStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/anniversary/AnniversaryService.cpp
     ${CMAKE_SOURCE_DIR}/src/shared/anniversary/AnniversaryMath.cpp
+    # SP2 anniversaires : liste de mes exploits (opcodes 206/207).
+    ${CMAKE_SOURCE_DIR}/src/masterd/handlers/exploits/ExploitHandler.cpp
+    ${CMAKE_SOURCE_DIR}/src/shared/network/ExploitPayloads.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/gmtickets/MysqlGmTicketStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/reputation/MysqlReputationStore.cpp
     ${CMAKE_SOURCE_DIR}/src/masterd/social/MysqlIgnoreStore.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -18,6 +18,7 @@
 #include "src/shared/network/MailPayloads.h"
 #include "src/shared/network/GmTicketPayloads.h"
 #include "src/shared/network/ReputationPayloads.h"
+#include "src/shared/network/ExploitPayloads.h" // SP2 anniversaires (2026-07-18)
 #include "src/shared/network/ArenaPayloads.h"
 #include "src/shared/network/BattleGroundPayloads.h"
 #include "src/shared/network/OutdoorPvpPayloads.h"
@@ -1609,6 +1610,12 @@ namespace engine
 			});
 		}
 
+		// SP2 anniversaires (2026-07-18) — send callback du presenter Exploits
+		// (requête 206 fire-and-forget ; réponse 207 dispatchée plus bas).
+		m_exploitsUi.SetSendCallback([this](uint16_t opcode, const std::vector<uint8_t>& payload) -> bool {
+			return m_authUi.SendGenericRequestAsync(opcode, payload);
+		});
+
 		// CMANGOS.33 (Phase 5.33 step 3+4) — Init du presenter LFG + cable du
 		// send callback pour les requetes 100/102/104/107. Reception dispatchee
 		// dans le push handler ci-dessous (responses 101/103/105 + push 106).
@@ -2840,6 +2847,18 @@ namespace engine
 					return;
 				}
 				m_reputationUi.OnUpdateNotification(*parsed);
+				return;
+			}
+			// SP2 anniversaires (2026-07-18) — Dispatch de la réponse Exploits (207).
+			case kOpcodeExploitListResponse:
+			{
+				auto parsed = ParseExploitListResponsePayload(payload, payloadSize);
+				if (!parsed)
+				{
+					LOG_WARN(Net, "[Engine] EXPLOIT_LIST_RESPONSE parse failed (size={})", payloadSize);
+					return;
+				}
+				m_exploitsUi.OnListResponse(*parsed);
 				return;
 			}
 			// CMANGOS.39 (Phase 4.39 step 3+4) — Dispatch des reponses Skills
@@ -8010,6 +8029,9 @@ namespace engine
 						// Peupler l'onglet Compétences (l'ancien toggle F2 le faisait ;
 						// le Skill Book se remplit via RequestList côté serveur).
 						m_skillBookUi.RequestList();
+						// SP2 anniversaires (2026-07-18) — peupler l'onglet Exploits
+						// (opcode 206 fire-and-forget, réponse 207 au push handler).
+						m_exploitsUi.RequestExploitList();
 						// Task 4 — pose l'avatar du joueur dans le viewport 3D À
 						// L'OUVERTURE seulement : SetMesh réinitialise l'animation, il ne
 						// doit PAS être rappelé chaque frame (sinon l'anim reste figée à
@@ -8409,6 +8431,11 @@ namespace engine
 				m_characterWindowImGui = std::make_unique<engine::render::CharacterWindowImGuiRenderer>();
 				m_characterWindowImGui->Bind(&m_cfg, &m_uiModelBinding, &m_invUi, &m_skillIconCache,
 					m_skillBookImGui.get(), m_grimoireImGui.get(), m_classSkillTreeImGui.get());
+				// SP2 anniversaires (2026-07-18) — onglet Exploits (renderer lié
+				// au presenter m_exploitsUi ; la requête part au toggle F1).
+				m_exploitsImGui = std::make_unique<engine::render::ExploitsImGuiRenderer>();
+				m_exploitsImGui->Bind(&m_exploitsUi);
+				m_characterWindowImGui->SetExploitsRenderer(m_exploitsImGui.get());
 				// Chantier 2 SP-A — catalogue d'objets client (noms/slots/bonus pour le
 				// panneau équipement + tooltips). Source d'affichage ; le serveur reste
 				// autoritaire. Non fatal : catalogue absent -> noms bruts (#itemId).

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -15,6 +15,8 @@
 #include "src/client/social/IgnoreListUi.h"
 #include "src/client/gmtickets/GmTicketUi.h"
 #include "src/client/reputation/ReputationUi.h"
+#include "src/client/exploits/ExploitsUi.h" // SP2 anniversaires (2026-07-18)
+#include "src/client/render/ExploitsImGuiRenderer.h"
 #include "src/client/arena/ArenaUi.h"
 #include "src/client/battleground/BattleGroundUi.h"
 #include "src/client/outdoorpvp/OutdoorPvpUi.h"
@@ -1338,6 +1340,10 @@ namespace engine
 		/// Recoit la reponse opcode 96 et le push 97 via le push handler du master ;
 		/// fire-and-forget de la requete 95 via \c m_authUi.SendGenericRequestAsync.
 		engine::client::ReputationUiPresenter m_reputationUi;
+		/// SP2 anniversaires (2026-07-18) — Presenter de la liste « mes
+		/// exploits » (opcodes 206/207). Requête au premier affichage de la
+		/// fenêtre Personnage (F1) ; réponse via le push handler du master.
+		engine::client::ExploitsUiPresenter   m_exploitsUi;
 		/// CMANGOS.24 (Phase 3.24 step 3+4) — Visibilite du panneau Reputation
 		/// (toggle via slash command \c /rep ou \c /reputation). Faux par defaut.
 		bool                                  m_reputationVisible = false;
@@ -1407,6 +1413,9 @@ namespace engine
 		/// perso 3D + inventaire + caractéristiques + argent (onglet défaut) et
 		/// délègue aux renderers Compétences/Techniques/Arbre en mode embarqué.
 		std::unique_ptr<engine::render::CharacterWindowImGuiRenderer> m_characterWindowImGui;
+		/// SP2 anniversaires (2026-07-18) — renderer de l'onglet Exploits de la
+		/// fenêtre Personnage (lit m_exploitsUi ; pas de fenêtre autonome).
+		std::unique_ptr<engine::render::ExploitsImGuiRenderer> m_exploitsImGui;
 		/// SP-E - Cache d'icones de competences (PNG -> texture ImGui), partage par
 		/// l'arbre, le Grimoire et la barre d'action. Init apres ImGui, Shutdown avant.
 		engine::client::SkillIconCache m_skillIconCache;

--- a/src/client/exploits/ExploitsUi.cpp
+++ b/src/client/exploits/ExploitsUi.cpp
@@ -1,0 +1,49 @@
+// ExploitsUiPresenter — implémentation. Voir le header.
+
+#include "src/client/exploits/ExploitsUi.h"
+
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/core/Log.h"
+
+namespace engine::client
+{
+	void ExploitsUiPresenter::RequestExploitList()
+	{
+		if (!m_send)
+		{
+			LOG_WARN(Net, "[ExploitsUi] RequestExploitList sans SendCallback");
+			return;
+		}
+		m_state.isLoading = true;
+		m_state.lastErrorText.clear();
+		(void)m_send(engine::network::kOpcodeExploitListRequest,
+			engine::network::BuildExploitListRequestPayload());
+	}
+
+	void ExploitsUiPresenter::OnListResponse(const engine::network::ExploitListResponsePayload& resp)
+	{
+		m_state.isLoading = false;
+		if (resp.error != 0u)
+		{
+			m_state.lastErrorText = (resp.error ==
+				static_cast<uint8_t>(engine::network::ExploitErrorCode::Unavailable))
+				? "Exploits indisponibles (serveur sans base de données)."
+				: "Session invalide — reconnectez-vous.";
+			LOG_WARN(Net, "[ExploitsUi] liste en erreur (code={})", resp.error);
+			return;
+		}
+		m_state.entries.clear();
+		m_state.entries.reserve(resp.entries.size());
+		for (const auto& e : resp.entries)
+		{
+			ExploitEntryView v;
+			v.code = e.code;
+			v.title = e.title;
+			v.description = e.description;
+			v.unlockedAtUnix = e.unlockedAtUnix;
+			m_state.entries.push_back(std::move(v));
+		}
+		m_state.everLoaded = true;
+		m_state.lastErrorText.clear();
+	}
+}

--- a/src/client/exploits/ExploitsUi.h
+++ b/src/client/exploits/ExploitsUi.h
@@ -1,0 +1,66 @@
+#pragma once
+// ExploitsUiPresenter — presenter client de la liste « mes exploits »
+// (spec 2026-07-18, SP2 : onglet Exploits de la fenêtre F1, opcodes 206/207).
+// Modèle ReputationUiPresenter : cache local + fire-and-forget via callback ;
+// aucun rendu ImGui ici (cf. ExploitsImGuiRenderer).
+//
+// Lecture seule : le client ne peut que demander SA liste ; les déblocages
+// sont décidés côté master (AnniversaryService & co).
+
+#include "src/shared/network/ExploitPayloads.h"
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace engine::client
+{
+	/// Une entrée exposée au renderer (mirror wire, champs nommés).
+	struct ExploitEntryView
+	{
+		std::string code;
+		std::string title;
+		std::string description;
+		uint64_t unlockedAtUnix = 0; ///< epoch s UTC ; 0 = verrouillé.
+	};
+
+	/// État snapshot lu par le renderer (lecture seule côté UI).
+	struct ExploitsUiState
+	{
+		std::vector<ExploitEntryView> entries;
+		bool        isLoading = false;
+		bool        everLoaded = false; ///< false tant qu'aucune réponse OK reçue.
+		std::string lastErrorText;      ///< Vide si pas d'erreur.
+	};
+
+	/// Presenter du panneau Exploits. Thread : main.
+	class ExploitsUiPresenter final
+	{
+	public:
+		ExploitsUiPresenter() = default;
+		ExploitsUiPresenter(const ExploitsUiPresenter&)            = delete;
+		ExploitsUiPresenter& operator=(const ExploitsUiPresenter&) = delete;
+
+		/// Callback fire-and-forget : (opcode, payload) sur la connexion master.
+		using SendCallback = std::function<bool(uint16_t opcode, const std::vector<uint8_t>& payload)>;
+
+		/// Câble le callback d'envoi. À appeler avant tout RequestExploitList.
+		void SetSendCallback(SendCallback cb) { m_send = std::move(cb); }
+
+		/// Envoie EXPLOIT_LIST_REQUEST (206). Réponse via OnListResponse.
+		/// Met isLoading=true le temps de la réponse. No-op si pas de callback.
+		void RequestExploitList();
+
+		/// Reçoit EXPLOIT_LIST_RESPONSE (207) : remplace le cache local
+		/// (ou pose lastErrorText si le serveur a répondu une erreur).
+		void OnListResponse(const engine::network::ExploitListResponsePayload& resp);
+
+		/// Snapshot lecture seule pour le renderer.
+		const ExploitsUiState& GetState() const { return m_state; }
+
+	private:
+		ExploitsUiState m_state{};
+		SendCallback    m_send;
+	};
+}

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -3,6 +3,7 @@
 #include "src/client/render/SkillBookImGuiRenderer.h"
 #include "src/client/render/GrimoireImGuiRenderer.h"
 #include "src/client/render/ClassSkillTreeImGuiRenderer.h"
+#include "src/client/render/ExploitsImGuiRenderer.h" // SP2 anniversaires (2026-07-18)
 #include "src/client/render/race/RacePreviewViewport.h"
 #include "src/client/render/SkillIconCache.h"
 #include "src/client/ui_common/UIModel.h"
@@ -142,6 +143,16 @@ namespace engine::render
 						m_classTree->SetEnabled(true);
 						m_classTree->Render();
 					}
+					ImGui::EndTabItem();
+				}
+				// SP2 anniversaires (2026-07-18) — onglet absent si le renderer
+				// n'est pas câblé (rétro-compatible).
+				if (m_exploits != nullptr
+					&& ImGui::BeginTabItem("Exploits", nullptr, tabFlag(Tab::Exploits)))
+				{
+					m_activeTab = Tab::Exploits;
+					m_exploits->SetEmbedded(true);
+					m_exploits->Render();
 					ImGui::EndTabItem();
 				}
 				ImGui::EndTabBar();

--- a/src/client/render/CharacterWindowImGuiRenderer.h
+++ b/src/client/render/CharacterWindowImGuiRenderer.h
@@ -8,7 +8,7 @@
 
 namespace engine::core { class Config; }
 namespace engine::client { class UIModelBinding; class InventoryUiPresenter; class SkillIconCache; struct UIModel; }
-namespace engine::render { class SkillBookImGuiRenderer; class GrimoireImGuiRenderer; class ClassSkillTreeImGuiRenderer; }
+namespace engine::render { class SkillBookImGuiRenderer; class GrimoireImGuiRenderer; class ClassSkillTreeImGuiRenderer; class ExploitsImGuiRenderer; }
 namespace engine::render::race { class RacePreviewViewport; }
 namespace engine::items { class ItemCatalog; }
 
@@ -17,7 +17,7 @@ namespace engine::render
 	class CharacterWindowImGuiRenderer
 	{
 	public:
-		enum class Tab { Personnage = 0, Competences, Techniques, Arbre };
+		enum class Tab { Personnage = 0, Competences, Techniques, Arbre, Exploits };
 
 		/// Câble les dépendances (pointeurs non possédés). Les 3 renderers de
 		/// panneaux sont pilotés en mode embarqué par cette fenêtre.
@@ -51,6 +51,10 @@ namespace engine::render
 			return true;
 		}
 
+		/// SP2 anniversaires (2026-07-18) — renderer de l'onglet Exploits
+		/// (non possédé). Nul -> onglet absent (rétro-compatible).
+		void SetExploitsRenderer(engine::render::ExploitsImGuiRenderer* r) { m_exploits = r; }
+
 		/// Viewport 3D du perso (optionnel ; Task 4). Nul -> placeholder dessiné.
 		void SetRaceViewport(engine::render::race::RacePreviewViewport* vp) { m_raceViewport = vp; }
 		void SetViewportSize(uint32_t w, uint32_t h) { m_viewportW = w; m_viewportH = h; }
@@ -82,6 +86,7 @@ namespace engine::render
 		engine::render::SkillBookImGuiRenderer* m_skillBook = nullptr;
 		engine::render::GrimoireImGuiRenderer* m_grimoire = nullptr;
 		engine::render::ClassSkillTreeImGuiRenderer* m_classTree = nullptr;
+		engine::render::ExploitsImGuiRenderer* m_exploits = nullptr; ///< SP2 anniversaires
 		engine::render::race::RacePreviewViewport* m_raceViewport = nullptr;
 		uint32_t m_viewportW = 0;
 		uint32_t m_viewportH = 0;

--- a/src/client/render/ExploitsImGuiRenderer.cpp
+++ b/src/client/render/ExploitsImGuiRenderer.cpp
@@ -1,0 +1,98 @@
+// ExploitsImGuiRenderer — implémentation. Voir le header.
+
+#include "src/client/render/ExploitsImGuiRenderer.h"
+
+#include "src/client/exploits/ExploitsUi.h"
+
+#include <cstdio>
+#include <ctime>
+
+#if defined(_WIN32)
+#	include "imgui.h"
+#endif
+
+namespace engine::render
+{
+	namespace
+	{
+		/// Formate un epoch s UTC en date locale courte « jj/mm/aaaa ».
+		/// \param out buffer d'au moins 16 octets.
+		void FormatUnlockDate(uint64_t unixSeconds, char* out, size_t outSize)
+		{
+			const std::time_t t = static_cast<std::time_t>(unixSeconds);
+			std::tm tmv{};
+#if defined(_WIN32)
+			localtime_s(&tmv, &t);
+#else
+			localtime_r(&t, &tmv);
+#endif
+			std::snprintf(out, outSize, "%02d/%02d/%04d",
+				tmv.tm_mday, tmv.tm_mon + 1, tmv.tm_year + 1900);
+		}
+	}
+
+	void ExploitsImGuiRenderer::Render()
+	{
+#if defined(_WIN32)
+		if (m_presenter == nullptr) return;
+		const engine::client::ExploitsUiState& st = m_presenter->GetState();
+
+		if (st.isLoading && !st.everLoaded)
+		{
+			ImGui::TextDisabled("Chargement des exploits...");
+			return;
+		}
+		if (!st.lastErrorText.empty())
+		{
+			ImGui::TextColored(ImVec4(0.9f, 0.4f, 0.3f, 1.0f), "%s", st.lastErrorText.c_str());
+			return;
+		}
+		if (!st.everLoaded)
+		{
+			ImGui::TextDisabled("Exploits non charges.");
+			return;
+		}
+
+		// Comptage débloqués pour l'en-tête.
+		size_t unlocked = 0;
+		for (const auto& e : st.entries)
+			if (e.unlockedAtUnix != 0u) ++unlocked;
+		ImGui::Text("Exploits : %zu / %zu debloques", unlocked, st.entries.size());
+		ImGui::Separator();
+
+		// Deux sections : débloqués (avec date) puis verrouillés (grisés).
+		// Le scroll appartient au conteneur (onglet de la fenêtre Personnage).
+		ImGui::SeparatorText("Debloques");
+		bool any = false;
+		for (const auto& e : st.entries)
+		{
+			if (e.unlockedAtUnix == 0u) continue;
+			any = true;
+			char date[16];
+			FormatUnlockDate(e.unlockedAtUnix, date, sizeof(date));
+			ImGui::BulletText("%s", e.title.c_str());
+			ImGui::SameLine();
+			ImGui::TextDisabled("(%s)", date);
+			if (ImGui::IsItemHovered() || ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+				ImGui::SetTooltip("%s", e.description.c_str());
+		}
+		if (!any)
+			ImGui::TextDisabled("Aucun exploit debloque pour le moment.");
+
+		ImGui::SeparatorText("A debloquer");
+		any = false;
+		for (const auto& e : st.entries)
+		{
+			if (e.unlockedAtUnix != 0u) continue;
+			any = true;
+			ImGui::BeginDisabled();
+			ImGui::BulletText("%s", e.title.c_str());
+			ImGui::EndDisabled();
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+				ImGui::SetTooltip("%s", e.description.c_str());
+		}
+		if (!any)
+			ImGui::TextDisabled("Tout est debloque. Bravo !");
+#endif
+	}
+}

--- a/src/client/render/ExploitsImGuiRenderer.h
+++ b/src/client/render/ExploitsImGuiRenderer.h
@@ -1,0 +1,38 @@
+#pragma once
+// ExploitsImGuiRenderer — rendu ImGui de la liste « mes exploits »
+// (spec 2026-07-18, SP2). Pas de logique réseau : l'état vient de
+// ExploitsUiPresenter::GetState(). Conçu pour vivre en onglet de la fenêtre
+// Personnage (mode embedded, cf. SkillBookImGuiRenderer) — pas de fenêtre
+// autonome en v1.
+//
+// Affichage : exploits débloqués (titre + date locale du déblocage), puis
+// verrouillés (grisés). Les secrets non débloqués n'arrivent jamais ici
+// (filtrés côté serveur).
+
+#include <cstdint>
+
+namespace engine::client { class ExploitsUiPresenter; }
+
+namespace engine::render
+{
+	class ExploitsImGuiRenderer
+	{
+	public:
+		ExploitsImGuiRenderer() = default;
+
+		/// Lie le presenter (non possédé ; doit survivre au renderer).
+		void Bind(engine::client::ExploitsUiPresenter* presenter) { m_presenter = presenter; }
+
+		/// Mode embarqué : dessine la liste dans l'onglet courant sans
+		/// fenêtre propre (conteneur CharacterWindowImGuiRenderer).
+		void SetEmbedded(bool e) { m_embedded = e; }
+
+		/// Dessine la liste. À appeler entre ImGui::NewFrame() et
+		/// ImGui::Render(). No-op si aucun presenter lié.
+		void Render();
+
+	private:
+		engine::client::ExploitsUiPresenter* m_presenter = nullptr;
+		bool m_embedded = false;
+	};
+}

--- a/src/masterd/exploits/MysqlExploitStore.cpp
+++ b/src/masterd/exploits/MysqlExploitStore.cpp
@@ -70,6 +70,47 @@ namespace engine::server
 		return 0;
 	}
 
+	std::vector<MysqlExploitStore::ListedExploit> MysqlExploitStore::ListForAccount(
+		uint64_t accountId, bool& outOk)
+	{
+		outOk = false;
+		std::vector<ListedExploit> out;
+		if (!IsAvailable()) return out;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return out;
+
+		// Catalogue actif scope=account + statut du compte. Les secrets non
+		// débloqués sont filtrés CÔTÉ SQL (ne jamais fuiter au client).
+		auto* stmt = cache->Acquire(mysql,
+			"SELECT e.code, e.title, e.description, "
+			"COALESCE(UNIX_TIMESTAMP(u.unlocked_at), 0) "
+			"FROM exploits e "
+			"LEFT JOIN account_exploit_unlocks u "
+			"  ON u.exploit_id = e.id AND u.account_id = ? "
+			"WHERE e.is_active = 1 AND e.scope = 'account' "
+			"  AND (e.is_secret = 0 OR u.account_id IS NOT NULL) "
+			"ORDER BY e.sort_order ASC, e.id ASC");
+		if (!stmt || !stmt->Bind(0, accountId) || !stmt->Execute())
+		{
+			LOG_WARN(Db, "[MysqlExploitStore] ListForAccount({}) failed: {}",
+				accountId, mysql_error(mysql));
+			return out;
+		}
+		while (stmt->FetchRow())
+		{
+			ListedExploit e;
+			e.code           = stmt->GetString(0);
+			e.title          = stmt->GetString(1);
+			e.description    = stmt->GetString(2);
+			e.unlockedAtUnix = stmt->GetUInt64(3);
+			out.push_back(std::move(e));
+		}
+		outOk = true;
+		return out;
+	}
+
 	bool MysqlExploitStore::TryClaimAnnualReward(uint64_t accountId, uint16_t year,
 		std::string_view kind)
 	{

--- a/src/masterd/exploits/MysqlExploitStore.h
+++ b/src/masterd/exploits/MysqlExploitStore.h
@@ -10,7 +10,9 @@
 // octrois annuels (migration 0074).
 
 #include <cstdint>
+#include <string>
 #include <string_view>
+#include <vector>
 
 namespace engine::server::db { class ConnectionPool; }
 
@@ -19,6 +21,16 @@ namespace engine::server
 	class MysqlExploitStore
 	{
 	public:
+		/// Ligne de la liste « mes exploits » (SP2, opcodes 206/207) : entrée
+		/// du catalogue actif scope=account + statut du compte.
+		struct ListedExploit
+		{
+			std::string code;
+			std::string title;
+			std::string description;
+			uint64_t unlockedAtUnix = 0; ///< epoch s UTC ; 0 = verrouillé.
+		};
+
 		explicit MysqlExploitStore(engine::server::db::ConnectionPool* pool) : m_pool(pool) {}
 
 		/// true si le pool DB est initialisé (mode no-DB : tout no-op).
@@ -41,6 +53,13 @@ namespace engine::server
 		/// d'être créée (l'octroi est à effectuer), false si déjà réclamé
 		/// cette année ou en erreur DB.
 		bool TryClaimAnnualReward(uint64_t accountId, uint16_t year, std::string_view kind);
+
+		/// SP2 — Liste du catalogue actif (scope=account) avec le statut du
+		/// compte, trié par sort_order. Les exploits marqués secrets
+		/// (is_secret=1, migration 0015) NON débloqués sont OMIS (ils ne
+		/// doivent pas fuiter au client). \param outOk false en erreur DB
+		/// (à distinguer d'une liste légitimement vide).
+		std::vector<ListedExploit> ListForAccount(uint64_t accountId, bool& outOk);
 
 	private:
 		engine::server::db::ConnectionPool* m_pool = nullptr;

--- a/src/masterd/handlers/exploits/ExploitHandler.cpp
+++ b/src/masterd/handlers/exploits/ExploitHandler.cpp
@@ -1,0 +1,76 @@
+// ExploitHandler — implémentation. Voir le header.
+
+#include "src/masterd/handlers/exploits/ExploitHandler.h"
+
+#include "src/masterd/exploits/MysqlExploitStore.h"
+#include "src/masterd/session/ConnectionSessionMap.h"
+#include "src/masterd/session/SessionManager.h"
+#include "src/shared/network/ExploitPayloads.h"
+#include "src/shared/network/NetServer.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+#include "src/shared/core/Log.h"
+
+namespace engine::server
+{
+	void ExploitHandler::HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+		uint64_t sessionIdHeader, const uint8_t* payload, size_t payloadSize)
+	{
+		using namespace engine::network;
+		if (opcode != kOpcodeExploitListRequest || !m_server || !m_sessions || !m_connMap)
+			return;
+		(void)ParseExploitListRequestPayload(payload, payloadSize); // payload vide accepté.
+
+		// Session → account (même garde que les autres handlers de liste).
+		auto connSessionId = m_connMap->GetSessionId(connId);
+		if (!connSessionId || *connSessionId == 0 || sessionIdHeader == 0
+			|| *connSessionId != sessionIdHeader)
+		{
+			auto pkt = BuildExploitListResponsePacket(
+				static_cast<uint8_t>(ExploitErrorCode::Unauthorized), {}, requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+		auto accountId = m_sessions->GetAccountId(*connSessionId);
+		if (!accountId)
+		{
+			auto pkt = BuildExploitListResponsePacket(
+				static_cast<uint8_t>(ExploitErrorCode::Unauthorized), {}, requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		if (m_store == nullptr || !m_store->IsAvailable())
+		{
+			auto pkt = BuildExploitListResponsePacket(
+				static_cast<uint8_t>(ExploitErrorCode::Unavailable), {}, requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		bool ok = false;
+		const auto listed = m_store->ListForAccount(*accountId, ok);
+		if (!ok)
+		{
+			auto pkt = BuildExploitListResponsePacket(
+				static_cast<uint8_t>(ExploitErrorCode::Unavailable), {}, requestId, sessionIdHeader);
+			if (!pkt.empty()) m_server->Send(connId, pkt);
+			return;
+		}
+
+		std::vector<ExploitEntry> entries;
+		entries.reserve(listed.size());
+		for (const auto& l : listed)
+		{
+			ExploitEntry e;
+			e.code = l.code;
+			e.title = l.title;
+			e.description = l.description;
+			e.unlockedAtUnix = l.unlockedAtUnix;
+			entries.push_back(std::move(e));
+		}
+		auto pkt = BuildExploitListResponsePacket(0u, entries, requestId, sessionIdHeader);
+		if (!pkt.empty()) m_server->Send(connId, pkt);
+		LOG_INFO(Net, "[ExploitHandler] liste envoyée (account_id={}, {} entrées)",
+			*accountId, entries.size());
+	}
+}

--- a/src/masterd/handlers/exploits/ExploitHandler.h
+++ b/src/masterd/handlers/exploits/ExploitHandler.h
@@ -1,0 +1,37 @@
+#pragma once
+// ExploitHandler — handler master de l'opcode kOpcodeExploitListRequest (206)
+// (spec 2026-07-18, SP2 : onglet Exploits de la fenêtre F1). Modèle
+// ReputationHandler : résolution session→account, lecture DB via
+// MysqlExploitStore::ListForAccount, réponse kOpcodeExploitListResponse.
+// Lecture seule : aucun opcode d'écriture (seul le serveur débloque).
+
+#include <cstddef>
+#include <cstdint>
+
+namespace engine::server
+{
+	class NetServer;
+	class SessionManager;
+	class ConnectionSessionMap;
+	class MysqlExploitStore;
+
+	class ExploitHandler
+	{
+	public:
+		void SetServer(NetServer* server)                       { m_server = server; }
+		void SetSessionManager(SessionManager* sessions)        { m_sessions = sessions; }
+		void SetConnectionSessionMap(ConnectionSessionMap* map) { m_connMap = map; }
+		void SetStore(MysqlExploitStore* store)                 { m_store = store; }
+
+		/// Route kOpcodeExploitListRequest vers la lecture DB + réponse.
+		/// Erreurs wire : Unauthorized (pas de session), Unavailable (no-DB).
+		void HandlePacket(uint32_t connId, uint16_t opcode, uint32_t requestId,
+			uint64_t sessionIdHeader, const uint8_t* payload, size_t payloadSize);
+
+	private:
+		NetServer*            m_server   = nullptr;
+		SessionManager*       m_sessions = nullptr;
+		ConnectionSessionMap* m_connMap  = nullptr;
+		MysqlExploitStore*    m_store    = nullptr;
+	};
+}

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -39,6 +39,7 @@
 #include "src/masterd/handlers/character/CharacterEnterWorldHandler.h"
 #include "src/masterd/anniversary/AnniversaryService.h"
 #include "src/masterd/exploits/MysqlExploitStore.h"
+#include "src/masterd/handlers/exploits/ExploitHandler.h"
 #include "src/masterd/handlers/dungeon/EnterDungeonHandler.h"
 #include "src/masterd/handlers/chat/ChatRelayHandler.h"
 #include "src/masterd/handlers/mail/MailHandler.h"
@@ -539,6 +540,14 @@ int main(int argc, char** argv)
 	engine::server::AnniversaryService anniversaryService;
 	anniversaryService.SetDependencies(&dbPool, &exploitStore, mailStoreActive);
 	characterEnterWorldHandler.SetAnniversaryService(&anniversaryService);
+
+	// SP2 — handler de lecture « liste de mes exploits » (opcode 206) pour
+	// l'onglet Exploits de la fenêtre F1 (et tout futur écran d'exploits).
+	engine::server::ExploitHandler exploitHandler;
+	exploitHandler.SetServer(&server);
+	exploitHandler.SetSessionManager(&sessionManager);
+	exploitHandler.SetConnectionSessionMap(&connSessionMap);
+	exploitHandler.SetStore(&exploitStore);
 	LOG_INFO(Net, "[ServerMain] AnniversaryService branché (exploits DB {})",
 		exploitStore.IsAvailable() ? "OK" : "INDISPONIBLE — no-op");
 	mailHandler.SetSessionManager(&sessionManager);
@@ -1168,6 +1177,9 @@ int main(int argc, char** argv)
 			tradeHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeReputationListRequest)
 			reputationHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
+		// Exploits (spec 2026-07-18, SP2) — liste « mes exploits » (206).
+		else if (opcode == kOpcodeExploitListRequest)
+			exploitHandler.HandlePacket(connId, opcode, requestId, sessionIdHeader, payload, payloadSize);
 		else if (opcode == kOpcodeLfgQueueRequest
 		      || opcode == kOpcodeLfgLeaveRequest
 		      || opcode == kOpcodeLfgStatusRequest

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -1125,7 +1125,7 @@ int main(int argc, char** argv)
 	PrintStartupBanner();
 
 	LOG_DEBUG(Server, "[MAIN_SRV] avant SetPacketHandler");
-	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &enterDungeonHandler, &mailHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &interactiveHandler, &guildHandler, &auctionHandler, &lootHandler, &lunarHandler, &worldClockHandler, &adminCommandHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
+	server.SetPacketHandler([&authHandler, &shardRegisterHandler, &shardTicketHandler, &serverListHandler, &passwordResetHandler, &termsHandler, &characterCreateHandler, &characterListHandler, &characterDeleteHandler, &characterSavePositionHandler, &chatRelayHandler, &characterEnterWorldHandler, &enterDungeonHandler, &mailHandler, &ignoreListHandler, &gmTicketHandler, &tradeHandler, &reputationHandler, &exploitHandler, &lfgHandler, &cinematicHandler, &skillHandler, &arenaHandler, &bgHandler, &outdoorPvpHandler, &weatherHandler, &gameEventHandler, &interactiveHandler, &guildHandler, &auctionHandler, &lootHandler, &lunarHandler, &worldClockHandler, &adminCommandHandler](uint32_t connId, uint16_t opcode, uint32_t requestId, uint64_t sessionIdHeader,
 		const uint8_t* payload, size_t payloadSize) {
 		using namespace engine::network;
 		if (opcode == kOpcodeShardRegister || opcode == kOpcodeShardHeartbeat)

--- a/src/shared/network/ExploitPayloads.cpp
+++ b/src/shared/network/ExploitPayloads.cpp
@@ -1,0 +1,114 @@
+// Implémentation Parse/Build des payloads Exploits (opcodes 206/207).
+// Convention identique aux autres *Payloads.cpp du repo (cf.
+// ReputationPayloads.cpp) : Build*Payload = payload nu (tests + requêtes
+// client via SendGenericRequestAsync) ; Build*ResponsePacket = header +
+// payload via PacketBuilder (côté handler master).
+
+#include "src/shared/network/ExploitPayloads.h"
+
+#include "src/shared/network/ByteReader.h"
+#include "src/shared/network/ByteWriter.h"
+#include "src/shared/network/PacketBuilder.h"
+#include "src/shared/network/ProtocolV1Constants.h"
+
+namespace engine::network
+{
+	namespace
+	{
+		/// Écrit une entrée (code, title, description, unlockedAtUnix).
+		bool WriteEntry(ByteWriter& w, const ExploitEntry& e)
+		{
+			if (!w.WriteString(e.code))        return false;
+			if (!w.WriteString(e.title))       return false;
+			if (!w.WriteString(e.description)) return false;
+			if (!w.WriteU64(e.unlockedAtUnix)) return false;
+			return true;
+		}
+
+		/// Lit une entrée (code, title, description, unlockedAtUnix).
+		bool ReadEntry(ByteReader& r, ExploitEntry& e)
+		{
+			if (!r.ReadString(e.code))        return false;
+			if (!r.ReadString(e.title))       return false;
+			if (!r.ReadString(e.description)) return false;
+			if (!r.ReadU64(e.unlockedAtUnix)) return false;
+			return true;
+		}
+
+		/// Sérialise le corps de EXPLOIT_LIST_RESPONSE (error + entries).
+		bool WriteListBody(ByteWriter& w, uint8_t error, const std::vector<ExploitEntry>& entries)
+		{
+			if (!w.WriteBytes(&error, 1u))
+				return false;
+			if (error != 0u)
+				return true;
+			if (!w.WriteArrayCount(static_cast<uint16_t>(entries.size())))
+				return false;
+			for (const auto& e : entries)
+			{
+				if (!WriteEntry(w, e))
+					return false;
+			}
+			return true;
+		}
+	}
+
+	std::optional<ExploitListRequestPayload> ParseExploitListRequestPayload(const uint8_t* /*payload*/, size_t /*payloadSize*/)
+	{
+		// Payload vide accepté.
+		return ExploitListRequestPayload{};
+	}
+
+	std::vector<uint8_t> BuildExploitListRequestPayload()
+	{
+		return std::vector<uint8_t>{};
+	}
+
+	std::optional<ExploitListResponsePayload> ParseExploitListResponsePayload(const uint8_t* payload, size_t payloadSize)
+	{
+		// Min : uint8 error (1).
+		if (!payload || payloadSize < 1u)
+			return std::nullopt;
+		ByteReader r(payload, payloadSize);
+		ExploitListResponsePayload out;
+		if (!r.ReadBytes(&out.error, 1u))
+			return std::nullopt;
+		if (out.error != 0u)
+			return out;
+		uint16_t count = 0;
+		if (!r.ReadArrayCount(count))
+			return std::nullopt;
+		out.entries.reserve(static_cast<size_t>(count));
+		for (uint16_t i = 0; i < count; ++i)
+		{
+			ExploitEntry e;
+			if (!ReadEntry(r, e))
+				return std::nullopt;
+			out.entries.push_back(std::move(e));
+		}
+		return out;
+	}
+
+	std::vector<uint8_t> BuildExploitListResponsePayload(uint8_t error, const std::vector<ExploitEntry>& entries)
+	{
+		std::vector<uint8_t> buf(kProtocolV1MaxPacketSize, 0u);
+		ByteWriter w(buf.data(), buf.size());
+		if (!WriteListBody(w, error, entries))
+			return {};
+		buf.resize(w.Offset());
+		return buf;
+	}
+
+	std::vector<uint8_t> BuildExploitListResponsePacket(uint8_t error, const std::vector<ExploitEntry>& entries,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader)
+	{
+		PacketBuilder builder;
+		ByteWriter w = builder.PayloadWriter();
+		if (!WriteListBody(w, error, entries))
+			return {};
+		const size_t payloadBytes = w.Offset();
+		if (!builder.Finalize(kOpcodeExploitListResponse, 0u, requestId, sessionIdHeader, payloadBytes))
+			return {};
+		return builder.Data();
+	}
+}

--- a/src/shared/network/ExploitPayloads.h
+++ b/src/shared/network/ExploitPayloads.h
@@ -1,0 +1,69 @@
+#pragma once
+// Wire payloads pour les opcodes Exploits (206/207) — spec 2026-07-18
+// (récompenses d'anniversaire, SP2 : onglet Exploits de la fenêtre F1).
+//
+// Une seule paire Request/Response :
+//   - List (206/207) : le client demande SA liste (payload vide, l'account
+//     est dérivé de la session côté master) ; le master renvoie le catalogue
+//     actif (scope account) avec le statut débloqué/verrouillé. Les exploits
+//     secrets NON débloqués sont omis par le serveur.
+//
+// Lecture seule côté client : seul le master débloque (MysqlExploitStore).
+// Format wire : ByteReader/ByteWriter little-endian, strings uint16+UTF-8.
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace engine::network
+{
+	/// Code d'erreur générique pour les opcodes Exploits.
+	/// 0 = OK ; sinon le tableau des entries est vide.
+	enum class ExploitErrorCode : uint8_t
+	{
+		Ok           = 0,
+		Unauthorized = 6, ///< Pas de session valide côté master.
+		Unavailable  = 7, ///< Store exploits indisponible (mode no-DB).
+	};
+
+	/// Wire format : (vide). L'account est dérivé de la session côté master.
+	struct ExploitListRequestPayload
+	{
+		// (vide)
+	};
+
+	/// Une entrée du catalogue d'exploits, avec le statut du compte.
+	struct ExploitEntry
+	{
+		std::string code;           ///< identifiant stable (ex. signup_anniv_1).
+		std::string title;          ///< libellé affichable (FR).
+		std::string description;    ///< description affichable (FR).
+		uint64_t unlockedAtUnix = 0; ///< epoch s UTC du déblocage ; 0 = verrouillé.
+	};
+
+	/// Wire format :
+	///   uint8  error                 (cf. ExploitErrorCode)
+	///   uint16 count                  (si error == 0)
+	///   <count> entrées : string code, string title, string description,
+	///                     uint64 unlockedAtUnix (0 = verrouillé)
+	struct ExploitListResponsePayload
+	{
+		uint8_t                   error = 0;
+		std::vector<ExploitEntry> entries;
+	};
+
+	/// Parse le payload d'un EXPLOIT_LIST_REQUEST. Toujours OK (payload vide).
+	std::optional<ExploitListRequestPayload> ParseExploitListRequestPayload(const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildExploitListRequestPayload();
+
+	std::optional<ExploitListResponsePayload> ParseExploitListResponsePayload(const uint8_t* payload, size_t payloadSize);
+
+	std::vector<uint8_t> BuildExploitListResponsePayload(uint8_t error, const std::vector<ExploitEntry>& entries);
+
+	/// Paquet complet (header + payload), utilisé côté handler master.
+	std::vector<uint8_t> BuildExploitListResponsePacket(uint8_t error, const std::vector<ExploitEntry>& entries,
+	                                                    uint32_t requestId, uint64_t sessionIdHeader);
+}

--- a/src/shared/network/ExploitPayloadsTests.cpp
+++ b/src/shared/network/ExploitPayloadsTests.cpp
@@ -1,0 +1,108 @@
+/// Tests round-trip des payloads Exploits (opcodes 206/207, spec 2026-07-18).
+/// Vérifie Build→Parse (liste vide, liste peuplée, erreur, payload tronqué).
+/// Pur CPU, ctest.
+
+#include "src/shared/network/ExploitPayloads.h"
+
+#include <cstdio>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using namespace engine::network;
+
+	void Test_RequestRoundTrip()
+	{
+		auto payload = BuildExploitListRequestPayload();
+		REQUIRE(payload.empty());
+		auto parsed = ParseExploitListRequestPayload(payload.data(), payload.size());
+		REQUIRE(parsed.has_value());
+	}
+
+	void Test_ResponseRoundTrip()
+	{
+		std::vector<ExploitEntry> entries;
+		ExploitEntry a;
+		a.code = "signup_anniv_1";
+		a.title = "Fidèle depuis 1 an";
+		a.description = "Un an de jeu depuis l'inscription du compte.";
+		a.unlockedAtUnix = 1753000000ull;
+		entries.push_back(a);
+		ExploitEntry b;
+		b.code = "birthday_1";
+		b.title = "Premier anniversaire fêté";
+		b.description = "Connecté le jour de son anniversaire — la première fois.";
+		b.unlockedAtUnix = 0ull; // verrouillé
+		entries.push_back(b);
+
+		auto payload = BuildExploitListResponsePayload(0u, entries);
+		REQUIRE(!payload.empty());
+		auto parsed = ParseExploitListResponsePayload(payload.data(), payload.size());
+		REQUIRE(parsed.has_value());
+		REQUIRE(parsed->error == 0u);
+		REQUIRE(parsed->entries.size() == 2u);
+		REQUIRE(parsed->entries[0].code == "signup_anniv_1");
+		REQUIRE(parsed->entries[0].title == a.title);
+		REQUIRE(parsed->entries[0].description == a.description);
+		REQUIRE(parsed->entries[0].unlockedAtUnix == 1753000000ull);
+		REQUIRE(parsed->entries[1].code == "birthday_1");
+		REQUIRE(parsed->entries[1].unlockedAtUnix == 0ull);
+	}
+
+	void Test_ResponseEmptyList()
+	{
+		auto payload = BuildExploitListResponsePayload(0u, {});
+		auto parsed = ParseExploitListResponsePayload(payload.data(), payload.size());
+		REQUIRE(parsed.has_value());
+		REQUIRE(parsed->error == 0u);
+		REQUIRE(parsed->entries.empty());
+	}
+
+	void Test_ResponseError()
+	{
+		auto payload = BuildExploitListResponsePayload(
+			static_cast<uint8_t>(ExploitErrorCode::Unauthorized), {});
+		REQUIRE(payload.size() == 1u); // erreur : pas de tableau
+		auto parsed = ParseExploitListResponsePayload(payload.data(), payload.size());
+		REQUIRE(parsed.has_value());
+		REQUIRE(parsed->error == static_cast<uint8_t>(ExploitErrorCode::Unauthorized));
+	}
+
+	void Test_ResponseTruncated()
+	{
+		std::vector<ExploitEntry> entries;
+		ExploitEntry a;
+		a.code = "x"; a.title = "y"; a.description = "z"; a.unlockedAtUnix = 1ull;
+		entries.push_back(a);
+		auto payload = BuildExploitListResponsePayload(0u, entries);
+		REQUIRE(payload.size() > 4u);
+		auto parsed = ParseExploitListResponsePayload(payload.data(), payload.size() - 3u);
+		REQUIRE(!parsed.has_value()); // tronqué → rejet
+		REQUIRE(!ParseExploitListResponsePayload(nullptr, 0u).has_value());
+	}
+}
+
+int main()
+{
+	Test_RequestRoundTrip();
+	Test_ResponseRoundTrip();
+	Test_ResponseEmptyList();
+	Test_ResponseError();
+	Test_ResponseTruncated();
+
+	if (g_failed == 0)
+	{
+		std::printf("[PASS] ExploitPayloadsTests\n");
+		return 0;
+	}
+	std::printf("[FAIL] ExploitPayloadsTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/src/shared/network/ProtocolV1Constants.h
+++ b/src/shared/network/ProtocolV1Constants.h
@@ -836,4 +836,12 @@ namespace engine::network
 	constexpr uint16_t kOpcodeWorldClockStateRequest        = 203u; ///< Client to Master : etat horloge (vide).
 	constexpr uint16_t kOpcodeWorldClockStateResponse       = 204u; ///< Master to Client : epoch, timeScale, offset, paused, lunarPeriod + serverTimeUnixMs.
 	constexpr uint16_t kOpcodeWorldClockChangeNotification  = 205u; ///< Master to Client (push, request_id=0) : changement admin.
+
+	// =====================================================================
+	// Exploits (spec 2026-07-18 recompenses anniversaire, SP2) — lecture seule
+	// cote client : le master seul debloque (MysqlExploitStore). Rétro-additif
+	// (pas de version ProtocolV1) ; deploiement lock-step master + client.
+	// =====================================================================
+	constexpr uint16_t kOpcodeExploitListRequest  = 206u; ///< Client to Master : liste de mes exploits (payload vide, account via session).
+	constexpr uint16_t kOpcodeExploitListResponse = 207u; ///< Master to Client : catalogue actif + statut debloque/verrouille (secrets non debloques omis).
 }


### PR DESCRIPTION
## Objectif (spec 2026-07-18, suite de #989)

Rendre les exploits **visibles en jeu** : nouvel onglet **Exploits** dans la fenetre Personnage (F1), alimente par une nouvelle paire d'opcodes TCP master. Le portail web continue de lire les memes tables sans changement.

## Contenu

- **Opcodes 206/207** (ExploitListRequest / ExploitListResponse) : retro-additifs (aucune version ProtocolV1 a bumper) ; l'account est derive de la session cote master, le client n'envoie rien d'autre.
- **ExploitPayloads** (Build/Parse + packet) + tests round-trip (exploit_payloads_tests, ctest Linux).
- **MysqlExploitStore::ListForAccount** : catalogue actif (scope account) + statut du compte, trie par sort_order ; les exploits secrets non debloques sont filtres COTE SQL (jamais envoyes au client).
- **ExploitHandler** (master, modele ReputationHandler) : session→account, erreurs Unauthorized / Unavailable (no-DB), cable au boot + dispatch.
- **Client** : presenter ExploitsUi (requete envoyee a l'ouverture F1) + renderer de l'onglet (debloques avec date locale + tooltip description, verrouilles grises) ; onglet absent si non cable (retro-compatible).

## Ordre de merge

**#989 (SP1) d'abord**, puis celle-ci — cette branche contient les commits de SP1 (meme chantier ; le diff se reduira apres le merge de #989).

## Validation

- CI : build Windows (client) + build Linux (master) + ctest.
- En jeu : F1 → onglet Exploits → liste des paliers fidelite/anniversaire (verrouilles au debut) ; apres un EnterWorld avec anciennete ≥ 1 an, le palier apparait debloque avec sa date.

**Deploiement** : ⚠️ **lock-step client + master** (nouveaux opcodes : un client neuf face a un master ancien recevrait une erreur sur l'onglet Exploits ; un master neuf seul est inoffensif). Shard non concerne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)