### PR TITLE
feat(server): console /help par role RBAC + /time + /uptime

### DIFF
--- a/docs/slash_commands_rbac.md
+++ b/docs/slash_commands_rbac.md
@@ -120,3 +120,22 @@ Les UI panels peuvent éventuellement utiliser un opcode léger
 `AdminCommandLog` qui ne fait que tracer sans bloquer (status toujours
 OK pour `minRole=player`), pour éviter la latence d'un round-trip
 serveur sur des commandes UI fréquentes.
+
+## Console : /help, /time, /uptime (2026-07-18)
+
+Trois commandes « server_routed » dispatchées par le `ChatCommandRouter`
+du master (réponses en notices `system`) :
+
+- **`/help [commande]`** (alias `/commands`, `/aide`, minRole `player`) :
+  liste les commandes **accessibles au rôle de l'appelant**, groupées par
+  catégorie, construite depuis `slash_commands.json`
+  (`SlashCommandRegistry::Entries`) — les entrées `status=planned` sont
+  omises. `/help /commande` donne le détail : description, rôle minimum,
+  alias. C'est la réponse au besoin « on ne connaît pas toutes les
+  commandes » : chacun voit exactement ce que son rôle permet.
+- **`/time`** (minRole `player`) : date et heure du serveur (UTC).
+- **`/uptime`** (minRole `moderator`) : temps de fonctionnement du master.
+
+Rappel : le `minRole` effectif de ces trois commandes est fixé **en code**
+à l'enregistrement sur le router (`src/masterd/main_linux.cpp`) ; le JSON
+doit rester aligné (source documentaire pour `/help`).

--- a/docs/superpowers/specs/2026-07-18-anniversary-rewards-design.md
+++ b/docs/superpowers/specs/2026-07-18-anniversary-rewards-design.md
@@ -54,15 +54,18 @@ Récompenser la fidélité des joueurs à partir de deux dates **immuables** :
 
 Nouveau `AnniversaryService` côté master, sans scheduler :
 
-- **À l'AUTH** : années révolues depuis `created_at` → débloque tous les
-  `signup_anniv_*` manquants. Si jour UTC == jour/mois de `birth_date` →
-  débloque `birthday_N` avec N = (nombre de paliers `birthday_*` déjà
-  débloqués dans `account_exploit_unlocks`) + 1 ; l'idempotence intra-jour
-  est assurée par la garde `(account_id, year, 'birthday_exploit')`.
-- **Au premier EnterWorld du jour J de naissance** : dépose le courrier
-  cadeau au personnage entrant (il faut un destinataire personnage). Garde
-  `(account_id, year, 'birthday_gift')`. Pas d'EnterWorld le jour J = pas de
-  cadeaux.
+- **Point d'accroche unique : EnterWorld** (décision d'implémentation — le
+  compte, le personnage destinataire ET la connexion pour la notification
+  chat y sont tous disponibles ; les règles utilisateur restent respectées :
+  « à la connexion suivante » = au prochain EnterWorld, jamais perdu ; jour J
+  strict pour la naissance) :
+  - années révolues depuis `created_at` → débloque tous les
+    `signup_anniv_*` manquants ;
+  - si jour UTC == jour/mois de `birth_date` → débloque `birthday_N` avec
+    N = (paliers `birthday_*` déjà débloqués) + 1, garde
+    `(account_id, year, 'birthday_exploit')` ; puis dépose le **courrier
+    cadeau** au personnage entrant, garde `(account_id, year,
+    'birthday_gift')`. Pas d'EnterWorld le jour J = pas de cadeaux.
 - La logique de dates vit dans un module pur (`AnniversaryMath`) avec horloge
   injectée (testable).
 

--- a/game/data/config/slash_commands.json
+++ b/game/data/config/slash_commands.json
@@ -467,6 +467,42 @@
       "status": "implemented",
       "implementation_file": "src/masterd/handlers/admin/AdminCommandHandler.cpp",
       "notes": "Commande admin horloge monde : le master appelle WorldClockHandler::SetTimeScale qui borne [1,1440] et broadcast 205. Hors bornes ou argument non numerique -> InvalidArgs."
+    },
+    {
+      "command": "/help [commande]",
+      "aliases": ["/commands", "/aide"],
+      "description": "Liste les commandes accessibles a VOTRE role (groupees par categorie) ; /help /commande donne le detail (description, role minimum, alias).",
+      "category": "ui_panel",
+      "minRole": "player",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "server_routed",
+      "implementation_file": "src/masterd/main_linux.cpp",
+      "notes": "Console 2026-07-18 : dispatch via ChatCommandRouter (master), liste construite depuis CE fichier (SlashCommandRegistry::Entries) filtree par le role de l'appelant ; les entrees status=planned sont omises. Reponses en notices system."
+    },
+    {
+      "command": "/time",
+      "aliases": [],
+      "description": "Affiche la date et l'heure du serveur (UTC).",
+      "category": "ui_panel",
+      "minRole": "player",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "server_routed",
+      "implementation_file": "src/masterd/main_linux.cpp",
+      "notes": "Console 2026-07-18 : dispatch via ChatCommandRouter (master)."
+    },
+    {
+      "command": "/uptime",
+      "aliases": [],
+      "description": "Temps de fonctionnement du serveur master (jours/heures/minutes/secondes).",
+      "category": "moderation",
+      "minRole": "moderator",
+      "serverInteraction": true,
+      "serverLogged": true,
+      "status": "server_routed",
+      "implementation_file": "src/masterd/main_linux.cpp",
+      "notes": "Console 2026-07-18 : info d'exploitation, reservee moderateur et plus (ajustable ici — le router relit ce fichier au boot via SlashCommandRegistry ? NON : le minRole effectif du router est fixe en code a Moderator ; garder les deux alignes)."
     }
   ]
 }

--- a/src/masterd/admin/SlashCommandRegistry.cpp
+++ b/src/masterd/admin/SlashCommandRegistry.cpp
@@ -311,6 +311,11 @@ namespace engine::server
 
 			if (const JsonNode* statusNode = FindString(item.o, "status"))
 				entry.status = statusNode->s;
+			// Console /help (2026-07-18) — champs affichables optionnels.
+			if (const JsonNode* descNode = FindString(item.o, "description"))
+				entry.description = descNode->s;
+			if (const JsonNode* catNode = FindString(item.o, "category"))
+				entry.category = catNode->s;
 
 			const size_t idx = m_entries.size();
 			m_entries.push_back(std::move(entry));

--- a/src/masterd/admin/SlashCommandRegistry.h
+++ b/src/masterd/admin/SlashCommandRegistry.h
@@ -33,6 +33,10 @@ namespace engine::server
 		std::vector<std::string>   aliases;   ///< Aliases ex: ["/sky"] pour "/sky info".
 		engine::server::AccountRole minRole = engine::server::AccountRole::Player;
 		std::string                status;    ///< "implemented" / "client_only_legacy" / etc. (info).
+		/// Console /help (2026-07-18) — description et catégorie affichables
+		/// (reprises du JSON ; vides si absentes).
+		std::string                description;
+		std::string                category;
 	};
 
 	/// Registre des slash commands lu au boot. Read-only apres LoadFromFile.
@@ -69,6 +73,11 @@ namespace engine::server
 
 		/// Nombre d'entrees uniques chargees (pas le total des cles indexees).
 		size_t Size() const { return m_entries.size(); }
+
+		/// Console /help (2026-07-18) — liste complete des entrees (ordre du
+		/// fichier). Lecture seule ; sert a construire la liste des commandes
+		/// visibles par un role donne.
+		const std::vector<SlashCommandEntry>& Entries() const { return m_entries; }
 
 	private:
 		/// Stockage canonique par valeur (une entree par commande).

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -61,6 +61,8 @@
 #include "src/masterd/handlers/worldclock/WorldClockHandler.h"
 #include "src/masterd/handlers/admin/AdminCommandHandler.h"
 #include "src/masterd/admin/SlashCommandRegistry.h"
+#include "src/shared/network/ChatPayloads.h" // Console /help /time /uptime (2026-07-18)
+#include "src/shared/net/ChatSystem.h"
 #include "src/masterd/account/AccountRoleService.h"
 #include "src/masterd/handlers/lfg/LfgHandler.h"
 #include "src/masterd/lfg/LfgQueue.h"
@@ -98,6 +100,7 @@
 
 #include <csignal>
 #include <chrono>
+#include <ctime> // Console /time (2026-07-18)
 #include <cstdio>
 #include <cstring>
 #include <memory>
@@ -1052,6 +1055,145 @@ int main(int argc, char** argv)
 	// GetRole/RequireMinRole. Utilise par AdminCommandHandler pour la
 	// verification du minRole. Lecture seule cote AdminCommand.
 	engine::server::AccountRoleService accountRoleService(*accountStore, &auditLog);
+
+	// ── Console 2026-07-18 : /help (+ /commands /aide), /time, /uptime ──
+	// Enregistrées sur le ChatCommandRouter du relay (dispatch serveur, RBAC
+	// vérifié par le router, réponses en notices « system »). /help liste les
+	// commandes VISIBLES PAR LE RÔLE de l'appelant depuis le registre
+	// slash_commands.json (source unique) ; /help <cmd> donne le détail.
+	{
+		const auto masterStartTime = std::chrono::steady_clock::now();
+
+		// Répond à l'appelant (accountId → session → connId) par une notice
+		// « system » sur le canal Server. No-op si le compte n'a plus de
+		// connexion (déconnexion entre l'envoi et le dispatch).
+		auto replyToAccount = [&server, &connSessionMap, &sessionManager](
+			uint64_t accountId, const std::string& text)
+		{
+			for (const auto& [connId, sessionId] : connSessionMap.Snapshot())
+			{
+				const auto acc = sessionManager.GetAccountId(sessionId);
+				if (!acc || *acc != accountId) continue;
+				const uint64_t nowMs = static_cast<uint64_t>(
+					std::chrono::duration_cast<std::chrono::milliseconds>(
+						std::chrono::system_clock::now().time_since_epoch()).count());
+				auto notice = engine::network::BuildChatRelayPacket(nowMs,
+					static_cast<uint8_t>(engine::net::ChatChannel::Server),
+					"system", text, sessionId);
+				if (!notice.empty())
+					server.Send(connId, notice);
+				return;
+			}
+		};
+
+		// Libellé FR d'un rôle (affichage /help).
+		auto roleLabelFr = [](engine::server::AccountRole r) -> const char*
+		{
+			switch (r)
+			{
+				case engine::server::AccountRole::Moderator:     return "modérateur";
+				case engine::server::AccountRole::GameMaster:    return "maître de jeu";
+				case engine::server::AccountRole::Administrator: return "administrateur";
+				default:                                          return "joueur";
+			}
+		};
+
+		// /help [commande] — liste par catégorie des commandes accessibles au
+		// rôle de l'appelant, ou détail d'une commande précise.
+		auto helpHandler = [&slashCommandRegistry, &accountStore, replyToAccount, roleLabelFr](
+			uint64_t accountId, std::string_view args)
+		{
+			const engine::server::AccountRole role = accountStore->GetRole(accountId);
+			if (!args.empty())
+			{
+				// Détail d'une commande : accepte "/kick" ou "kick".
+				std::string wanted(args);
+				if (wanted.front() != '/') wanted.insert(wanted.begin(), '/');
+				const engine::server::SlashCommandEntry* e = slashCommandRegistry.Lookup(wanted);
+				if (e == nullptr)
+				{
+					replyToAccount(accountId, "Commande inconnue : " + wanted);
+					return;
+				}
+				if (!engine::server::AccountRoleService::RequireMinRole(role, e->minRole))
+				{
+					replyToAccount(accountId, wanted + " est réservée au rôle "
+						+ std::string(roleLabelFr(e->minRole)) + " (ou supérieur).");
+					return;
+				}
+				std::string detail = e->command;
+				if (!e->description.empty()) detail += " — " + e->description;
+				detail += " [rôle min : " + std::string(roleLabelFr(e->minRole)) + "]";
+				if (!e->aliases.empty())
+				{
+					detail += " [alias :";
+					for (const std::string& a : e->aliases) detail += " " + a;
+					detail += "]";
+				}
+				replyToAccount(accountId, detail);
+				return;
+			}
+
+			// Liste groupée par catégorie, filtrée par le rôle de l'appelant.
+			// Les commandes "planned" (pas encore implémentées) sont omises.
+			replyToAccount(accountId, std::string("Commandes disponibles pour votre rôle (")
+				+ roleLabelFr(role) + ") — « /help /commande » pour le détail :");
+			std::vector<std::string> categories;
+			for (const auto& e : slashCommandRegistry.Entries())
+			{
+				if (e.status == "planned") continue;
+				if (!engine::server::AccountRoleService::RequireMinRole(role, e.minRole)) continue;
+				bool seen = false;
+				for (const std::string& c : categories)
+					if (c == e.category) { seen = true; break; }
+				if (!seen) categories.push_back(e.category);
+			}
+			for (const std::string& cat : categories)
+			{
+				std::string line = (cat.empty() ? std::string("autres") : cat) + " :";
+				for (const auto& e : slashCommandRegistry.Entries())
+				{
+					if (e.category != cat || e.status == "planned") continue;
+					if (!engine::server::AccountRoleService::RequireMinRole(role, e.minRole)) continue;
+					line += " " + e.command;
+				}
+				replyToAccount(accountId, line);
+			}
+		};
+		chatRelayHandler.CommandRouter().Register("/help", engine::server::AccountRole::Player, helpHandler);
+		chatRelayHandler.CommandRouter().Register("/commands", engine::server::AccountRole::Player, helpHandler);
+		chatRelayHandler.CommandRouter().Register("/aide", engine::server::AccountRole::Player, helpHandler);
+
+		// /time — date et heure serveur (UTC).
+		chatRelayHandler.CommandRouter().Register("/time", engine::server::AccountRole::Player,
+			[replyToAccount](uint64_t accountId, std::string_view)
+			{
+				const std::time_t now = std::time(nullptr);
+				std::tm tmv{};
+				gmtime_r(&now, &tmv);
+				char buf[64];
+				std::snprintf(buf, sizeof(buf),
+					"Heure serveur : %04d-%02d-%02d %02d:%02d:%02d UTC",
+					tmv.tm_year + 1900, tmv.tm_mon + 1, tmv.tm_mday,
+					tmv.tm_hour, tmv.tm_min, tmv.tm_sec);
+				replyToAccount(accountId, buf);
+			});
+
+		// /uptime — temps de fonctionnement du master (modérateur et plus).
+		chatRelayHandler.CommandRouter().Register("/uptime", engine::server::AccountRole::Moderator,
+			[replyToAccount, masterStartTime](uint64_t accountId, std::string_view)
+			{
+				const auto up = std::chrono::duration_cast<std::chrono::seconds>(
+					std::chrono::steady_clock::now() - masterStartTime).count();
+				const long long d = up / 86400ll, h = (up / 3600ll) % 24ll,
+					m = (up / 60ll) % 60ll, s = up % 60ll;
+				char buf[96];
+				std::snprintf(buf, sizeof(buf),
+					"Uptime master : %lldj %lldh %lldmin %llds", d, h, m, s);
+				replyToAccount(accountId, buf);
+			});
+		LOG_INFO(Net, "[ServerMain] Console : /help /commands /aide /time /uptime enregistrées");
+	}
 
 	engine::server::AdminCommandHandler adminCommandHandler;
 	adminCommandHandler.SetServer(&server);


### PR DESCRIPTION
## Objectif

On ne connait pas toutes les commandes disponibles dans la console : **`/help` liste desormais exactement les commandes accessibles a VOTRE role** (hierarchie player < moderator < game_master < administrator), et deux commandes utilitaires sont ajoutees.

## Commandes

| Commande | Role min | Effet |
|---|---|---|
| `/help` (alias `/commands`, `/aide`) | joueur | Liste par categorie des commandes de votre role (les commandes `planned` sont omises) + rappel « /help /commande pour le detail » |
| `/help /commande` | joueur | Detail : description, role minimum, alias — ou « reservee au role X » si au-dessus de votre niveau |
| `/time` | joueur | Date et heure du serveur (UTC) |
| `/uptime` | moderateur | Duree de fonctionnement du master (j/h/min/s) |

## Implementation

- La liste `/help` est construite depuis **`slash_commands.json`** (source unique du RBAC) via `SlashCommandRegistry` — qui parse desormais aussi `description` et `category`. Toute commande ajoutee au JSON apparait automatiquement dans `/help`.
- Dispatch via le **`ChatCommandRouter`** du ChatRelay (le router verifie le RBAC ; l'audit serveur existant `[ChatRelayHandler] cmd dispatched` loggue chaque appel). Reponses en notices `system` adressees au bon client.
- `slash_commands.json` et `docs/slash_commands_rbac.md` mis a jour (regle du projet : toute commande figure au registre).
- Inclut aussi un petit commit docs : alignement du spec anniversaires sur l'implementation (point d'accroche EnterWorld) — changement reste non commite d'une session precedente.

## Validation

- CI : build Linux (master).
- En jeu : `/help` avec un compte joueur → uniquement les commandes player ; avec un compte admin → tout ; `/help /kick` → detail ; `/time` → heure UTC ; `/uptime` en joueur → « Insufficient permissions », en moderateur → uptime.

**Deploiement** : ⚠️ **redeploiement serveur MASTER requis** (nouvelles commandes du router + registre etendu). Shard et client non concernes (le client envoie deja tout texte `/xxx` inconnu au master via le chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)