### PR TITLE
feat(game): auras sur les vraies stats - %PV max et %vitesse (push 79)

### DIFF
--- a/game/data/creatures/archetypes.json
+++ b/game/data/creatures/archetypes.json
@@ -15,6 +15,70 @@
       },
       "xpReward": 10,
       "model": { "mesh": "orcs", "scale": 0.9 }
+    },
+    {
+      "id": 101,
+      "name": "Loup gris",
+      "level": 1,
+      "stats": {
+        "hp": 40,
+        "damage": 4,
+        "accuracy": 85.0,
+        "rangeMeters": 2.0,
+        "critRate": 3.0,
+        "critMult": 1.5,
+        "attackPeriodMs": 1600
+      },
+      "xpReward": 7,
+      "model": { "mesh": "orcs", "scale": 0.7 }
+    },
+    {
+      "id": 102,
+      "name": "Lapin des pres",
+      "level": 1,
+      "stats": {
+        "hp": 12,
+        "damage": 1,
+        "accuracy": 60.0,
+        "rangeMeters": 1.5,
+        "critRate": 0.5,
+        "critMult": 1.2,
+        "attackPeriodMs": 2500
+      },
+      "xpReward": 2,
+      "model": { "mesh": "orcs", "scale": 0.4 }
+    },
+    {
+      "id": 103,
+      "name": "Bandit de grand chemin",
+      "level": 4,
+      "stats": {
+        "hp": 90,
+        "damage": 8,
+        "accuracy": 82.0,
+        "rangeMeters": 2.5,
+        "critRate": 5.0,
+        "critMult": 1.6,
+        "attackPeriodMs": 1800
+      },
+      "xpReward": 18,
+      "model": { "mesh": "orcs", "scale": 1.0 }
+    },
+    {
+      "id": 104,
+      "name": "Sanglier alpha",
+      "level": 5,
+      "stats": {
+        "hp": 140,
+        "damage": 11,
+        "accuracy": 84.0,
+        "rangeMeters": 2.8,
+        "critRate": 4.0,
+        "critMult": 1.7,
+        "attackPeriodMs": 2100
+      },
+      "xpReward": 30,
+      "model": { "mesh": "orcs", "scale": 1.2 }
     }
   ]
 }

--- a/game/data/items/items.json
+++ b/game/data/items/items.json
@@ -110,7 +110,7 @@
     {
       "id": 5103,
       "name": "Gateau du zephyr",
-      "description": "Un gateau d'anniversaire a partager : -15% menace generee pour le groupe proche. Ne se conserve pas au-dela du jour J.",
+      "description": "Un gateau d'anniversaire a partager : +8% vitesse de deplacement pour le groupe proche. Ne se conserve pas au-dela du jour J.",
       "icon": "items/gateau_zephyr.png",
       "type": "consumable",
       "slot": "none"
@@ -118,7 +118,7 @@
     {
       "id": 5104,
       "name": "Gateau du sage",
-      "description": "Un gateau d'anniversaire a partager : -20% menace generee pour le groupe proche. Ne se conserve pas au-dela du jour J.",
+      "description": "Un gateau d'anniversaire a partager : +8% PV maximum pour le groupe proche. Ne se conserve pas au-dela du jour J.",
       "icon": "items/gateau_sage.png",
       "type": "consumable",
       "slot": "none"

--- a/game/data/items/items.json
+++ b/game/data/items/items.json
@@ -260,6 +260,39 @@
       "type": "weapon",
       "slot": "mainhand",
       "bonus": { "damage": 12, "accuracy": 4 }
+    },
+    {
+      "_comment": "Loot reel (2026-07-19) — materiaux de butin (plage 6001+). Ne s'equipent pas ; vendables aux marchands / futurs ingredients d'artisanat.",
+      "id": 6001,
+      "name": "Peau de loup",
+      "description": "Une peau epaisse et grise. Les tanneurs en font bon usage.",
+      "icon": "items/peau_loup.png",
+      "type": "misc",
+      "slot": "none"
+    },
+    {
+      "id": 6002,
+      "name": "Patte de lapin",
+      "description": "Un porte-bonheur classique. Moins chanceux pour le lapin.",
+      "icon": "items/patte_lapin.png",
+      "type": "misc",
+      "slot": "none"
+    },
+    {
+      "id": 6003,
+      "name": "Defense de sanglier",
+      "description": "Une defense robuste, prisee des artisans.",
+      "icon": "items/defense_sanglier.png",
+      "type": "misc",
+      "slot": "none"
+    },
+    {
+      "id": 6004,
+      "name": "Bourse volee",
+      "description": "Une bourse derobee par un bandit. Son proprietaire ne la reclamera plus.",
+      "icon": "items/bourse_volee.png",
+      "type": "misc",
+      "slot": "none"
     }
   ]
 }

--- a/game/data/loot/loot_tables.txt
+++ b/game/data/loot/loot_tables.txt
@@ -1,3 +1,28 @@
-# source_archetype_id item_id quantity visibility
-100 2001 1 owner
-100 2002 3 owner
+# Tables de loot du shard — Loot reel 2026-07-19.
+# Format : source_archetype_id item_id quantity visibility [drop_chance_pct] [min_count max_count]
+#   - drop_chance_pct optionnel (1..100 ; absent = 100, drop garanti)
+#   - min_count/max_count optionnels (quantite uniforme ; absents = quantity fixe)
+# Les item_id referencent game/data/items/items.json (2001/2002 = butin
+# historique, 5001+ = equipement, 6001+ = materiaux de butin).
+
+# 100 — Sanglier des collines
+100 6003 1 owner 80 1 2
+100 2002 1 owner 45 1 2
+100 2001 1 owner 20
+
+# 101 — Loup gris
+101 6001 1 owner 85 1 2
+101 2002 1 owner 15
+
+# 102 — Lapin des pres
+102 6002 1 owner 95
+
+# 103 — Bandit de grand chemin
+103 6004 1 owner 70 1 3
+103 2001 1 owner 35
+103 5008 1 owner 5
+
+# 104 — Sanglier alpha (mini-boss)
+104 6003 1 owner 100 2 4
+104 5001 1 owner 12
+104 2002 1 owner 60 2 3

--- a/game/data/zones/zone_1/spawners.json
+++ b/game/data/zones/zone_1/spawners.json
@@ -8,6 +8,38 @@
       "count": 2,
       "respawnSec": 8,
       "leashDistanceMeters": 24.0
+    },
+    {
+      "id": "zone_1_spawn_02_loups",
+      "archetypeId": 101,
+      "position": [96.0, 0.0, 140.0],
+      "count": 3,
+      "respawnSec": 10,
+      "leashDistanceMeters": 28.0
+    },
+    {
+      "id": "zone_1_spawn_03_lapins",
+      "archetypeId": 102,
+      "position": [110.0, 0.0, 105.0],
+      "count": 4,
+      "respawnSec": 6,
+      "leashDistanceMeters": 18.0
+    },
+    {
+      "id": "zone_1_spawn_04_bandits",
+      "archetypeId": 103,
+      "position": [160.0, 0.0, 150.0],
+      "count": 2,
+      "respawnSec": 15,
+      "leashDistanceMeters": 30.0
+    },
+    {
+      "id": "zone_1_spawn_05_alpha",
+      "archetypeId": 104,
+      "position": [150.0, 0.0, 96.0],
+      "count": 1,
+      "respawnSec": 45,
+      "leashDistanceMeters": 32.0
     }
   ]
 }

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -9619,6 +9619,14 @@ namespace engine
 					&& (m_uiModelBinding.GetModel().playerStats.stateFlags & 1u) != 0u;
 				if (m_dialogueActive || moveLocked || localPlayerDead)
 					moveInput = engine::gameplay::MoveInput{};
+				// Roadmap-2 (2026-07-19) — vitesses AUTORITAIRES du serveur
+				// (PlayerStats kind 79 : classe + équipement + buffs d'auras).
+				// 0 = pas encore reçu → la config locale reste en vigueur.
+				{
+					const auto& ps79 = m_uiModelBinding.GetModel().playerStats;
+					if (ps79.speedRun > 0.1f)
+						m_characterController.SetMoveSpeeds(ps79.speedWalk, ps79.speedRun, ps79.speedSprint);
+				}
 				// Collisionneur composite : terrain (sol + eau) + cylindres des props/décor.
 				m_characterController.Update(static_cast<float>(dt), moveInput, m_worldCollider);
 				const engine::math::Vec3 ccPos = m_characterController.GetPosition();

--- a/src/client/gameplay/CharacterController.h
+++ b/src/client/gameplay/CharacterController.h
@@ -85,6 +85,9 @@ namespace engine::gameplay
 			float walkSpeed = 5.0f;  ///< range: 4-6 m/s
 			float runSpeed = 9.0f;   ///< range: 8-10 m/s
 			float sprintSpeed = 13.0f; ///< range: 12-14 m/s (Alt maintenu)
+			// (Roadmap-2 2026-07-19 : ces trois vitesses peuvent être écrasées
+			// à chaud par SetMoveSpeeds — valeurs autoritaires du serveur,
+			// équipement + buffs d'auras inclus, cf. PlayerStats kind 79.)
 			float crouchSpeed = 2.5f;  ///< range: 2-3 m/s (Ctrl maintenu)
 			float acceleration = 25.0f; ///< m/s^2
 			float friction = 20.0f;     ///< m/s^2 (horizontal decel when no input)
@@ -147,6 +150,18 @@ namespace engine::gameplay
 		engine::math::Vec3 GetPosition() const { return m_positionCenter; }
 		engine::math::Vec3 GetVelocity() const { return m_velocity; }
 		IWorldCollider::Capsule GetCapsule() const { return m_capsule; }
+
+		/// Roadmap-2 (2026-07-19) — écrase les vitesses de déplacement par les
+		/// valeurs AUTORITAIRES du serveur (PlayerStats kind 79 : base classe
+		/// + équipement + buffs d'auras). Appelée chaque frame par l'Engine
+		/// (idempotente, valeurs ignorées si <= 0). Les autres paramètres
+		/// (gravité, saut, esquive…) restent ceux de la config locale.
+		void SetMoveSpeeds(float walk, float run, float sprint)
+		{
+			if (walk > 0.0f)   m_cfg.walkSpeed = walk;
+			if (run > 0.0f)    m_cfg.runSpeed = run;
+			if (sprint > 0.0f) m_cfg.sprintSpeed = sprint;
+		}
 
 		/// Declenche une impulsion d'esquive (roulade) dans la direction XZ donnee.
 		/// Pendant `dodgeDurationSec`, la vitesse horizontale est forcee a

--- a/src/shardd/anticheat/AntiCheatGameplay.h
+++ b/src/shardd/anticheat/AntiCheatGameplay.h
@@ -65,16 +65,47 @@ namespace engine::server::anticheat
 
 			const uint64_t dtMs = (nowMs > last.tsMs) ? (nowMs - last.tsMs) : 1;
 			const float speedMps = dist / (static_cast<float>(dtMs) / 1000.0f);
-			const float maxAllowed = m_cfg.maxSpeedMps * m_cfg.speedTolerance;
+			// Roadmap-2 (2026-07-19) — le plafond intègre le multiplicateur de
+			// vitesse LÉGITIME du joueur (buffs %MoveSpeed, cf.
+			// SetPlayerSpeedMultiplier) ; 1.0 si aucun buff.
+			const float maxAllowed = m_cfg.maxSpeedMps * m_cfg.speedTolerance
+				* PlayerSpeedMultiplier(player);
 
 			last = {x, y, z, nowMs, true};
 			return (speedMps > maxAllowed) ? CheatVerdict::SpeedHack : CheatVerdict::OK;
 		}
 
-		void Reset(PlayerId player) { m_state.erase(player); }
+		void Reset(PlayerId player)
+		{
+			m_state.erase(player);
+			m_speedMultiplier.erase(player);
+		}
+
+		/// Roadmap-2 (2026-07-19) — déclare le multiplicateur de vitesse
+		/// LÉGITIME du joueur (1.0 = aucun buff). Posé par le shard à chaque
+		/// recalcul de stats (RefreshLiveDerivedStats) pour que les buffs
+		/// %MoveSpeed ne déclenchent pas de faux SpeedHack. Valeur bornée
+		/// [0.1, 10] par sûreté.
+		void SetPlayerSpeedMultiplier(PlayerId player, float multiplier)
+		{
+			const float clamped = multiplier < 0.1f ? 0.1f : (multiplier > 10.0f ? 10.0f : multiplier);
+			if (clamped == 1.0f)
+				m_speedMultiplier.erase(player);
+			else
+				m_speedMultiplier[player] = clamped;
+		}
 
 	private:
+		/// Multiplicateur courant du joueur (1.0 si non déclaré).
+		float PlayerSpeedMultiplier(PlayerId player) const
+		{
+			const auto it = m_speedMultiplier.find(player);
+			return it != m_speedMultiplier.end() ? it->second : 1.0f;
+		}
+
 		AntiCheatConfig m_cfg;
 		std::unordered_map<PlayerId, LastReportedPos> m_state;
+		/// Roadmap-2 — multiplicateurs de vitesse légitimes par joueur.
+		std::unordered_map<PlayerId, float> m_speedMultiplier;
 	};
 }

--- a/src/shardd/gameplay/anniversary/CakeBuffLibrary.cpp
+++ b/src/shardd/gameplay/anniversary/CakeBuffLibrary.cpp
@@ -11,8 +11,10 @@ namespace engine::server
 		constexpr CakeBuffDef kCakeBuffs[] = {
 			{ 5101u, "gateau_braves",    "+6 % de dégâts infligés",   SpellEffectType::BuffDamagePercent,      6.0f },
 			{ 5102u, "gateau_colosse",   "-8 % de dégâts subis",      SpellEffectType::DamageReductionPercent, 8.0f },
-			{ 5103u, "gateau_zephyr",    "-15 % de menace générée",   SpellEffectType::ThreatReducePercent,   15.0f },
-			{ 5104u, "gateau_sage",      "-20 % de menace générée",   SpellEffectType::ThreatReducePercent,   20.0f },
+			// Roadmap-2 (2026-07-19) — les effets de VRAIES stats existent
+			// désormais : le zéphyr retrouve sa vitesse, le sage donne des PV.
+			{ 5103u, "gateau_zephyr",    "+8 % de vitesse de déplacement", SpellEffectType::MoveSpeedPercent,  8.0f },
+			{ 5104u, "gateau_sage",      "+8 % de PV maximum",             SpellEffectType::MaxHealthPercent,  8.0f },
 			{ 5105u, "gateau_guetteur",  "+4 % de dégâts infligés",   SpellEffectType::BuffDamagePercent,      4.0f },
 			{ 5106u, "gateau_duelliste", "+8 % de dégâts infligés",   SpellEffectType::BuffDamagePercent,      8.0f },
 			{ 5107u, "gateau_gardien",   "-10 % de dégâts subis",     SpellEffectType::DamageReductionPercent, 10.0f },

--- a/src/shardd/gameplay/spell/SpellKitLibrary.cpp
+++ b/src/shardd/gameplay/spell/SpellKitLibrary.cpp
@@ -425,6 +425,8 @@ namespace engine::server
 			if (text == "TauntThreatMult") { outType = SpellEffectType::TauntThreatMult; return true; }
 			if (text == "SlowMobPercent") { outType = SpellEffectType::SlowMobPercent; return true; }
 			if (text == "ThreatReducePercent") { outType = SpellEffectType::ThreatReducePercent; return true; }
+			if (text == "MaxHealthPercent") { outType = SpellEffectType::MaxHealthPercent; return true; }
+			if (text == "MoveSpeedPercent") { outType = SpellEffectType::MoveSpeedPercent; return true; }
 			return false;
 		}
 

--- a/src/shardd/gameplay/spell/SpellKitLibrary.h
+++ b/src/shardd/gameplay/spell/SpellKitLibrary.h
@@ -28,6 +28,14 @@ namespace engine::server
 		/// (appliquée dans ApplyAuraDamageModifiers côté cible). Analogue à
 		/// DebuffDamageTakenPercent mais en signe inverse (réduction, pas amplification).
 		DamageReductionPercent = 9,
+		/// Roadmap-2 (2026-07-19) — modificateurs de VRAIES stats, agrégés par
+		/// ApplyAuraStatModifiers (ServerApp) et poussés au client par
+		/// PlayerStats (kind 79) à l'application/retrait de l'aura :
+		/// +% PV max (les PV courants sont clampés, jamais soignés gratis).
+		MaxHealthPercent = 10,
+		/// +% vitesses de déplacement (walk/run/sprint) — répercuté aussi sur
+		/// la tolérance anti-cheat par joueur.
+		MoveSpeedPercent = 11,
 	};
 
 	/// Combat SP3 — type de cible d'un sort.

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -260,19 +260,48 @@ namespace engine::server
 			return static_cast<uint32_t>(std::llround(modified));
 		}
 
+		/// Roadmap-2 (2026-07-19) — applique les modificateurs de STATS des
+		/// auras au DerivedStats : +% PV max et +% vitesses. Les effets de
+		/// dégâts restent gérés à la résolution (ApplyAuraDamageModifiers).
+		/// Les multiplicateurs sont plafonnés vers le bas (jamais < 10 % de la
+		/// base) pour qu'un débuff extrême ne fige/tue pas le personnage.
+		void ApplyAuraStatModifiers(const std::vector<ActiveAura>& auras,
+			engine::server::gameplay::DerivedStats& d)
+		{
+			const float hpPct = SumAuraPercent(auras, SpellEffectType::MaxHealthPercent);
+			if (hpPct != 0.0f)
+			{
+				const float mult = std::max(0.1f, 1.0f + hpPct / 100.0f);
+				d.hp = std::max<uint32_t>(1u, static_cast<uint32_t>(
+					std::llround(static_cast<double>(d.hp) * mult)));
+			}
+			const float spdPct = SumAuraPercent(auras, SpellEffectType::MoveSpeedPercent);
+			if (spdPct != 0.0f)
+			{
+				const float mult = std::max(0.1f, 1.0f + spdPct / 100.0f);
+				d.speedWalk   *= mult;
+				d.speedRun    *= mult;
+				d.speedSprint *= mult;
+			}
+		}
+
 		/// Combat SP3 — insère ou rafraîchit une aura (même spellId + même casteur
 		/// = refresh de la durée, pas d'empilement en V1).
-		void UpsertAura(std::vector<ActiveAura>& auras, ActiveAura&& aura)
+		/// \return true si l'aura vient d'être AJOUTÉE (nouvelle), false si
+		/// c'était un simple refresh — les appelants ne déclenchent le recalcul
+		/// de stats (Roadmap-2) que sur un vrai ajout.
+		bool UpsertAura(std::vector<ActiveAura>& auras, ActiveAura&& aura)
 		{
 			for (ActiveAura& existing : auras)
 			{
 				if (existing.spellId == aura.spellId && existing.casterEntityId == aura.casterEntityId)
 				{
 					existing = std::move(aura);
-					return;
+					return false;
 				}
 			}
 			auras.push_back(std::move(aura));
+			return true;
 		}
 
 		/// Combat SP2 — copie les stats dérivées du moteur de personnages dans le
@@ -3557,6 +3586,9 @@ namespace engine::server
 			*m_statsTables, client.factionId, client.classId, sex, client.level);
 		if (!d) return;
 		ApplyEquipmentBonus(client, *d);
+		// Roadmap-2 (2026-07-19) — les auras de stats (%PV max, %vitesse)
+		// s'appliquent APRÈS l'équipement (mêmes règles que SendPlayerStats).
+		ApplyAuraStatModifiers(client.auras, *d);
 
 		ApplyDerivedCombatStats(client, *d);
 		client.maxResource = d->resource;
@@ -3570,6 +3602,14 @@ namespace engine::server
 		if (client.stats.currentHealth > client.stats.maxHealth)
 		{
 			client.stats.currentHealth = client.stats.maxHealth;
+		}
+		// Roadmap-2 (2026-07-19) — déclare à l'anti-cheat le multiplicateur de
+		// vitesse LÉGITIME (buffs %MoveSpeed) pour éviter les faux SpeedHack.
+		if (client.persistenceCharacterKey != 0u)
+		{
+			const float spdPct = SumAuraPercent(client.auras, SpellEffectType::MoveSpeedPercent);
+			m_antiCheat.SetPlayerSpeedMultiplier(client.persistenceCharacterKey,
+				std::max(0.1f, 1.0f + spdPct / 100.0f));
 		}
 	}
 
@@ -5183,7 +5223,13 @@ namespace engine::server
 							: static_cast<uint32_t>(std::llround(
 								static_cast<double>(effect.mult) * static_cast<double>(client.combat.damagePerHit)));
 					}
-					UpsertAura(ally->auras, std::move(aura));
+					// Roadmap-2 (2026-07-19) — une NOUVELLE aura peut modifier
+					// les stats réelles (%PV max, %vitesse) : recalcul + push 79.
+					if (UpsertAura(ally->auras, std::move(aura)))
+					{
+						RefreshLiveDerivedStats(*ally);
+						(void)SendPlayerStats(*ally);
+					}
 					if (ally == &client)
 					{
 						casterAurasChanged = true;
@@ -5344,7 +5390,12 @@ namespace engine::server
 			defAura.expiresAtMs     = nowMs + 8000u;
 			defAura.nextTickAtMs    = 0u;
 			defAura.casterEntityId  = client.entityId;
-			UpsertAura(client.auras, std::move(defAura));
+			if (UpsertAura(client.auras, std::move(defAura)))
+			{
+				// Roadmap-2 — recalcul des stats réelles à l'ajout d'aura.
+				RefreshLiveDerivedStats(client);
+				(void)SendPlayerStats(client);
+			}
 			BroadcastAuraUpdate(client.entityId, client.auras);
 			LOG_INFO(Net,
 				"[ServerApp] SP-C Defense aura applied (client_id={}, skill={}, percent={:.1f}, duration_ms=8000)",
@@ -5393,6 +5444,11 @@ namespace engine::server
 			if (client.auras.size() != beforeCount)
 			{
 				BroadcastAuraUpdate(client.entityId, client.auras);
+				// Roadmap-2 (2026-07-19) — l'expiration d'une aura peut rendre
+				// des stats réelles (%PV max, %vitesse) : recalcul + push 79.
+				// Les PV courants sont re-clampés sous le nouveau max.
+				RefreshLiveDerivedStats(client);
+				(void)SendPlayerStats(client);
 			}
 		}
 
@@ -5795,7 +5851,14 @@ namespace engine::server
 				aura.percent = def->percent;
 				aura.expiresAtMs = nowMonotonicMs + kCakeAuraTtlMs;
 				aura.casterEntityId = client.entityId;
-				UpsertAura(target->auras, std::move(aura));
+				const bool newlyAdded = UpsertAura(target->auras, std::move(aura));
+				// Roadmap-2 — recalcul UNIQUEMENT au vrai ajout (l'entretien
+				// 1 Hz ne fait que rafraîchir la durée : pas de spam 79).
+				if (newlyAdded)
+				{
+					RefreshLiveDerivedStats(*target);
+					(void)SendPlayerStats(*target);
+				}
 				BroadcastAuraUpdate(target->entityId, target->auras);
 			}
 		}
@@ -6951,6 +7014,8 @@ namespace engine::server
 		if (!d) return false;
 		// Chantier 2 SP-A — bonus d'équipement (source autoritaire : catalogue serveur).
 		ApplyEquipmentBonus(client, *d);
+		// Roadmap-2 (2026-07-19) — reflète aussi les auras de stats sur le wire.
+		ApplyAuraStatModifiers(client.auras, *d);
 
 		PlayerStatsMessage msg{};
 		msg.clientId    = client.clientId;

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1632,6 +1632,14 @@ namespace engine::server
 		SendDynamicEventBootstrap(acceptedClient);
 		SendQuestStateBootstrap(acceptedClient);
 		(void)SendWalletUpdate(acceptedClient);
+		// Loot réel (2026-07-19) — resynchronise l'inventaire ET l'équipement
+		// PERSISTÉS à l'entrée en monde. Avant ce fix, le serveur rechargeait
+		// bien les deux depuis le fichier personnage mais n'en envoyait rien :
+		// au relog, le sac paraissait vide jusqu'au premier delta (loot,
+		// achat, équipement…).
+		(void)SendInventoryDelta(acceptedClient,
+			std::span<const ItemStack>(acceptedClient.inventory.data(), acceptedClient.inventory.size()));
+		(void)SendEquipmentUpdate(acceptedClient);
 		OnClientLogin(acceptedClient);
 	}
 
@@ -2002,6 +2010,36 @@ namespace engine::server
 				LOG_ERROR(Net, "[ServerApp] Loot table init FAILED: zero value at line {}", lineNumber);
 				m_lootTableEntries.clear();
 				return false;
+			}
+
+			// Loot réel (2026-07-19) — colonnes OPTIONNELLES rétro-compatibles :
+			//   [drop_chance_pct]           1..100 (absent = 100, toujours)
+			//   [min_count max_count]       quantité uniforme (absent = fixe)
+			uint32_t chance = 0;
+			if (lineStream >> chance)
+			{
+				if (chance == 0 || chance > 100)
+				{
+					LOG_ERROR(Net, "[ServerApp] Loot table init FAILED: drop_chance {} hors [1..100] ligne {}",
+						chance, lineNumber);
+					m_lootTableEntries.clear();
+					return false;
+				}
+				entry.dropChancePct = static_cast<uint8_t>(chance);
+				uint32_t minCount = 0;
+				uint32_t maxCount = 0;
+				if (lineStream >> minCount >> maxCount)
+				{
+					if (minCount == 0 || maxCount < minCount)
+					{
+						LOG_ERROR(Net, "[ServerApp] Loot table init FAILED: min/max ({}/{}) invalides ligne {}",
+							minCount, maxCount, lineNumber);
+						m_lootTableEntries.clear();
+						return false;
+					}
+					entry.minCount = minCount;
+					entry.maxCount = maxCount;
+				}
 			}
 
 			m_lootTableEntries.push_back(entry);
@@ -3973,22 +4011,50 @@ namespace engine::server
 			sentOk);
 	}
 
+	/// Loot réel (2026-07-19) — Tire le drop effectif d'une entrée : proba
+	/// dropChancePct (m_combatRng), puis quantité uniforme [minCount,
+	/// maxCount] si bornée, sinon quantité fixe item.quantity.
+	/// \return true si l'entrée droppe (outItem rempli), false si le tirage
+	/// échoue. Effet de bord : consomme m_combatRng.
+	bool ServerApp::RollLootEntry(const LootTableEntry& entry, ItemStack& outItem)
+	{
+		if (entry.dropChancePct < 100u)
+		{
+			std::uniform_int_distribution<uint32_t> chanceDist(1u, 100u);
+			if (chanceDist(m_combatRng) > entry.dropChancePct)
+			{
+				return false;
+			}
+		}
+		outItem = entry.item;
+		if (entry.maxCount > 0u)
+		{
+			std::uniform_int_distribution<uint32_t> countDist(entry.minCount, entry.maxCount);
+			outItem.quantity = countDist(m_combatRng);
+		}
+		return true;
+	}
+
 	void ServerApp::AutoLootMobToKiller(const MobEntity& mob, EntityId looterEntityId)
 	{
 		// Même collecte que SpawnLootBagForMob : toutes les entrées de la table
 		// pour cet archétype (la visibilité owner/public ne concerne que les
 		// sacs ; en crédit direct le looter du groupe a déjà été résolu).
+		// Loot réel (2026-07-19) : chaque entrée passe par RollLootEntry
+		// (proba de drop + quantité aléatoire).
 		std::vector<ItemStack> droppedItems;
 		for (const LootTableEntry& entry : m_lootTableEntries)
 		{
-			if (entry.sourceArchetypeId == mob.archetypeId)
+			ItemStack rolled{};
+			if (entry.sourceArchetypeId == mob.archetypeId && RollLootEntry(entry, rolled))
 			{
-				droppedItems.push_back(entry.item);
+				droppedItems.push_back(rolled);
 			}
 		}
 		if (droppedItems.empty())
 		{
-			// Pas de loot pour cet archétype : pas de fenêtre côté client.
+			// Pas de loot pour cet archétype (ou tirages malchanceux) : pas de
+			// fenêtre côté client.
 			LOG_DEBUG(Net, "[ServerApp] Auto-loot skipped: no loot table entry (mob_entity_id={}, archetype_id={})",
 				mob.entityId, mob.archetypeId);
 			return;
@@ -4050,7 +4116,13 @@ namespace engine::server
 				return;
 			}
 
-			droppedItems.push_back(entry.item);
+			// Loot réel (2026-07-19) — tirage proba + quantité (la visibilité
+			// est validée sur TOUTES les entrées de l'archétype, tirées ou non).
+			ItemStack rolled{};
+			if (RollLootEntry(entry, rolled))
+			{
+				droppedItems.push_back(rolled);
+			}
 		}
 
 		if (!foundLoot)
@@ -4058,6 +4130,13 @@ namespace engine::server
 			LOG_WARN(Net, "[ServerApp] Loot bag spawn skipped: no loot table entry (mob_entity_id={}, archetype_id={})",
 				mob.entityId,
 				mob.archetypeId);
+			return;
+		}
+		if (droppedItems.empty())
+		{
+			// Tirages malchanceux : rien à mettre dans le sac, pas de spawn.
+			LOG_DEBUG(Net, "[ServerApp] Loot bag spawn skipped: rolls empty (mob_entity_id={}, archetype_id={})",
+				mob.entityId, mob.archetypeId);
 			return;
 		}
 

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -108,6 +108,13 @@ namespace engine::server
 		uint32_t sourceArchetypeId = 0;
 		ItemStack item{};
 		LootVisibility visibility = LootVisibility::Owner;
+		/// Loot réel (2026-07-19) — probabilité de drop en % (1..100 ;
+		/// colonne optionnelle du fichier texte, défaut 100 = toujours).
+		uint8_t dropChancePct = 100;
+		/// Quantité aléatoire uniforme [minCount, maxCount] quand
+		/// maxCount > 0 ; sinon quantité FIXE = item.quantity (rétro-compat).
+		uint32_t minCount = 0;
+		uint32_t maxCount = 0;
 	};
 
 	/// One connected client tracked by endpoint and assigned server id.
@@ -589,6 +596,11 @@ namespace engine::server
 
 		/// Chantier 2 SP-A — pousse au client le snapshot complet de son équipement porté.
 		bool SendEquipmentUpdate(const ConnectedClient& receiver);
+
+		/// Loot réel (2026-07-19) — tirage d'une entrée de table de loot
+		/// (proba dropChancePct + quantité uniforme [minCount,maxCount]).
+		/// \return true si l'entrée droppe (\p outItem rempli).
+		bool RollLootEntry(const LootTableEntry& entry, ItemStack& outItem);
 
 		/// Chantier 2 SP-A — somme des StatBonus de tout l'équipement porté (résolus
 		/// via m_itemCatalog). Additionnée aux DerivedStats avant émission (anti-triche).


### PR DESCRIPTION
## Objectif (roadmap 2026-07-19, chantier 2)

Les auras ne modifiaient que les degats. Elles peuvent desormais modifier les **vraies stats** : **+% PV max** et **+% vitesse de deplacement** — la fondation des consommables utiles (chantier 3 : ceinture/potions/nourriture), des sorts de soutien et des procs d'equipement.

## Changements

- **Nouveaux effets** `MaxHealthPercent` / `MoveSpeedPercent` (enum + parse JSON des kits — utilisables immediatement dans les sorts data-driven).
- **Agregation** `ApplyAuraStatModifiers` appliquee apres le bonus d'equipement dans le recalcul central ET dans `SendPlayerStats` — le kind 79 portait deja PV max et vitesses : **aucun bump kProtocolVersion**. PV courants clampes (pas de soin gratuit ; a l'expiration, re-clamp sous le max reduit).
- **Recalcul + push 79 au bon moment** : `UpsertAura` distingue AJOUT vs refresh (l'entretien 1 Hz des gateaux ne spamme pas) ; accroche aux 3 sites d'ajout joueur + a l'expiration (`TickAuras`).
- **Anti-cheat** : multiplicateur de vitesse legitime PAR JOUEUR (pose au recalcul) — un buff +8 % vitesse ne declenche pas de faux `SpeedHack`.
- **Client (fix important)** : les vitesses du kind 79 n'etaient **qu'affichees** dans la fiche — jamais appliquees au deplacement. Le CharacterController applique desormais chaque frame les vitesses **autoritaires du serveur** (classe + equipement + auras). Les bottes `speedRun +0.3` deviennent enfin reelles, elles aussi.
- **Gateaux** : le zephyr retrouve sa **vitesse** (+8 %), le sage donne **+8 % PV max**.

## Ordre de merge

**#994 (loot) d'abord**, puis celle-ci (la branche contient son commit).

## Validation

- CI : builds client + shard.
- En jeu : manger le gateau du zephyr → vitesse visiblement accrue (et pas de ForcePosition anti-cheat) ; gateau du sage → PV max +8 % dans la fiche ET la barre de vie ; retirer le gateau du slot → retour a la normale en ~3 s ; equiper les Bottes de marche → vitesse legerement accrue (nouveau).

**Deploiement** : ⚠️ **lock-step client + shard** (le client doit appliquer les vitesses ; le shard doit tolerer les vitesses buffees). Master non concerne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)