### PR TITLE
feat(game): loot reel - probabilites de drop, resync inventaire au relog, contenu

### DIFF
--- a/game/data/creatures/archetypes.json
+++ b/game/data/creatures/archetypes.json
@@ -15,6 +15,70 @@
       },
       "xpReward": 10,
       "model": { "mesh": "orcs", "scale": 0.9 }
+    },
+    {
+      "id": 101,
+      "name": "Loup gris",
+      "level": 1,
+      "stats": {
+        "hp": 40,
+        "damage": 4,
+        "accuracy": 85.0,
+        "rangeMeters": 2.0,
+        "critRate": 3.0,
+        "critMult": 1.5,
+        "attackPeriodMs": 1600
+      },
+      "xpReward": 7,
+      "model": { "mesh": "orcs", "scale": 0.7 }
+    },
+    {
+      "id": 102,
+      "name": "Lapin des pres",
+      "level": 1,
+      "stats": {
+        "hp": 12,
+        "damage": 1,
+        "accuracy": 60.0,
+        "rangeMeters": 1.5,
+        "critRate": 0.5,
+        "critMult": 1.2,
+        "attackPeriodMs": 2500
+      },
+      "xpReward": 2,
+      "model": { "mesh": "orcs", "scale": 0.4 }
+    },
+    {
+      "id": 103,
+      "name": "Bandit de grand chemin",
+      "level": 4,
+      "stats": {
+        "hp": 90,
+        "damage": 8,
+        "accuracy": 82.0,
+        "rangeMeters": 2.5,
+        "critRate": 5.0,
+        "critMult": 1.6,
+        "attackPeriodMs": 1800
+      },
+      "xpReward": 18,
+      "model": { "mesh": "orcs", "scale": 1.0 }
+    },
+    {
+      "id": 104,
+      "name": "Sanglier alpha",
+      "level": 5,
+      "stats": {
+        "hp": 140,
+        "damage": 11,
+        "accuracy": 84.0,
+        "rangeMeters": 2.8,
+        "critRate": 4.0,
+        "critMult": 1.7,
+        "attackPeriodMs": 2100
+      },
+      "xpReward": 30,
+      "model": { "mesh": "orcs", "scale": 1.2 }
     }
   ]
 }

--- a/game/data/items/items.json
+++ b/game/data/items/items.json
@@ -260,6 +260,39 @@
       "type": "weapon",
       "slot": "mainhand",
       "bonus": { "damage": 12, "accuracy": 4 }
+    },
+    {
+      "_comment": "Loot reel (2026-07-19) — materiaux de butin (plage 6001+). Ne s'equipent pas ; vendables aux marchands / futurs ingredients d'artisanat.",
+      "id": 6001,
+      "name": "Peau de loup",
+      "description": "Une peau epaisse et grise. Les tanneurs en font bon usage.",
+      "icon": "items/peau_loup.png",
+      "type": "misc",
+      "slot": "none"
+    },
+    {
+      "id": 6002,
+      "name": "Patte de lapin",
+      "description": "Un porte-bonheur classique. Moins chanceux pour le lapin.",
+      "icon": "items/patte_lapin.png",
+      "type": "misc",
+      "slot": "none"
+    },
+    {
+      "id": 6003,
+      "name": "Defense de sanglier",
+      "description": "Une defense robuste, prisee des artisans.",
+      "icon": "items/defense_sanglier.png",
+      "type": "misc",
+      "slot": "none"
+    },
+    {
+      "id": 6004,
+      "name": "Bourse volee",
+      "description": "Une bourse derobee par un bandit. Son proprietaire ne la reclamera plus.",
+      "icon": "items/bourse_volee.png",
+      "type": "misc",
+      "slot": "none"
     }
   ]
 }

--- a/game/data/loot/loot_tables.txt
+++ b/game/data/loot/loot_tables.txt
@@ -1,3 +1,28 @@
-# source_archetype_id item_id quantity visibility
-100 2001 1 owner
-100 2002 3 owner
+# Tables de loot du shard — Loot reel 2026-07-19.
+# Format : source_archetype_id item_id quantity visibility [drop_chance_pct] [min_count max_count]
+#   - drop_chance_pct optionnel (1..100 ; absent = 100, drop garanti)
+#   - min_count/max_count optionnels (quantite uniforme ; absents = quantity fixe)
+# Les item_id referencent game/data/items/items.json (2001/2002 = butin
+# historique, 5001+ = equipement, 6001+ = materiaux de butin).
+
+# 100 — Sanglier des collines
+100 6003 1 owner 80 1 2
+100 2002 1 owner 45 1 2
+100 2001 1 owner 20
+
+# 101 — Loup gris
+101 6001 1 owner 85 1 2
+101 2002 1 owner 15
+
+# 102 — Lapin des pres
+102 6002 1 owner 95
+
+# 103 — Bandit de grand chemin
+103 6004 1 owner 70 1 3
+103 2001 1 owner 35
+103 5008 1 owner 5
+
+# 104 — Sanglier alpha (mini-boss)
+104 6003 1 owner 100 2 4
+104 5001 1 owner 12
+104 2002 1 owner 60 2 3

--- a/game/data/zones/zone_1/spawners.json
+++ b/game/data/zones/zone_1/spawners.json
@@ -8,6 +8,38 @@
       "count": 2,
       "respawnSec": 8,
       "leashDistanceMeters": 24.0
+    },
+    {
+      "id": "zone_1_spawn_02_loups",
+      "archetypeId": 101,
+      "position": [96.0, 0.0, 140.0],
+      "count": 3,
+      "respawnSec": 10,
+      "leashDistanceMeters": 28.0
+    },
+    {
+      "id": "zone_1_spawn_03_lapins",
+      "archetypeId": 102,
+      "position": [110.0, 0.0, 105.0],
+      "count": 4,
+      "respawnSec": 6,
+      "leashDistanceMeters": 18.0
+    },
+    {
+      "id": "zone_1_spawn_04_bandits",
+      "archetypeId": 103,
+      "position": [160.0, 0.0, 150.0],
+      "count": 2,
+      "respawnSec": 15,
+      "leashDistanceMeters": 30.0
+    },
+    {
+      "id": "zone_1_spawn_05_alpha",
+      "archetypeId": 104,
+      "position": [150.0, 0.0, 96.0],
+      "count": 1,
+      "respawnSec": 45,
+      "leashDistanceMeters": 32.0
     }
   ]
 }

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1632,6 +1632,14 @@ namespace engine::server
 		SendDynamicEventBootstrap(acceptedClient);
 		SendQuestStateBootstrap(acceptedClient);
 		(void)SendWalletUpdate(acceptedClient);
+		// Loot réel (2026-07-19) — resynchronise l'inventaire ET l'équipement
+		// PERSISTÉS à l'entrée en monde. Avant ce fix, le serveur rechargeait
+		// bien les deux depuis le fichier personnage mais n'en envoyait rien :
+		// au relog, le sac paraissait vide jusqu'au premier delta (loot,
+		// achat, équipement…).
+		(void)SendInventoryDelta(acceptedClient,
+			std::span<const ItemStack>(acceptedClient.inventory.data(), acceptedClient.inventory.size()));
+		(void)SendEquipmentUpdate(acceptedClient);
 		OnClientLogin(acceptedClient);
 	}
 
@@ -2002,6 +2010,36 @@ namespace engine::server
 				LOG_ERROR(Net, "[ServerApp] Loot table init FAILED: zero value at line {}", lineNumber);
 				m_lootTableEntries.clear();
 				return false;
+			}
+
+			// Loot réel (2026-07-19) — colonnes OPTIONNELLES rétro-compatibles :
+			//   [drop_chance_pct]           1..100 (absent = 100, toujours)
+			//   [min_count max_count]       quantité uniforme (absent = fixe)
+			uint32_t chance = 0;
+			if (lineStream >> chance)
+			{
+				if (chance == 0 || chance > 100)
+				{
+					LOG_ERROR(Net, "[ServerApp] Loot table init FAILED: drop_chance {} hors [1..100] ligne {}",
+						chance, lineNumber);
+					m_lootTableEntries.clear();
+					return false;
+				}
+				entry.dropChancePct = static_cast<uint8_t>(chance);
+				uint32_t minCount = 0;
+				uint32_t maxCount = 0;
+				if (lineStream >> minCount >> maxCount)
+				{
+					if (minCount == 0 || maxCount < minCount)
+					{
+						LOG_ERROR(Net, "[ServerApp] Loot table init FAILED: min/max ({}/{}) invalides ligne {}",
+							minCount, maxCount, lineNumber);
+						m_lootTableEntries.clear();
+						return false;
+					}
+					entry.minCount = minCount;
+					entry.maxCount = maxCount;
+				}
 			}
 
 			m_lootTableEntries.push_back(entry);
@@ -3973,22 +4011,50 @@ namespace engine::server
 			sentOk);
 	}
 
+	/// Loot réel (2026-07-19) — Tire le drop effectif d'une entrée : proba
+	/// dropChancePct (m_combatRng), puis quantité uniforme [minCount,
+	/// maxCount] si bornée, sinon quantité fixe item.quantity.
+	/// \return true si l'entrée droppe (outItem rempli), false si le tirage
+	/// échoue. Effet de bord : consomme m_combatRng.
+	bool ServerApp::RollLootEntry(const LootTableEntry& entry, ItemStack& outItem)
+	{
+		if (entry.dropChancePct < 100u)
+		{
+			std::uniform_int_distribution<uint32_t> chanceDist(1u, 100u);
+			if (chanceDist(m_combatRng) > entry.dropChancePct)
+			{
+				return false;
+			}
+		}
+		outItem = entry.item;
+		if (entry.maxCount > 0u)
+		{
+			std::uniform_int_distribution<uint32_t> countDist(entry.minCount, entry.maxCount);
+			outItem.quantity = countDist(m_combatRng);
+		}
+		return true;
+	}
+
 	void ServerApp::AutoLootMobToKiller(const MobEntity& mob, EntityId looterEntityId)
 	{
 		// Même collecte que SpawnLootBagForMob : toutes les entrées de la table
 		// pour cet archétype (la visibilité owner/public ne concerne que les
 		// sacs ; en crédit direct le looter du groupe a déjà été résolu).
+		// Loot réel (2026-07-19) : chaque entrée passe par RollLootEntry
+		// (proba de drop + quantité aléatoire).
 		std::vector<ItemStack> droppedItems;
 		for (const LootTableEntry& entry : m_lootTableEntries)
 		{
-			if (entry.sourceArchetypeId == mob.archetypeId)
+			ItemStack rolled{};
+			if (entry.sourceArchetypeId == mob.archetypeId && RollLootEntry(entry, rolled))
 			{
-				droppedItems.push_back(entry.item);
+				droppedItems.push_back(rolled);
 			}
 		}
 		if (droppedItems.empty())
 		{
-			// Pas de loot pour cet archétype : pas de fenêtre côté client.
+			// Pas de loot pour cet archétype (ou tirages malchanceux) : pas de
+			// fenêtre côté client.
 			LOG_DEBUG(Net, "[ServerApp] Auto-loot skipped: no loot table entry (mob_entity_id={}, archetype_id={})",
 				mob.entityId, mob.archetypeId);
 			return;
@@ -4050,7 +4116,13 @@ namespace engine::server
 				return;
 			}
 
-			droppedItems.push_back(entry.item);
+			// Loot réel (2026-07-19) — tirage proba + quantité (la visibilité
+			// est validée sur TOUTES les entrées de l'archétype, tirées ou non).
+			ItemStack rolled{};
+			if (RollLootEntry(entry, rolled))
+			{
+				droppedItems.push_back(rolled);
+			}
 		}
 
 		if (!foundLoot)
@@ -4058,6 +4130,13 @@ namespace engine::server
 			LOG_WARN(Net, "[ServerApp] Loot bag spawn skipped: no loot table entry (mob_entity_id={}, archetype_id={})",
 				mob.entityId,
 				mob.archetypeId);
+			return;
+		}
+		if (droppedItems.empty())
+		{
+			// Tirages malchanceux : rien à mettre dans le sac, pas de spawn.
+			LOG_DEBUG(Net, "[ServerApp] Loot bag spawn skipped: rolls empty (mob_entity_id={}, archetype_id={})",
+				mob.entityId, mob.archetypeId);
 			return;
 		}
 

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -108,6 +108,13 @@ namespace engine::server
 		uint32_t sourceArchetypeId = 0;
 		ItemStack item{};
 		LootVisibility visibility = LootVisibility::Owner;
+		/// Loot réel (2026-07-19) — probabilité de drop en % (1..100 ;
+		/// colonne optionnelle du fichier texte, défaut 100 = toujours).
+		uint8_t dropChancePct = 100;
+		/// Quantité aléatoire uniforme [minCount, maxCount] quand
+		/// maxCount > 0 ; sinon quantité FIXE = item.quantity (rétro-compat).
+		uint32_t minCount = 0;
+		uint32_t maxCount = 0;
 	};
 
 	/// One connected client tracked by endpoint and assigned server id.
@@ -589,6 +596,11 @@ namespace engine::server
 
 		/// Chantier 2 SP-A — pousse au client le snapshot complet de son équipement porté.
 		bool SendEquipmentUpdate(const ConnectedClient& receiver);
+
+		/// Loot réel (2026-07-19) — tirage d'une entrée de table de loot
+		/// (proba dropChancePct + quantité uniforme [minCount,maxCount]).
+		/// \return true si l'entrée droppe (\p outItem rempli).
+		bool RollLootEntry(const LootTableEntry& entry, ItemStack& outItem);
 
 		/// Chantier 2 SP-A — somme des StatBonus de tout l'équipement porté (résolus
 		/// via m_itemCatalog). Additionnée aux DerivedStats avant émission (anti-triche).


### PR DESCRIPTION
## Objectif (roadmap 2026-07-19, chantier 1)

Boucle de jeu complete : **tuer -> ramasser -> garder -> re-voir son butin au relog**.

## Decouverte d'exploration

La boucle de loot du shard **existait deja de bout en bout** (kill → credit auto de l'inventaire → persistance → fenetre Butin + InventoryDelta ; sac au sol en repli si looter deconnecte, ramassage touche F). Le systeme reellement mort est le **LootHandler du master** (roll Need/Greed sur 5 items hardcodes, n'octroie rien, IDs incoherents) — laisse dormant, hors boucle. Les tables SQL 0057 ne sont pas utilisables par le shard (no-DB) : la source de verite reste `game/data/loot/loot_tables.txt`.

## Changements

1. **FIX relog (le vrai bug)** : l'inventaire et l'equipement PERSISTES etaient recharges cote serveur mais jamais renvoyes a l'entree en monde — le sac paraissait vide jusqu'au premier delta. Ajout de `SendInventoryDelta` + `SendEquipmentUpdate` a l'admission.
2. **Probabilites de drop** : colonnes optionnelles retro-compatibles du format texte — `drop_chance_pct` (1..100) et `min_count max_count` (quantite uniforme). `RollLootEntry` (RNG combat) applique par l'auto-loot ET le sac au sol ; tirages malchanceux = pas de fenetre/pas de sac.
3. **Contenu** : 4 nouveaux archetypes (Loup gris, Lapin des pres, Bandit de grand chemin, Sanglier alpha mini-boss), 4 materiaux de butin (6001-6004), tables de loot avec probas/quantites — dont **drops rares d'equipement** (Anneau de force 5 %, Heaume de fer 12 %) — et 4 nouveaux spawners en zone 1.

## Wire

**Aucun changement** : kinds UDP existants (PickupRequest 10, InventoryDelta 11, LootNotify 87), kProtocolVersion inchange.

## Validation

- CI : builds shard Windows/Linux.
- En jeu : tuer un loup → fenetre Butin + peau de loup en sac ; tuer l'alpha plusieurs fois → defenses 2-4 + heaume ~1 fois sur 8 ; relog → **l'inventaire et l'equipement sont toujours affiches** (c'etait le bug) ; se deconnecter au moment du kill → sac au sol ramassable a la reconnexion.

**Deploiement** : ⚠️ **redeploiement SHARD requis** (+ data game/data/). Master et client non concernes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)