### PR TITLE
feat(game): ceinture d objets actifs + consommables utilisables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,6 +43,8 @@ if(WIN32)
     ${CMAKE_SOURCE_DIR}/src/shared/server_bootstrap/ServerApp.cpp
     # SP3 anniversaires (2026-07-18) : buffs de gateau (utilise par ServerApp).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/anniversary/CakeBuffLibrary.cpp
+    # Roadmap-3 (2026-07-19) : effets des consommables de ceinture.
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/items/ConsumableEffectLibrary.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/AdmittedCharacterRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/ShardPresenceService.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/chat/ChatCommandParser.cpp
@@ -1298,6 +1300,8 @@ elseif(UNIX)
     ${CMAKE_SOURCE_DIR}/src/shared/server_bootstrap/ServerApp.cpp
     # SP3 anniversaires (2026-07-18) : buffs de gateau (utilise par ServerApp).
     ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/anniversary/CakeBuffLibrary.cpp
+    # Roadmap-3 (2026-07-19) : effets des consommables de ceinture.
+    ${CMAKE_SOURCE_DIR}/src/shardd/gameplay/items/ConsumableEffectLibrary.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/UdpTransport.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/AdmittedCharacterRegistry.cpp
     ${CMAKE_SOURCE_DIR}/src/shardd/world/ShardPresenceService.cpp

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -12067,6 +12067,56 @@ namespace engine
 							}
 						}
 
+						// Roadmap-3 (2026-07-19) — CEINTURE : 4 slots d'objets
+						// ACTIFS à droite de la barre d'action (jetons
+						// "item:<id>" : gâteaux, potions…). Activation par
+						// Maj+1..4 ou clic sur la case ; le serveur applique
+						// l'effet (CastRequest avec le jeton).
+						{
+							const float beltSlot = 44.0f;
+							const float beltGap = 6.0f;
+							const float beltX = barX + barWidth + 24.0f;
+							const float beltY = dh - beltSlot - 16.0f;
+							const auto& beltLayout = uiModel.playerStats.beltLayout;
+							const bool shiftHeld = m_input.IsDown(engine::platform::Key::Shift);
+							for (size_t bi = 0; bi < beltLayout.size(); ++bi)
+							{
+								const float bx0 = beltX + static_cast<float>(bi) * (beltSlot + beltGap);
+								const std::string& beltTok = beltLayout[bi];
+								uint32_t beltItemId = 0u;
+								const bool occupied = engine::anniversary::ParseItemToken(beltTok, beltItemId);
+								fg->AddRectFilled(ImVec2(bx0, beltY), ImVec2(bx0 + beltSlot, beltY + beltSlot),
+									occupied ? IM_COL32(30, 44, 34, 220) : IM_COL32(14, 16, 22, 160), 6.0f);
+								fg->AddRect(ImVec2(bx0, beltY), ImVec2(bx0 + beltSlot, beltY + beltSlot),
+									IM_COL32(120, 170, 130, occupied ? 220 : 120), 6.0f, 0, 2.0f);
+								char beltKeyLabel[8];
+								std::snprintf(beltKeyLabel, sizeof(beltKeyLabel), "M%d", static_cast<int>(bi) + 1);
+								fg->AddText(ImVec2(bx0 + 3.0f, beltY + 2.0f),
+									IM_COL32(200, 230, 205, 200), beltKeyLabel);
+								if (!occupied)
+									continue;
+								const engine::items::ItemDefinition* bdef = m_itemCatalog.Find(beltItemId);
+								const char* blabel = (bdef != nullptr && !bdef->name.empty())
+									? bdef->name.c_str() : "Objet";
+								fg->AddText(ImVec2(bx0 + 3.0f, beltY + beltSlot * 0.5f - 6.0f),
+									IM_COL32(235, 245, 235, 255), blabel);
+								const bool beltKeyPressed = keysAllowed && shiftHeld
+									&& m_input.WasPressed(static_cast<engine::platform::Key>('1' + static_cast<int>(bi)));
+								const bool beltClicked =
+									m_input.WasMousePressed(engine::platform::MouseButton::Left)
+									&& m_input.MouseX() >= static_cast<int>(bx0)
+									&& m_input.MouseX() <= static_cast<int>(bx0 + beltSlot)
+									&& m_input.MouseY() >= static_cast<int>(beltY)
+									&& m_input.MouseY() <= static_cast<int>(beltY + beltSlot);
+								if (beltKeyPressed || beltClicked)
+								{
+									const uint32_t beltClientId = m_gameplayUdp.ServerClientId();
+									if (beltClientId != 0u)
+										(void)m_gameplayUdp.SendCastRequest(beltClientId, 0ull, beltTok);
+								}
+							}
+						}
+
 						// --- Barre de cast (au-dessus de la barre d'action) pilotée
 						// par CastBarUpdate ; progression calculée localement.
 						if (uiModel.castBar.active && uiModel.castBar.durationMs > 0u)
@@ -13035,12 +13085,27 @@ namespace engine
 					else if (equipAction.kind ==
 						engine::render::CharacterWindowImGuiRenderer::PendingEquipAction::Kind::Unequip)
 						(void)m_gameplayUdp.SendUnequipRequest(equipClientId, equipAction.slot);
-				// SP3 anniversaires (2026-07-18) — gâteau cliqué dans le sac :
-				// placé au slot 10 de la barre (jeton "item:<id>", envoi kind 88
-				// via le presenter Grimoire ; validation serveur : objet possédé).
+				// Roadmap-3 (2026-07-19) — consommable cliqué dans le sac :
+				// placé au 1er slot LIBRE de la CEINTURE (slot 1 remplacé si
+				// pleine). Envoi kind 99 ; le serveur valide la possession et
+				// renvoie le layout autoritaire (kind 100).
 				else if (equipAction.kind ==
 					engine::render::CharacterWindowImGuiRenderer::PendingEquipAction::Kind::SlotCake)
-					m_grimoireUi.AssignSlot(9u, engine::anniversary::MakeCakeToken(equipAction.itemId));
+				{
+					std::array<std::string, 4> belt = m_uiModelBinding.GetModel().playerStats.beltLayout;
+					const std::string beltToken = engine::anniversary::MakeItemToken(equipAction.itemId);
+					bool alreadySlotted = false;
+					for (const std::string& s : belt)
+						if (s == beltToken) { alreadySlotted = true; break; }
+					if (!alreadySlotted)
+					{
+						size_t target = 0;
+						for (size_t i = 0; i < belt.size(); ++i)
+							if (belt[i].empty()) { target = i; break; }
+						belt[target] = beltToken;
+						(void)m_gameplayUdp.SendSetBeltLayout(equipClientId, belt);
+					}
+				}
 				}
 			}
 			// CMANGOS.21 (Phase 5.21 step 3+4) — Render du panneau Arena si

--- a/src/client/net/GameplayUdpClient.cpp
+++ b/src/client/net/GameplayUdpClient.cpp
@@ -376,6 +376,24 @@ namespace engine::client
 		return ok;
 	}
 
+	bool GameplayUdpClient::SendSetBeltLayout(uint32_t clientId, const std::array<std::string, 4>& slots)
+	{
+		engine::server::SetBeltLayoutMessage msg{};
+		msg.clientId = clientId;
+		msg.slots = slots;
+		const std::vector<std::byte> packet = engine::server::EncodeSetBeltLayout(msg);
+		const bool ok = SendBytes(packet);
+		if (ok)
+		{
+			LOG_DEBUG(Net, "[GameplayUdpClient] SetBeltLayout sent (client_id={})", clientId);
+		}
+		else
+		{
+			LOG_WARN(Net, "[GameplayUdpClient] SetBeltLayout FAILED (client_id={})", clientId);
+		}
+		return ok;
+	}
+
 	bool GameplayUdpClient::SendChooseClassSkill(uint32_t clientId, uint32_t level, std::string_view skillId)
 	{
 		engine::server::ChooseClassSkillRequestMessage msg{};

--- a/src/client/net/GameplayUdpClient.h
+++ b/src/client/net/GameplayUdpClient.h
@@ -78,6 +78,11 @@ namespace engine::client
 		/// Le serveur valide (kit/unicité) et renvoie un ActionBarLayoutUpdate autoritaire.
 		bool SendSetActionBarLayout(uint32_t clientId, const std::array<std::string, 10>& slots);
 
+		/// Roadmap-3 (2026-07-19) — Ceinture : pose le layout des 4 slots
+		/// d'objets actifs (jetons "item:<id>", kind 99). ACK autoritaire
+		/// par BeltLayoutUpdate (kind 100).
+		bool SendSetBeltLayout(uint32_t clientId, const std::array<std::string, 4>& slots);
+
 		/// SP-B — envoie un choix de skill de classe (ChooseClassSkillRequest, kind 91).
 		/// Le shard valide (niveau, unicité, appartenance au kit) et renvoie un
 		/// ClassProgressionUpdate autoritaire si le choix est accepté.

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -423,9 +423,11 @@ namespace engine::render
 						ImGui::TextUnformatted(s.label.empty() ? "Objet" : s.label.c_str());
 						ImGui::EndDragDropSource();
 					}
-					// SP3 anniversaires (2026-07-18) — le gâteau se place dans la
-					// barre d'action d'un clic (geste volontaire du joueur).
-					const bool isCake = engine::anniversary::IsCakeItemId(s.itemId);
+					// Roadmap-3 (2026-07-19) — tout CONSOMMABLE (gâteau, potion,
+					// nourriture) se place dans la CEINTURE d'un clic (geste
+					// volontaire du joueur ; le serveur valide la possession).
+					const bool isCake = (def != nullptr)
+						&& def->type == engine::items::ItemType::Consumable;
 					if (ImGui::IsItemHovered() && !s.label.empty())
 					{
 						ImGui::BeginTooltip();
@@ -443,7 +445,7 @@ namespace engine::render
 							if (isCake)
 							{
 								ImGui::Separator();
-								ImGui::TextDisabled("Clic : placer dans la barre d'action (slot 10)");
+								ImGui::TextDisabled("Clic : placer dans la ceinture");
 							}
 						}
 						ImGui::EndTooltip();

--- a/src/client/ui_common/UIModel.cpp
+++ b/src/client/ui_common/UIModel.cpp
@@ -623,6 +623,19 @@ namespace engine::client
 			return ApplyCastBarUpdate(packet);
 		case engine::server::MessageKind::ActionBarLayoutUpdate:
 			return ApplyActionBarLayoutUpdate(packet);
+		// Roadmap-3 (2026-07-19) — ceinture (kind 100).
+		case engine::server::MessageKind::BeltLayoutUpdate:
+		{
+			engine::server::BeltLayoutUpdateMessage beltMsg{};
+			if (!engine::server::DecodeBeltLayoutUpdate(packet, beltMsg))
+			{
+				LOG_WARN(Net, "[UIModelBinding] BeltLayoutUpdate FAILED: decode error");
+				return false;
+			}
+			m_model.playerStats.beltLayout = beltMsg.slots;
+			LOG_INFO(Net, "[UIModelBinding] BeltLayoutUpdate applied (client_id={})", beltMsg.clientId);
+			return true;
+		}
 		// SP-B — progression par-classe (kind 90, shard → client).
 		case engine::server::MessageKind::ClassProgressionUpdate:
 			return ApplyClassProgressionUpdate(packet);

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -230,6 +230,9 @@ namespace engine::client
 		/// Grimoire — layout autoritaire des 10 slots (slot i → spellId, "" = vide),
 		/// reçu via ActionBarLayoutUpdate (enter-world / ACK serveur).
 		std::array<std::string, 10> actionBarLayout{};
+		/// Roadmap-3 (2026-07-19) — ceinture : 4 slots d'objets actifs
+		/// (jetons "item:<id>"), reçue via BeltLayoutUpdate (kind 100).
+		std::array<std::string, 4> beltLayout{};
 		/// PR-C — progression de niveau (barre d'XP), reçue via PlayerXpUpdate
 		/// (enter-world + chaque gain d'XP). \c xpForNextLevel = 0 signale le cap
 		/// de niveau. \c hasXp reste faux tant qu'aucun PlayerXpUpdate n'est reçu.

--- a/src/shardd/gameplay/character/CharacterPersistence.cpp
+++ b/src/shardd/gameplay/character/CharacterPersistence.cpp
@@ -202,6 +202,13 @@ namespace engine::server
 				persisted.GetString("actionbar.slot." + std::to_string(slotIndex), "");
 		}
 
+		// Roadmap-3 (2026-07-19) — ceinture (absent = "" = vide, rétro-compat).
+		for (size_t slotIndex = 0; slotIndex < outState.beltLayout.size(); ++slotIndex)
+		{
+			outState.beltLayout[slotIndex] =
+				persisted.GetString("belt.slot." + std::to_string(slotIndex), "");
+		}
+
 		// Anniversaires SP3 (2026-07-18) — expirations des gâteaux (clés
 		// bornées : 10 ids possibles, cf. CakeItemToken). Absent/0 = pas
 		// d'expiration enregistrée. Rétro-compatible : vieux fichiers sans
@@ -348,6 +355,12 @@ namespace engine::server
 		for (size_t slotIndex = 0; slotIndex < state.actionBarLayout.size(); ++slotIndex)
 		{
 			output << "actionbar.slot." << slotIndex << "=" << state.actionBarLayout[slotIndex] << "\n";
+		}
+
+		// Roadmap-3 (2026-07-19) — ceinture (4 slots, clés fixes).
+		for (size_t slotIndex = 0; slotIndex < state.beltLayout.size(); ++slotIndex)
+		{
+			output << "belt.slot." << slotIndex << "=" << state.beltLayout[slotIndex] << "\n";
 		}
 
 		// Anniversaires SP3 (2026-07-18) — expirations UTC (epoch ms) des

--- a/src/shardd/gameplay/character/CharacterPersistence.h
+++ b/src/shardd/gameplay/character/CharacterPersistence.h
@@ -50,6 +50,9 @@ namespace engine::server
 		std::vector<ProfessionEntry> professions;
 		/// Grimoire — 10 slots de barre d'action (slot i → spellId, "" = vide).
 		std::array<std::string, 10> actionBarLayout{};
+		/// Roadmap-3 (2026-07-19) — ceinture : 4 slots d'objets actifs
+		/// (jetons "item:<id>", "" = vide). Clés belt.slot.N.
+		std::array<std::string, 4> beltLayout{};
 		/// SP-B — compétences par-classe déjà choisies (un skill par tier/niveau débloqué).
 		std::vector<std::string> knownSkillIds;
 		/// Anniversaires SP3 (2026-07-18) — expirations UTC (epoch ms) des

--- a/src/shardd/gameplay/items/ConsumableEffectLibrary.cpp
+++ b/src/shardd/gameplay/items/ConsumableEffectLibrary.cpp
@@ -1,0 +1,24 @@
+// ConsumableEffectLibrary — implémentation. Voir le header.
+
+#include "src/shardd/gameplay/items/ConsumableEffectLibrary.h"
+
+namespace engine::server
+{
+	namespace
+	{
+		constexpr ConsumableEffectDef kConsumables[] = {
+			// 2002 Minor Potion — le grand classique : soin instantané 35 %.
+			{ 2002u, 35.0f, "", SpellEffectType::BuffDamagePercent, 0.0f, 0u,
+			  "Vous buvez la potion mineure : +35 % de PV." },
+		};
+	}
+
+	const ConsumableEffectDef* FindConsumableEffect(uint32_t itemId)
+	{
+		for (const ConsumableEffectDef& def : kConsumables)
+		{
+			if (def.itemId == itemId) return &def;
+		}
+		return nullptr;
+	}
+}

--- a/src/shardd/gameplay/items/ConsumableEffectLibrary.h
+++ b/src/shardd/gameplay/items/ConsumableEffectLibrary.h
@@ -1,0 +1,37 @@
+#pragma once
+// ConsumableEffectLibrary — table FIXE des effets des objets CONSOMMABLES
+// activables depuis la ceinture (Roadmap-3, 2026-07-19). Même philosophie
+// que CakeBuffLibrary : mapping en code (peu d'entrées, stables), le
+// catalogue items.json reste la source des noms/descriptions.
+//
+// V1 : deux familles d'effets — soin instantané (% PV max) et aura de buff
+// (réutilise les SpellEffectType, dont MaxHealthPercent/MoveSpeedPercent
+// livrés par Roadmap-2). Un objet consommé = pile décrémentée de 1.
+
+#include "src/shardd/gameplay/spell/SpellKitLibrary.h"
+
+#include <cstdint>
+
+namespace engine::server
+{
+	/// Effet d'un consommable de ceinture.
+	struct ConsumableEffectDef
+	{
+		uint32_t itemId = 0;
+		/// Soin instantané en % des PV max (0 = pas de soin).
+		float healPercentMaxHp = 0.0f;
+		/// Aura appliquée au buveur (durée auraDurationMs ; ignorée si
+		/// auraDurationMs == 0). spellId = identifiant d'aura répliqué (84).
+		const char* auraSpellId = "";
+		SpellEffectType auraType = SpellEffectType::BuffDamagePercent;
+		float auraPercent = 0.0f;
+		uint32_t auraDurationMs = 0;
+		/// Notice chat FR envoyée au buveur.
+		const char* noticeFr = "";
+	};
+
+	/// Retourne l'effet du consommable \p itemId, ou nullptr si cet objet
+	/// n'est pas un consommable activable (les gâteaux ont leur propre
+	/// chemin, cf. CakeBuffLibrary).
+	const ConsumableEffectDef* FindConsumableEffect(uint32_t itemId);
+}

--- a/src/shared/anniversary/CakeItemToken.h
+++ b/src/shared/anniversary/CakeItemToken.h
@@ -24,16 +24,25 @@ namespace engine::anniversary
 		return itemId >= kFirstCakeItemId && itemId < kFirstCakeItemId + kCakeVariantCount;
 	}
 
-	/// Jeton de slot pour \p itemId : "item:<itemId>".
-	inline std::string MakeCakeToken(uint32_t itemId)
+	/// Roadmap-3 (2026-07-19) — jeton de slot GÉNÉRIQUE pour tout objet :
+	/// "item:<itemId>" (ceinture : gâteaux, potions, nourriture…).
+	inline std::string MakeItemToken(uint32_t itemId)
 	{
 		return "item:" + std::to_string(itemId);
 	}
 
-	/// Parse un jeton de slot. \return true si \p token est "item:<id>" avec
-	/// <id> = gâteau valide (écrit dans \p outItemId). Tout autre contenu
-	/// (spellId, vide, id hors plage) retourne false.
-	inline bool ParseCakeToken(std::string_view token, uint32_t& outItemId)
+	/// Jeton de slot pour \p itemId : "item:<itemId>" (alias historique
+	/// gâteau — même format que MakeItemToken).
+	inline std::string MakeCakeToken(uint32_t itemId)
+	{
+		return MakeItemToken(itemId);
+	}
+
+	/// Roadmap-3 (2026-07-19) — Parse GÉNÉRIQUE d'un jeton "item:<id>" (tout
+	/// id d'objet > 0 : gâteaux, potions, nourriture…). \return true si le
+	/// format est strict (préfixe + chiffres) — l'appelant valide ensuite
+	/// l'existence/l'activabilité de l'objet (catalogue, possession).
+	inline bool ParseItemToken(std::string_view token, uint32_t& outItemId)
 	{
 		constexpr std::string_view kPrefix = "item:";
 		if (token.size() <= kPrefix.size() || token.compare(0, kPrefix.size(), kPrefix) != 0)
@@ -46,7 +55,17 @@ namespace engine::anniversary
 			value = value * 10u + static_cast<uint32_t>(c - '0');
 			if (value > 1000000u) return false; // garde anti-overflow
 		}
-		if (!IsCakeItemId(value)) return false;
+		if (value == 0u) return false;
+		outItemId = value;
+		return true;
+	}
+
+	/// Parse un jeton de slot GÂTEAU. \return true si \p token est
+	/// "item:<id>" avec <id> = gâteau valide (5101..5110).
+	inline bool ParseCakeToken(std::string_view token, uint32_t& outItemId)
+	{
+		uint32_t value = 0;
+		if (!ParseItemToken(token, value) || !IsCakeItemId(value)) return false;
 		outItemId = value;
 		return true;
 	}

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -818,6 +818,79 @@ namespace engine::server
 		return true;
 	}
 
+	// Roadmap-3 (2026-07-19) — Ceinture (kinds 99/100, miroir exact 88/89 :
+	// clientId u32 + 4 chaînes préfixées u16, jetons "item:<id>" bornés 64 o).
+
+	std::vector<std::byte> EncodeSetBeltLayout(const SetBeltLayoutMessage& message)
+	{
+		size_t hint = 4;
+		for (const std::string& slot : message.slots)
+		{
+			hint += 2 + slot.size();
+		}
+		std::vector<std::byte> packet = BeginPacket(MessageKind::SetBeltLayout, hint);
+		WriteU32(packet, message.clientId);
+		for (const std::string& slot : message.slots)
+		{
+			WriteSizedString(packet, slot);
+		}
+		return packet;
+	}
+
+	bool DecodeSetBeltLayout(std::span<const std::byte> packet, SetBeltLayoutMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::SetBeltLayout, payload) || payload.size() < 4)
+		{
+			return false;
+		}
+		outMessage.clientId = ReadU32(payload, 0);
+		size_t offset = 4;
+		for (std::string& slot : outMessage.slots)
+		{
+			if (!ReadSizedString(payload, offset, slot) || slot.size() > 64u)
+			{
+				return false;
+			}
+		}
+		return offset == payload.size();
+	}
+
+	std::vector<std::byte> EncodeBeltLayoutUpdate(const BeltLayoutUpdateMessage& message)
+	{
+		size_t hint = 4;
+		for (const std::string& slot : message.slots)
+		{
+			hint += 2 + slot.size();
+		}
+		std::vector<std::byte> packet = BeginPacket(MessageKind::BeltLayoutUpdate, hint);
+		WriteU32(packet, message.clientId);
+		for (const std::string& slot : message.slots)
+		{
+			WriteSizedString(packet, slot);
+		}
+		return packet;
+	}
+
+	bool DecodeBeltLayoutUpdate(std::span<const std::byte> packet, BeltLayoutUpdateMessage& outMessage)
+	{
+		std::span<const std::byte> payload;
+		if (!DecodeHeader(packet, MessageKind::BeltLayoutUpdate, payload) || payload.size() < 4)
+		{
+			return false;
+		}
+		outMessage.clientId = ReadU32(payload, 0);
+		size_t offset = 4;
+		for (std::string& slot : outMessage.slots)
+		{
+			if (!ReadSizedString(payload, offset, slot) || slot.size() > 64u)
+			{
+				return false;
+			}
+		}
+		return offset == payload.size();
+	}
+
 	std::vector<std::byte> EncodeClassProgressionUpdate(const ClassProgressionUpdateMessage& message)
 	{
 		// SP-B — payload : clientId (4) + classId (u16+str) + count (u16) + N skillIds (u16+str).

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -308,7 +308,12 @@ namespace engine::server
 		UnequipRequest = 97,
 		/// EquipmentUpdate (serveur→client) : snapshot complet de l'équipement porté
 		/// (liste des slots occupés → itemId). Idempotent, comme InventoryDelta.
-		EquipmentUpdate = 98
+		EquipmentUpdate = 98,
+		// Roadmap-3 (2026-07-19) — Ceinture : barre d'objets ACTIFS (4 slots,
+		// jetons "item:<id>" : gâteaux, potions, nourriture). Kinds ADDITIFS
+		// (pas de bump kProtocolVersion) sur le modèle 88/89.
+		SetBeltLayout = 99,     ///< Client → Shard : pose le layout ceinture.
+		BeltLayoutUpdate = 100  ///< Shard → Client : layout autoritaire (enter-world / ACK).
 	};
 
 	/// Initial client handshake sent before any other message.
@@ -474,6 +479,23 @@ namespace engine::server
 	{
 		uint32_t clientId = 0;
 		std::array<std::string, 10> slots{};
+	};
+
+	/// Roadmap-3 (2026-07-19) — Ceinture : 4 slots d'objets actifs (slot i →
+	/// jeton "item:<id>", "" = vide). Validée côté shard : objet POSSÉDÉ et
+	/// activable (consommable ou gâteau).
+	struct SetBeltLayoutMessage
+	{
+		uint32_t clientId = 0;
+		std::array<std::string, 4> slots{};
+	};
+
+	/// Roadmap-3 — layout ceinture autoritaire poussé par le shard
+	/// (enter-world / ACK de SetBeltLayout, même réconciliation que 89).
+	struct BeltLayoutUpdateMessage
+	{
+		uint32_t clientId = 0;
+		std::array<std::string, 4> slots{};
 	};
 
 	/// SP-B — shard → client : état autoritaire de progression de classe (classId + skills connus).
@@ -811,6 +833,11 @@ namespace engine::server
 	bool DecodeSetActionBarLayout(std::span<const std::byte> packet, SetActionBarLayoutMessage& outMessage);
 	std::vector<std::byte> EncodeActionBarLayoutUpdate(const ActionBarLayoutUpdateMessage& message);
 	bool DecodeActionBarLayoutUpdate(std::span<const std::byte> packet, ActionBarLayoutUpdateMessage& outMessage);
+	// Roadmap-3 (2026-07-19) — Ceinture (kinds 99/100, modèle 88/89).
+	std::vector<std::byte> EncodeSetBeltLayout(const SetBeltLayoutMessage& message);
+	bool DecodeSetBeltLayout(std::span<const std::byte> packet, SetBeltLayoutMessage& outMessage);
+	std::vector<std::byte> EncodeBeltLayoutUpdate(const BeltLayoutUpdateMessage& message);
+	bool DecodeBeltLayoutUpdate(std::span<const std::byte> packet, BeltLayoutUpdateMessage& outMessage);
 
 	/// SP-B — encode/decode de la progression de classe (shard→client, rétro-additif).
 	std::vector<std::byte> EncodeClassProgressionUpdate(const ClassProgressionUpdateMessage& message);

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1,6 +1,7 @@
 #include "src/shared/server_bootstrap/ServerApp.h"
 
 #include "src/shared/anniversary/CakeItemToken.h" // SP3 anniversaires (2026-07-18)
+#include "src/shardd/gameplay/items/ConsumableEffectLibrary.h" // Roadmap-3 (2026-07-19)
 #include "src/shared/core/Log.h"
 #include "src/shared/net/ChatEmotes.h"
 #include "src/shared/net/ChatSystem.h"
@@ -904,6 +905,14 @@ namespace engine::server
 			return;
 		}
 
+		// Roadmap-3 (2026-07-19) — Ceinture : réassignation des slots (kind 99).
+		SetBeltLayoutMessage setBelt{};
+		if (DecodeSetBeltLayout(packetBytes, setBelt))
+		{
+			HandleSetBeltLayout(datagram.endpoint, setBelt);
+			return;
+		}
+
 		// SP-B — choix d'une compétence par-classe (kind 91).
 		ChooseClassSkillRequestMessage chooseSkill{};
 		if (DecodeChooseClassSkillRequest(packetBytes, chooseSkill))
@@ -1432,6 +1441,8 @@ namespace engine::server
 		acceptedClient.professions = std::move(persistedState.professions);
 		/// Grimoire — restore action bar layout (10 slots).
 		acceptedClient.actionBarLayout = std::move(persistedState.actionBarLayout);
+		// Roadmap-3 (2026-07-19) — ceinture persistée.
+		acceptedClient.beltLayout = std::move(persistedState.beltLayout);
 		// Anniversaires SP3 (2026-07-18) — expirations des gâteaux possédés
 		// (la purge de minuit tourne dans TickCakeBuffs).
 		acceptedClient.cakeExpiresAtMsUtcByItemId = std::move(persistedState.cakeExpiresAtMsUtcByItemId);
@@ -1657,6 +1668,7 @@ namespace engine::server
 		(void)SendPlayerStats(acceptedClient);
 		(void)SendPlayerXpUpdate(acceptedClient); // PR-C — sync initial barre d'XP
 		(void)SendActionBarLayout(acceptedClient); // Grimoire — layout persisté (ou vide)
+		(void)SendBeltLayout(acceptedClient); // Roadmap-3 — ceinture persistée (ou vide)
 		(void)SendClassProgression(acceptedClient); // SP-B — progression par-classe persistée (ou vide)
 		SendDynamicEventBootstrap(acceptedClient);
 		SendQuestStateBootstrap(acceptedClient);
@@ -2243,6 +2255,8 @@ namespace engine::server
 		state.professions = client.professions;
 		/// Grimoire — persist action bar layout.
 		state.actionBarLayout = client.actionBarLayout;
+		/// Roadmap-3 — persist la ceinture (4 slots d'objets actifs).
+		state.beltLayout = client.beltLayout;
 		/// Anniversaires SP3 — persist les expirations des gâteaux possédés.
 		state.cakeExpiresAtMsUtcByItemId = client.cakeExpiresAtMsUtcByItemId;
 		/// SP-B — persist known class skills.
@@ -4558,14 +4572,17 @@ namespace engine::server
 			return;
 		}
 
-		// ── Anniversaires SP3 (2026-07-18) : activation d'un gâteau slotté ──
-		// AVANT les chemins de sorts : le jeton "item:<id>" n'est pas un
-		// spellId et ne requiert aucun profil de classe.
+		// ── Activation d'un OBJET (jeton "item:<id>") — AVANT les chemins de
+		// sorts (pas un spellId, aucun profil de classe requis). Gâteaux
+		// (anniversaires SP3) et consommables de ceinture (Roadmap-3).
 		{
-			uint32_t cakeItemId = 0u;
-			if (engine::anniversary::ParseCakeToken(message.spellId, cakeItemId))
+			uint32_t tokenItemId = 0u;
+			if (engine::anniversary::ParseItemToken(message.spellId, tokenItemId))
 			{
-				HandleCakeActivation(*client, cakeItemId);
+				if (engine::anniversary::IsCakeItemId(tokenItemId))
+					HandleCakeActivation(*client, tokenItemId);
+				else
+					HandleConsumableUse(*client, tokenItemId);
 				return;
 			}
 		}
@@ -4880,6 +4897,149 @@ namespace engine::server
 		SaveConnectedClient(*client, "actionbar_change");
 		(void)SendActionBarLayout(*client); // ACK autoritaire (layout validé)
 		LOG_INFO(Net, "[ServerApp] SetActionBarLayout applied (client_id={})", client->clientId);
+	}
+
+	void ServerApp::HandleSetBeltLayout(const Endpoint& endpoint, const SetBeltLayoutMessage& message)
+	{
+		ConnectedClient* client = FindClient(endpoint);
+		if (client == nullptr)
+		{
+			LOG_WARN(Net, "[ServerApp] SetBeltLayout ignored from unknown endpoint {}",
+				UdpTransport::EndpointToString(endpoint));
+			return;
+		}
+		if (client->clientId != message.clientId)
+		{
+			LOG_WARN(Net, "[ServerApp] SetBeltLayout ignored: client_id mismatch (expected={}, got={})",
+				client->clientId, message.clientId);
+			return;
+		}
+
+		// Validation autoritaire : chaque slot non vide = jeton "item:<id>"
+		// d'un objet POSSÉDÉ et ACTIVABLE (gâteau ou consommable connu),
+		// unicité par slot. Rejet = renvoi de l'état inchangé (kind 100).
+		std::array<std::string, 4> validated{};
+		for (size_t slotIndex = 0; slotIndex < message.slots.size(); ++slotIndex)
+		{
+			const std::string& token = message.slots[slotIndex];
+			if (token.empty())
+			{
+				continue;
+			}
+			uint32_t itemId = 0u;
+			if (!engine::anniversary::ParseItemToken(token, itemId)
+				|| (!engine::anniversary::IsCakeItemId(itemId)
+					&& FindConsumableEffect(itemId) == nullptr))
+			{
+				LOG_WARN(Net, "[ServerApp] SetBeltLayout reject: jeton '{}' non activable (client_id={})",
+					token, client->clientId);
+				(void)SendBeltLayout(*client);
+				return;
+			}
+			bool owned = false;
+			for (const ItemStack& s : client->inventory)
+			{
+				if (s.itemId == itemId && s.quantity > 0u) { owned = true; break; }
+			}
+			if (!owned)
+			{
+				LOG_WARN(Net, "[ServerApp] SetBeltLayout reject: objet {} non possede (client_id={})",
+					itemId, client->clientId);
+				(void)SendBeltLayout(*client);
+				return;
+			}
+			for (size_t prior = 0; prior < slotIndex; ++prior)
+			{
+				if (validated[prior] == token)
+				{
+					(void)SendBeltLayout(*client);
+					return;
+				}
+			}
+			validated[slotIndex] = token;
+		}
+
+		client->beltLayout = validated;
+		SaveConnectedClient(*client, "belt_change");
+		(void)SendBeltLayout(*client); // ACK autoritaire
+		LOG_INFO(Net, "[ServerApp] SetBeltLayout applied (client_id={})", client->clientId);
+	}
+
+	bool ServerApp::SendBeltLayout(const ConnectedClient& client)
+	{
+		BeltLayoutUpdateMessage msg{};
+		msg.clientId = client.clientId;
+		msg.slots = client.beltLayout;
+		return m_transport.Send(client.endpoint, EncodeBeltLayoutUpdate(msg));
+	}
+
+	void ServerApp::HandleConsumableUse(ConnectedClient& client, uint32_t itemId)
+	{
+		const ConsumableEffectDef* def = FindConsumableEffect(itemId);
+		if (def == nullptr) return;
+		// Slotté en ceinture (les consommables ne s'activent QUE depuis la
+		// ceinture — geste volontaire, cf. règle gâteau).
+		const std::string token = engine::anniversary::MakeItemToken(itemId);
+		bool slotted = false;
+		for (const std::string& slot : client.beltLayout)
+			if (slot == token) { slotted = true; break; }
+		if (!slotted)
+		{
+			SendChatSystemNotice(client, "Placez d'abord cet objet dans votre ceinture.");
+			return;
+		}
+		std::string invErr;
+		if (!RemoveStackFromInventory(client, itemId, 1u, invErr))
+		{
+			SendChatSystemNotice(client, "Vous ne possédez plus cet objet.");
+			return;
+		}
+
+		// Effet : soin instantané (% PV max) et/ou aura de buff.
+		if (def->healPercentMaxHp > 0.0f)
+		{
+			const uint32_t healAmount = static_cast<uint32_t>(std::llround(
+				static_cast<double>(client.stats.maxHealth)
+				* static_cast<double>(def->healPercentMaxHp) / 100.0));
+			client.stats.currentHealth = std::min(
+				client.stats.maxHealth, client.stats.currentHealth + healAmount);
+		}
+		if (def->auraDurationMs > 0u)
+		{
+			ActiveAura aura;
+			aura.spellId = def->auraSpellId;
+			aura.type = def->auraType;
+			aura.percent = def->auraPercent;
+			aura.expiresAtMs = NowMonotonicMs() + def->auraDurationMs;
+			aura.casterEntityId = client.entityId;
+			if (UpsertAura(client.auras, std::move(aura)))
+			{
+				RefreshLiveDerivedStats(client);
+				(void)SendPlayerStats(client);
+			}
+			BroadcastAuraUpdate(client.entityId, client.auras);
+		}
+
+		// Pile épuisée : vider les slots de ceinture portant ce jeton.
+		bool stillOwned = false;
+		for (const ItemStack& s : client.inventory)
+			if (s.itemId == itemId && s.quantity > 0u) { stillOwned = true; break; }
+		bool beltChanged = false;
+		if (!stillOwned)
+		{
+			for (std::string& slot : client.beltLayout)
+				if (slot == token) { slot.clear(); beltChanged = true; }
+		}
+
+		SaveConnectedClient(client, "consumable_use");
+		(void)SendInventoryDelta(client,
+			std::span<const ItemStack>(client.inventory.data(), client.inventory.size()));
+		if (beltChanged)
+			(void)SendBeltLayout(client);
+		if (def->noticeFr[0] != '\0')
+			SendChatSystemNotice(client, def->noticeFr);
+		LOG_INFO(Net, "[ServerApp] Consommable utilise (client_id={}, item_id={})",
+			client.clientId, itemId);
 	}
 
 	bool ServerApp::SendClassProgression(const ConnectedClient& client)
@@ -5702,12 +5862,16 @@ namespace engine::server
 		const CakeBuffDef* def = FindCakeBuff(cakeItemId);
 		if (def == nullptr) return;
 		const std::string token = engine::anniversary::MakeCakeToken(cakeItemId);
+		// Roadmap-3 (2026-07-19) — le gâteau s'active depuis la barre d'action
+		// OU la ceinture (nouvelle barre d'objets actifs).
 		bool slotted = false;
 		for (const std::string& slot : client.actionBarLayout)
 			if (slot == token) { slotted = true; break; }
+		for (const std::string& slot : client.beltLayout)
+			if (slot == token) { slotted = true; break; }
 		if (!slotted)
 		{
-			SendChatSystemNotice(client, "Placez d'abord le gâteau dans votre barre d'action.");
+			SendChatSystemNotice(client, "Placez d'abord le gâteau dans votre ceinture (ou barre d'action).");
 			return;
 		}
 		bool owned = false;
@@ -5769,10 +5933,18 @@ namespace engine::server
 				{
 					if (slot == token) { slot.clear(); layoutChanged = true; }
 				}
+				// Roadmap-3 — vide aussi les slots de ceinture du gâteau mangé.
+				bool beltChanged = false;
+				for (std::string& slot : client.beltLayout)
+				{
+					if (slot == token) { slot.clear(); beltChanged = true; }
+				}
 				if (client.activeCakeItemId == cakeItemId)
 					client.activeCakeItemId = 0u;
 				if (layoutChanged)
 					(void)SendActionBarLayout(client);
+				if (beltChanged)
+					(void)SendBeltLayout(client);
 				SendChatSystemNotice(client,
 					"Le gâteau d'anniversaire a été mangé — la fête est finie pour cette année !");
 				it = client.cakeExpiresAtMsUtcByItemId.erase(it);
@@ -5789,8 +5961,11 @@ namespace engine::server
 				continue;
 			const CakeBuffDef* def = FindCakeBuff(client.activeCakeItemId);
 			const std::string activeToken = engine::anniversary::MakeCakeToken(client.activeCakeItemId);
+			// Roadmap-3 — slotté = barre d'action OU ceinture.
 			bool slotted = false;
 			for (const std::string& slot : client.actionBarLayout)
+				if (slot == activeToken) { slotted = true; break; }
+			for (const std::string& slot : client.beltLayout)
 				if (slot == activeToken) { slotted = true; break; }
 			bool owned = false;
 			for (const ItemStack& s : client.inventory)

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -161,6 +161,11 @@ namespace engine::server
 		uint64_t lastForcePositionSentMs = 0;
 		/// Combat SP3 — auras actives (buffs, HoT, debuffs subis).
 		std::vector<ActiveAura> auras;
+		/// Roadmap-3 (2026-07-19) — Ceinture : 4 slots d'objets ACTIFS
+		/// (jetons "item:<id>" : gâteaux, potions, nourriture ; "" = vide).
+		/// Autoritaire (validée par HandleSetBeltLayout : objet possédé et
+		/// activable) et persistée (belt.slot.N).
+		std::array<std::string, 4> beltLayout{};
 		/// Anniversaires SP3 (2026-07-18) — gâteau ACTIF (0 = aucun). Posé par
 		/// un CastRequest "item:<id>" ; le buff est entretenu par TickCakeBuffs
 		/// tant que le gâteau reste slotté ET possédé ; NON persisté (à
@@ -601,6 +606,21 @@ namespace engine::server
 		/// (proba dropChancePct + quantité uniforme [minCount,maxCount]).
 		/// \return true si l'entrée droppe (\p outItem rempli).
 		bool RollLootEntry(const LootTableEntry& entry, ItemStack& outItem);
+
+		/// Roadmap-3 (2026-07-19) — Ceinture : validation autoritaire du
+		/// layout (kind 99) — chaque jeton "item:<id>" doit référencer un
+		/// objet POSSÉDÉ et ACTIVABLE (consommable du catalogue ou gâteau),
+		/// unicité par slot ; rejet = renvoi de l'état inchangé (kind 100).
+		void HandleSetBeltLayout(const Endpoint& endpoint, const SetBeltLayoutMessage& message);
+
+		/// Roadmap-3 — pousse le layout ceinture autoritaire (kind 100).
+		bool SendBeltLayout(const ConnectedClient& client);
+
+		/// Roadmap-3 — consomme un objet activable NON-gâteau de la ceinture
+		/// (ex. potion 2002) : vérifie slotté + possédé, applique l'effet
+		/// (ConsumableEffectLibrary), décrémente la pile (slot vidé si
+		/// épuisée), resynchronise inventaire + ceinture + notice.
+		void HandleConsumableUse(ConnectedClient& client, uint32_t itemId);
 
 		/// Chantier 2 SP-A — somme des StatBonus de tout l'équipement porté (résolus
 		/// via m_itemCatalog). Additionnée aux DerivedStats avant émission (anti-triche).


### PR DESCRIPTION
## Objectif (roadmap 2026-07-19, chantier 3)

La **ceinture** demandee : une nouvelle barre de 4 slots dediee aux objets ACTIFS (gateaux d'anniversaire, potions, nourriture), a droite de la barre d'action. La **Minor Potion devient enfin buvable** — et comme elle droppe deja sur les mobs (#994), la boucle complete existe : tuer → looter la potion → la mettre en ceinture → la boire en combat.

## Fonctionnement

1. Clic sur un consommable du sac → il se place au premier slot libre de la ceinture.
2. Activation par **Maj+1..4** ou clic sur la case.
3. Le serveur valide tout (possession, objet activable) et applique l'effet : soin instantane (%PV max) et/ou aura de buff (profite des effets reels de #995). Pile decrementee ; slot vide quand epuisee.
4. Le gateau d'anniversaire s'active desormais depuis la ceinture OU la barre d'action ; la purge de minuit nettoie aussi la ceinture.
5. Layout persiste (retro-compatible) et resynchronise a l'enter-world.

## Wire

Kinds UDP **additifs** SetBeltLayout=99 / BeltLayoutUpdate=100 (miroir exact de 88/89) — **pas de bump kProtocolVersion**, mais deploiement **lock-step client + shard** (les deux doivent connaitre les kinds et le jeton generalise).

## Validation

- CI : builds client + shard.
- En jeu : looter une Minor Potion → clic dans le sac → apparait en ceinture → Maj+1 → notice « +35 % de PV » + PV remontent + pile -1 ; vider la pile → slot se vide ; relog → ceinture conservee ; gateau depuis la ceinture → buff de groupe comme avant.

**Deploiement** : ⚠️ **lock-step client + shard**. Master non concerne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)