### PR TITLE
feat(server): scheduler de jobs periodiques master + purge des courriers

### DIFF
--- a/src/masterd/jobs/MasterJobScheduler.h
+++ b/src/masterd/jobs/MasterJobScheduler.h
@@ -1,0 +1,84 @@
+#pragma once
+// MasterJobScheduler — registre MINIMAL de jobs périodiques du master
+// (Roadmap-4, 2026-07-19). Remplace les blocs « if (now - last >= interval) »
+// écrits à la main dans la boucle principale : un job = un nom + un
+// intervalle + un callable. Header-only, mono-thread (la boucle principale
+// appelle Tick() ; les jobs longs gèrent eux-mêmes leur asynchronisme, ex.
+// BirthdayEmailJob envoie le SMTP sur un thread détaché).
+//
+// Journalisation : liste des jobs au boot (LogRegistered), LOG_DEBUG à
+// chaque exécution avec la durée — un job qui dérape se voit dans les logs.
+// Premier passage : chaque job s'exécute dès le premier Tick() (utile pour
+// les jobs « rattrapage au boot » comme l'e-mail d'anniversaire).
+
+#include "src/shared/core/Log.h"
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::server
+{
+	class MasterJobScheduler
+	{
+	public:
+		using JobFn = std::function<void()>;
+
+		/// Enregistre un job périodique. \param name identifiant de log
+		/// (snake_case). \param interval période minimale entre deux
+		/// exécutions. \param fn exécuté sur le thread de la boucle
+		/// principale — doit rester court (déléguer le lent à un thread).
+		void Register(std::string name, std::chrono::seconds interval, JobFn fn)
+		{
+			m_jobs.push_back(Job{ std::move(name), interval,
+				std::chrono::steady_clock::time_point{}, std::move(fn) });
+		}
+
+		/// Journalise la liste des jobs enregistrés (appeler une fois au boot).
+		void LogRegistered() const
+		{
+			for (const Job& job : m_jobs)
+			{
+				LOG_INFO(Net, "[MasterJobScheduler] job '{}' (période {} s)",
+					job.name, static_cast<long long>(job.interval.count()));
+			}
+		}
+
+		/// Exécute les jobs dus (appelé à chaque itération de la boucle
+		/// principale ; la cadence effective est bornée par les intervalles).
+		/// Effets de bord : ceux des jobs + logs de durée.
+		void Tick()
+		{
+			const auto now = std::chrono::steady_clock::now();
+			for (Job& job : m_jobs)
+			{
+				if (job.lastRun != std::chrono::steady_clock::time_point{}
+					&& now - job.lastRun < job.interval)
+				{
+					continue;
+				}
+				job.lastRun = now;
+				const auto t0 = std::chrono::steady_clock::now();
+				job.fn();
+				const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::steady_clock::now() - t0).count();
+				LOG_DEBUG(Net, "[MasterJobScheduler] job '{}' exécuté en {} ms",
+					job.name, static_cast<long long>(ms));
+			}
+		}
+
+		size_t Size() const { return m_jobs.size(); }
+
+	private:
+		struct Job
+		{
+			std::string name;
+			std::chrono::seconds interval{ 0 };
+			std::chrono::steady_clock::time_point lastRun{};
+			JobFn fn;
+		};
+		std::vector<Job> m_jobs;
+	};
+}

--- a/src/masterd/mail/MysqlMailStore.cpp
+++ b/src/masterd/mail/MysqlMailStore.cpp
@@ -64,6 +64,44 @@ namespace engine::server::mail
 		return m_pool && m_pool->IsInitialized();
 	}
 
+	size_t MysqlMailStore::PurgeExpired(uint64_t nowMs)
+	{
+		if (!IsAvailable()) return 0;
+		auto guard = m_pool->Acquire();
+		MYSQL* mysql = guard.get();
+		auto* cache = guard.cache();
+		if (!mysql || !cache) return 0;
+
+		engine::server::db::ScopedTransaction tx(mysql);
+
+		// 1. Pièces jointes des courriers à purger (pas de FK ON DELETE
+		// CASCADE sur mail_items — migration 0045).
+		auto* itemsStmt = cache->Acquire(mysql,
+			"DELETE mi FROM mail_items mi JOIN mail m ON m.mail_id = mi.mail_id "
+			"WHERE (m.expires_ts_ms > 0 AND m.expires_ts_ms < ?) OR m.state = 3");
+		if (!itemsStmt || !itemsStmt->Bind(0, nowMs) || !itemsStmt->Execute())
+		{
+			LOG_WARN(Net, "[MysqlMailStore] PurgeExpired: delete mail_items failed");
+			return 0;
+		}
+
+		// 2. Les courriers eux-mêmes.
+		auto* mailStmt = cache->Acquire(mysql,
+			"DELETE FROM mail WHERE (expires_ts_ms > 0 AND expires_ts_ms < ?) OR state = 3");
+		if (!mailStmt || !mailStmt->Bind(0, nowMs) || !mailStmt->Execute())
+		{
+			LOG_WARN(Net, "[MysqlMailStore] PurgeExpired: delete mail failed");
+			return 0;
+		}
+		const size_t purged = static_cast<size_t>(mailStmt->AffectedRows());
+		tx.Commit();
+		if (purged > 0)
+		{
+			LOG_INFO(Net, "[MysqlMailStore] PurgeExpired: {} courrier(s) purgé(s)", purged);
+		}
+		return purged;
+	}
+
 	uint64_t MysqlMailStore::Insert(Mail& out)
 	{
 		if (!IsAvailable()) return 0;

--- a/src/masterd/mail/MysqlMailStore.h
+++ b/src/masterd/mail/MysqlMailStore.h
@@ -20,6 +20,13 @@ namespace engine::server::mail
 		/// avec ce store ou avec un InMemoryMailStore (mode no-DB / tests).
 		bool IsAvailable() const noexcept;
 
+		/// Roadmap-4 (2026-07-19) — purge les courriers EXPIRÉS
+		/// (expires_ts_ms > 0 et < \p nowMs — l'expiration vaut disparition,
+		/// pièces jointes comprises) et les courriers SUPPRIMÉS par leur
+		/// destinataire (state=Deleted). mail_items d'abord (pas de FK
+		/// cascade), puis mail. \return nombre de courriers supprimés.
+		size_t PurgeExpired(uint64_t nowMs);
+
 		uint64_t Insert(Mail& out) override;
 		std::optional<Mail> Find(uint64_t mailId) const override;
 		std::vector<Mail> ListInbox(uint64_t receiverAccountId) const override;

--- a/src/masterd/main_linux.cpp
+++ b/src/masterd/main_linux.cpp
@@ -39,6 +39,7 @@
 #include "src/masterd/handlers/character/CharacterEnterWorldHandler.h"
 #include "src/masterd/anniversary/AnniversaryService.h"
 #include "src/masterd/anniversary/BirthdayEmailJob.h"
+#include "src/masterd/jobs/MasterJobScheduler.h" // Roadmap-4 (2026-07-19)
 #include "src/masterd/exploits/MysqlExploitStore.h"
 #include "src/masterd/handlers/exploits/ExploitHandler.h"
 #include "src/masterd/handlers/dungeon/EnterDungeonHandler.h"
@@ -560,6 +561,26 @@ int main(int argc, char** argv)
 	// boucle principale ; garde annuelle kind='birthday_email' (0074).
 	engine::server::BirthdayEmailJob birthdayEmailJob;
 	birthdayEmailJob.SetDependencies(&dbPool, &exploitStore, &smtpConfig);
+
+	// Roadmap-4 (2026-07-19) — registre des jobs périodiques du master.
+	// Chaque futur job (relances, résumés…) s'enregistre ici au lieu
+	// d'ajouter un bloc « if (now - last >= interval) » à la boucle.
+	engine::server::MasterJobScheduler jobScheduler;
+	// E-mail d'anniversaire : réévalue l'heure LOCALE des comptes fêtés
+	// (envoi dès 7 h chez le joueur) ; interne 1x/jour par compte (garde).
+	jobScheduler.Register("birthday_email", std::chrono::minutes(10),
+		[&birthdayEmailJob] { birthdayEmailJob.Tick(); });
+	// Purge des courriers expirés et supprimés (pièces jointes comprises —
+	// l'expiration vaut disparition). No-op propre en mode no-DB.
+	jobScheduler.Register("mail_purge", std::chrono::hours(1),
+		[&mailStoreDb]
+		{
+			const uint64_t nowMs = static_cast<uint64_t>(
+				std::chrono::duration_cast<std::chrono::milliseconds>(
+					std::chrono::system_clock::now().time_since_epoch()).count());
+			(void)mailStoreDb.PurgeExpired(nowMs);
+		});
+	jobScheduler.LogRegistered();
 	mailHandler.SetSessionManager(&sessionManager);
 	mailHandler.SetConnectionSessionMap(&connSessionMap);
 	LOG_INFO(Net, "[ServerMain] MailHandler configured (CMANGOS.18 step 3)");
@@ -1814,23 +1835,17 @@ int main(int argc, char** argv)
 	auto lastLunarTickTime = std::chrono::steady_clock::now();
 	constexpr auto kLunarTickInterval = std::chrono::seconds(300);
 
-	// Anniversaires (extension e-mail) — vérification périodique du jour UTC :
-	// le job ne travaille réellement qu'une fois par jour (boot + rollover).
-	auto lastBirthdayEmailTick = std::chrono::steady_clock::time_point{};
-	constexpr auto kBirthdayEmailTickInterval = std::chrono::minutes(10);
+	// Roadmap-4 (2026-07-19) — les jobs périodiques (e-mail d'anniversaire,
+	// purge des courriers…) sont désormais cadencés par jobScheduler.Tick()
+	// dans la boucle ci-dessous.
 
 	while (server.IsRunning() && g_quit == 0)
 	{
 		std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
 		auto now = std::chrono::steady_clock::now();
-		// Anniversaires (extension e-mail) — tick 10 min : réévalue l'heure
-		// LOCALE de chaque compte fêté (envoi dès 7 h chez le joueur).
-		if (now - lastBirthdayEmailTick >= kBirthdayEmailTickInterval)
-		{
-			lastBirthdayEmailTick = now;
-			birthdayEmailJob.Tick();
-		}
+		// Roadmap-4 (2026-07-19) — jobs périodiques (intervalles internes).
+		jobScheduler.Tick();
 		if (now - lastSummaryLog >= kSummaryInterval)
 		{
 			lastSummaryLog = now;


### PR DESCRIPTION
## Objectif (roadmap 2026-07-19, chantier 4)

Un **registre de jobs periodiques** pour le master : chaque futur job (relances, resumes quotidiens…) s'enregistre en une ligne au lieu d'ajouter un bloc d'horlogerie artisanal a la boucle principale.

## Contenu

- **MasterJobScheduler** (header-only) : nom + intervalle + callable ; `Tick()` dans la boucle principale ; liste des jobs au boot ; duree de chaque execution loggee (un job qui derape se voit).
- **BirthdayEmailJob migre** sur le registre (10 min — comportement strictement identique, envoi a 7 h locales inchange).
- **Nouveau job `mail_purge`** (1 h) : `MysqlMailStore::PurgeExpired` supprime les courriers **expires** (l'expiration vaut disparition, pieces jointes comprises) et **supprimes** par leur destinataire (state=3) — les lignes ne s'accumulent plus indefiniment. Deux DELETE en transaction (mail_items n'a pas de FK cascade). No-op propre en mode no-DB.

## Validation

- CI : build Linux (master).
- Logs au boot : `[MasterJobScheduler] job 'birthday_email' (période 600 s)` + `job 'mail_purge' (période 3600 s)` ; apres 1 h avec un courrier expire en base : `[MysqlMailStore] PurgeExpired: N courrier(s) purgé(s)`.

**Deploiement** : ⚠️ **redeploiement serveur MASTER requis**. Shard et client non concernes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)