### PR TITLE
feat(game): boite marchable - sols d etage et escaliers praticables

### DIFF
--- a/game/data/collision/building_pieces.json
+++ b/game/data/collision/building_pieces.json
@@ -104,6 +104,50 @@
       "box_0": { "cx": -0.75, "cy": 1.55, "cz": -0.10, "hx": 0.25, "hy": 1.57, "hz": 0.18 },
       "box_1": { "cx":  0.75, "cy": 1.55, "cz": -0.10, "hx": 0.25, "hy": 1.57, "hz": 0.18 },
       "box_2": { "cx":  0.0,  "cy": 2.70, "cz": -0.10, "hx": 1.0,  "hy": 0.42, "hz": 0.18 }
+    },
+
+    "_comment_walkable": "Roadmap-5 (2026-07-19) — SOLS et ESCALIERS a dessus MARCHABLE (walkable=true -> PropBox.walkableTop, capuchon superieur du sweep). Bounds MESUREES dans les .gltf (accessor POSITION min/max). Dalles de sol : 2x2 m, epaisseur 2 cm. Escalier interieur : rampe approximee en 8 boites-marches pleines (montee 3,93 m sur 4,56 m — marches ~0.49 m, gravies via stair/maxClimb).",
+    "floor_brick": {
+      "walkable": true,
+      "box_count": 1,
+      "box_0": { "cx": 0.0, "cy": 0.0, "cz": 0.0, "hx": 1.0, "hy": 0.01, "hz": 1.0 }
+    },
+    "floor_redbrick": {
+      "walkable": true,
+      "box_count": 1,
+      "box_0": { "cx": 0.0, "cy": 0.0, "cz": 0.0, "hx": 1.0, "hy": 0.01, "hz": 1.0 }
+    },
+    "floor_unevenbrick": {
+      "walkable": true,
+      "box_count": 1,
+      "box_0": { "cx": 0.0, "cy": 0.0, "cz": 0.0, "hx": 1.0, "hy": 0.01, "hz": 1.0 }
+    },
+    "floor_wooddark": {
+      "walkable": true,
+      "box_count": 1,
+      "box_0": { "cx": 0.0, "cy": 0.0, "cz": 0.0, "hx": 1.0, "hy": 0.01, "hz": 1.0 }
+    },
+    "floor_woodlight": {
+      "walkable": true,
+      "box_count": 1,
+      "box_0": { "cx": 0.0, "cy": 0.0, "cz": 0.0, "hx": 1.0, "hy": 0.01, "hz": 1.0 }
+    },
+    "stair_interior_rails": {
+      "walkable": true,
+      "box_count": 8,
+      "box_0": { "cx": 0.0, "cy": 0.257, "cz": -0.041, "hx": 0.858, "hy": 0.257, "hz": 0.285 },
+      "box_1": { "cx": 0.0, "cy": 0.503, "cz": -0.611, "hx": 0.858, "hy": 0.503, "hz": 0.285 },
+      "box_2": { "cx": 0.0, "cy": 0.748, "cz": -1.182, "hx": 0.858, "hy": 0.748, "hz": 0.285 },
+      "box_3": { "cx": 0.0, "cy": 0.994, "cz": -1.752, "hx": 0.858, "hy": 0.994, "hz": 0.285 },
+      "box_4": { "cx": 0.0, "cy": 1.240, "cz": -2.322, "hx": 0.858, "hy": 1.240, "hz": 0.285 },
+      "box_5": { "cx": 0.0, "cy": 1.485, "cz": -2.893, "hx": 0.858, "hy": 1.485, "hz": 0.285 },
+      "box_6": { "cx": 0.0, "cy": 1.731, "cz": -3.463, "hx": 0.858, "hy": 1.731, "hz": 0.285 },
+      "box_7": { "cx": 0.0, "cy": 1.977, "cz": -4.034, "hx": 0.858, "hy": 1.977, "hz": 0.285 }
+    },
+    "stairs_exterior_platform": {
+      "walkable": true,
+      "box_count": 1,
+      "box_0": { "cx": 0.0, "cy": 0.885, "cz": 0.0, "hx": 0.813, "hy": 0.103, "hz": 1.0 }
     }
   }
 }

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -15180,7 +15180,12 @@ namespace engine
 						box.axisX = (sX > 1e-6f) ? engine::math::Vec3{ colX.x/sX, 0.0f, colX.z/sX } : engine::math::Vec3{ 1, 0, 0 };
 						box.axisZ = (sZ > 1e-6f) ? engine::math::Vec3{ colZ.x/sZ, 0.0f, colZ.z/sZ } : engine::math::Vec3{ 0, 0, 1 };
 						box.loY = wy - lb.hy * sY; box.hiY = wy + lb.hy * sY;
-						box.stair = isStair; box.wall = !isStair;
+						box.stair = isStair;
+						// Roadmap-5 (2026-07-19) — dessus marchable pour les
+						// sols (tag JSON "walkable") et les marches d'escalier ;
+						// les murs restent des barrières latérales pures.
+						box.walkableTop = piece->walkable || isStair;
+						box.wall = !box.walkableTop;
 						m_worldCollider.AddBox(box);
 					}
 				}

--- a/src/client/gameplay/CompositeWorldCollider.cpp
+++ b/src/client/gameplay/CompositeWorldCollider.cpp
@@ -146,6 +146,41 @@ namespace engine::gameplay
 		{
 			if (b.passable) continue;
 
+			// --- 3a) Capuchon supérieur (Roadmap-5, 2026-07-19) : dessus
+			// MARCHABLE (sols d'étage, marches d'escalier). Même mécanique que
+			// le capuchon cylindre 2a : quand le bas de la capsule descend à
+			// travers hiY au-dessus de l'empreinte du rectangle, on pose le
+			// perso (normale verticale → IsWalkable). JAMAIS actif sur les
+			// murs (walkableTop=false) — la sonde anti-encastrement du
+			// contrôleur accrocherait leur sommet (« vol contre le mur »).
+			if (b.walkableTop)
+			{
+				const float bottomStart = startCenter.y - halfH - capsule.radius;
+				const float bottomEnd   = endCenter.y   - halfH - capsule.radius;
+				const float denom = bottomStart - bottomEnd; // > 0 si la capsule descend
+				if (denom > 1e-6f)
+				{
+					const float tc = (bottomStart - b.hiY) / denom; // bas de capsule == hiY
+					if (tc >= 0.0f && tc <= 1.0f && tc < best.fraction)
+					{
+						// Point d'impact XZ projeté dans le repère du rectangle
+						// (empreinte élargie du rayon de capsule, comme le flanc).
+						const float pxw = sx + tc * dx - b.cx;
+						const float pzw = sz + tc * dz - b.cz;
+						const float pu = pxw * b.axisX.x + pzw * b.axisX.z;
+						const float pv = pxw * b.axisZ.x + pzw * b.axisZ.z;
+						if (std::fabs(pu) <= b.halfX + capsule.radius
+							&& std::fabs(pv) <= b.halfZ + capsule.radius)
+						{
+							best.hit = true;
+							best.fraction = tc;
+							best.normal = engine::math::Vec3{ 0.0f, 1.0f, 0.0f };
+							best.stair = b.stair;
+						}
+					}
+				}
+			}
+
 			// Recouvrement vertical (identique aux cylindres).
 			const float capLo = endCenter.y - halfH - capsule.radius;
 			const float capHi = endCenter.y + halfH + capsule.radius;

--- a/src/client/gameplay/CompositeWorldCollider.cpp
+++ b/src/client/gameplay/CompositeWorldCollider.cpp
@@ -181,6 +181,20 @@ namespace engine::gameplay
 				}
 			}
 
+			// Le flanc ne concerne QUE le déplacement HORIZONTAL (même garde
+			// que le flanc des cylindres, bloc 2) : un sweep purement vertical
+			// (chute/pose) est l'affaire du capuchon 3a — sans cette garde, le
+			// slab-test ci-dessous rend tEnter=0 dès que le départ est dans
+			// l'empreinte XZ et écrase la pose avec une normale horizontale.
+			if (dx * dx + dz * dz < 1e-8f) continue;
+
+			// Dessus marchable : une capsule qui DÉMARRE au-dessus du dessus
+			// (à la peau près) ne peut pas heurter le flanc — sinon on serait
+			// bloqué latéralement en marchant sur la dalle ou en atterrissant
+			// dessus avec un déplacement diagonal.
+			if (b.walkableTop && startCenter.y - halfH - capsule.radius >= b.hiY - kStandSkin)
+				continue;
+
 			// Recouvrement vertical (identique aux cylindres).
 			const float capLo = endCenter.y - halfH - capsule.radius;
 			const float capHi = endCenter.y + halfH + capsule.radius;

--- a/src/client/gameplay/CompositeWorldCollider.h
+++ b/src/client/gameplay/CompositeWorldCollider.h
@@ -50,6 +50,11 @@ namespace engine::gameplay
 		bool passable = false; ///< aucune collision (battant de porte)
 		bool stair = false;    ///< gravissable (cf. CharacterController)
 		bool wall = true;      ///< barrière latérale pure, pas de dessus marchable
+		/// Roadmap-5 (2026-07-19) — dessus MARCHABLE (capuchon supérieur,
+		/// cf. bloc 3a du sweep) : sols d'étage et marches d'escalier. Ne
+		/// JAMAIS l'activer sur un mur (wall) — la sonde anti-encastrement
+		/// accrocherait son sommet (bug « vol contre le mur », #919/#920).
+		bool walkableTop = false;
 	};
 
 	/// Collisionneur composite : combine un IWorldCollider de terrain (sol + eau) et

--- a/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
+++ b/src/client/gameplay/tests/CompositeWorldColliderTests.cpp
@@ -253,6 +253,58 @@ int main()
 		check(hj && onJamb.hit, "porte: on bute un jambage (hit)");
 	}
 
+	// === Roadmap-5 (2026-07-19) : dessus MARCHABLE des boîtes (capuchon 3a) ===
+	// Dalle de sol 2x2 m à y ∈ [1.0, 1.05], centrée (5,0).
+	auto makeFloor = []() {
+		PropBox b;
+		b.cx = 5.0f; b.cz = 0.0f; b.halfX = 1.0f; b.halfZ = 1.0f;
+		b.axisX = Vec3{ 1, 0, 0 }; b.axisZ = Vec3{ 0, 0, 1 };
+		b.loY = 1.0f; b.hiY = 1.05f;
+		b.wall = false; b.walkableTop = true;
+		return b;
+	};
+
+	// B7) Descente au-dessus de la dalle : le bas de capsule (centre - 1.2)
+	//     traverse hiY=1.05 -> pose (normale verticale). Départ centre y=3
+	//     (bas 1.8), arrivée y=1.5 (bas 0.3) : tc = (1.8-1.05)/1.5 = 0.5.
+	{
+		CompositeWorldCollider c(&terrain); c.AddBox(makeFloor());
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 5, 3, 0 }, Vec3{ 5, 1.5f, 0 }, hit);
+		check(h && hit.hit, "sol: descente -> pose sur le dessus");
+		check(hit.normal.y > 0.9f, "sol: normale verticale (walkable)");
+		check(hit.fraction > 0.45f && hit.fraction < 0.55f, "sol: fraction plausible");
+	}
+
+	// B8) Même descente sur une boîte MUR (walkableTop=false) : PAS de pose
+	//     (les murs restent des barrières latérales pures — anti « vol »).
+	{
+		PropBox wallBox = makeFloor();
+		wallBox.wall = true; wallBox.walkableTop = false;
+		CompositeWorldCollider c(&terrain); c.AddBox(wallBox);
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 5, 3, 0 }, Vec3{ 5, 1.5f, 0 }, hit);
+		check(!h, "mur: pas de capuchon superieur (pas de pose)");
+	}
+
+	// B9) Descente HORS de l'empreinte (x=8, au-delà de halfX+r) : pas de pose.
+	{
+		CompositeWorldCollider c(&terrain); c.AddBox(makeFloor());
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 8, 3, 0 }, Vec3{ 8, 1.5f, 0 }, hit);
+		check(!h, "sol: hors empreinte -> pas de pose");
+	}
+
+	// B10) Marche d'escalier (stair=true) : le flag stair se propage au hit
+	//      du capuchon (TryStepUp montera via maxClimb).
+	{
+		PropBox step = makeFloor(); step.stair = true;
+		CompositeWorldCollider c(&terrain); c.AddBox(step);
+		IWorldCollider::SweepHit hit;
+		bool h = c.SweepCapsule(cap, Vec3{ 5, 3, 0 }, Vec3{ 5, 1.5f, 0 }, hit);
+		check(h && hit.stair, "marche: flag stair propage par le capuchon");
+	}
+
 	// 5) QueryWater délégué au terrain.
 	{
 		CompositeWorldCollider c(&terrain);

--- a/src/client/world/BuildingCollisionCatalog.cpp
+++ b/src/client/world/BuildingCollisionCatalog.cpp
@@ -47,6 +47,8 @@ namespace engine::world
 
 		Piece p;
 		p.passable = passable;
+		// Roadmap-5 (2026-07-19) — dessus marchable (sols, plateformes).
+		p.walkable = m_cfg.GetBool(base + "walkable", false);
 		for (int i = 0; i < count; ++i)
 		{
 			const std::string b = base + "box_" + std::to_string(i) + ".";

--- a/src/client/world/BuildingCollisionCatalog.h
+++ b/src/client/world/BuildingCollisionCatalog.h
@@ -22,7 +22,9 @@ namespace engine::world
 		struct LocalBox { float cx, cy, cz, hx, hy, hz; };
 
 		/// Résultat de Lookup pour une pièce présente au catalogue.
-		struct Piece { bool passable = false; std::vector<LocalBox> boxes; };
+		/// Roadmap-5 (2026-07-19) — walkable=true : le DESSUS des boîtes est
+		/// marchable (sols d'étage, plateformes ; clé JSON "walkable").
+		struct Piece { bool passable = false; bool walkable = false; std::vector<LocalBox> boxes; };
 
 		/// Charge le catalogue depuis le texte JSON. \return false si parse invalide.
 		bool LoadFromJson(const std::string& jsonText);


### PR DESCRIPTION
## Objectif (roadmap 2026-07-19, chantier 5)

Regler la dette #921 : **marcher SUR les choses**. Les boites de collision des batiments (PropBox) etaient laterales-seules — sols d'etage infranchissables, escaliers impossibles a monter.

## Changements

- **Capuchon superieur des boites** (nouveau bloc 3a du sweep, meme mecanique que le capuchon cylindre existant) : la capsule qui descend au-dessus de l'empreinte du rectangle oriente se POSE dessus (normale verticale → walkable). Gate par le nouveau flag `PropBox::walkableTop` — **jamais actif sur les murs** (le bug historique « vol contre le mur » #919/#920 reste verrouille, test dedie).
- **Sols enfin catalogues** : 5 variantes `Floor_*` (bounds **mesurees** dans les .gltf — dalle 2×2 m, epaisseur 2 cm), `Stairs_Exterior_Platform`, et `Stair_Interior_Rails` approxime en **8 boites-marches pleines** (montee 3,93 m — gravies marche par marche via le flag `stair` + `maxClimb` du TryStepUp existant).
- Nouvelle cle JSON `walkable` par piece (parser etendu) ; Engine propage `walkableTop = walkable || isStair`.
- **Tests** B7-B10 (pose sur dalle, pas de pose sur mur, hors empreinte, propagation stair) — ctest.

## Validation

- CI : build client + ctest (composite_world_collider_tests).
- En jeu : entrer dans la taverne → monter l'escalier interieur marche par marche → marcher sur le plancher de l'etage sans tomber a travers ; longer un mur → toujours bloque lateralement, pas de teleportation au sommet.

**Deploiement** : ✅ client uniquement (+ data), pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)