### PR TITLE
feat(editor): gizmo viewport scene + multi-selection + placement undoable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1516,6 +1516,28 @@ if(MSVC)
 endif()
 add_test(NAME entity_edit_commands_tests COMMAND entity_edit_commands_tests)
 
+# Roadmap-6 (2026-07-19) — Tests CPU pour CompositeCommand (undo groupe des
+# gestes multi-selection : ordre Execute/Undo, integration CommandStack).
+# Pur CPU, non gate WIN32 (execute aussi par le ctest de build-linux).
+add_executable(composite_command_tests src/world_editor/tests/CompositeCommandTests.cpp)
+target_include_directories(composite_command_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(composite_command_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(composite_command_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME composite_command_tests COMMAND composite_command_tests)
+
+# Roadmap-6 (2026-07-19) — Tests CPU pour PlaceLayoutInstanceCommand /
+# MoveLayoutInstanceCommand (placement undoable, foncteurs mock par guid).
+# Pur CPU, non gate WIN32.
+add_executable(layout_placement_commands_tests src/world_editor/tests/LayoutPlacementCommandsTests.cpp)
+target_include_directories(layout_placement_commands_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(layout_placement_commands_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(layout_placement_commands_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME layout_placement_commands_tests COMMAND layout_placement_commands_tests)
+
 # Sous-projet 1, bloc H — Tests CPU pour Config::SaveToFile (round-trip JSON
 # plat des 4 types scalaires + echappement). Pur CPU + E/S, non gate WIN32.
 add_executable(config_save_to_file_tests src/world_editor/tests/ConfigSaveToFileTests.cpp)

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -10,6 +10,9 @@
 #include "src/world_editor/ui/WorldEditorSession.h"
 #include "src/world_editor/ui/WorldMapIo.h" // lot B3 : SanitizeZoneId (namespacing zone)
 #include "src/world_editor/core/WorldEditorShell.h"
+#include "src/world_editor/core/CompositeCommand.h"            // Roadmap-6 : undo groupé du gizmo
+#include "src/world_editor/inspector/SetEntityTransformCommand.h" // Roadmap-6 : undo du drag de gizmo
+#include "src/world_editor/scene/LayoutPlacementCommands.h"    // Roadmap-6 : placement undoable
 #include "src/world_editor/panels/ScenePanel.h"
 #include "src/shared/core/memory/Memory.h"
 #include "src/shared/platform/FileSystem.h"
@@ -8100,6 +8103,18 @@ namespace engine
 				{
 					m_worldEditorShell->HandleShortcut(0x2E, false, false);
 				}
+				// Roadmap-6 (2026-07-19) — E / T / C : mode du gizmo de scène
+				// (dÉplacer / Tourner / éChelle). Sans modifiers, hors saisie
+				// de texte (garde imguiTextInput ci-dessus).
+				if (!ctrl && !shift)
+				{
+					if (m_input.WasPressed(engine::platform::Key::E))
+						m_worldEditorShell->HandleShortcut('E', false, false);
+					if (m_input.WasPressed(engine::platform::Key::T))
+						m_worldEditorShell->HandleShortcut('T', false, false);
+					if (m_input.WasPressed(engine::platform::Key::C))
+						m_worldEditorShell->HandleShortcut('C', false, false);
+				}
 			}
 		}
 
@@ -9568,6 +9583,9 @@ namespace engine
 			// Gizmo (axes/anneaux X=rouge/Y=vert/Z=bleu) sur la pièce active,
 			// en overlay sur la 3D (sous les panneaux). Visuel seul pour l'instant.
 			DrawEditorBuildingGizmo();
+			// Roadmap-6 — gizmo des entités de scène sélectionnées (E/T/C) +
+			// marqueurs de multi-sélection. No-op en mode édition bâtiment.
+			DrawEditorSceneGizmo();
 		}
 #endif
 
@@ -10832,11 +10850,26 @@ namespace engine
 				}
 			}
 
+			// Roadmap-6 (2026-07-19) — gizmo de scène : cliquer-glisser sur les
+			// handles (axes / anneau yaw / poignée d'échelle) de la sélection.
+			// Hors mode bâtiment (le gizmo bâtiment garde la main) et sans Ctrl
+			// (Ctrl = picking d'entité ci-dessous). S'il capture la souris, le
+			// clic ne doit alimenter NI le picking NI les outils terrain.
+			bool sceneGizmoGrabbed = false;
+			if (!buildingEditMode && m_worldEditorShell && m_worldEditorShell->IsInitialized()
+				&& !m_worldEditorImGui->WantsCaptureMouse()
+				&& !m_input.IsDown(engine::platform::Key::Control))
+			{
+				sceneGizmoGrabbed = UpdateEditorSceneGizmoDrag(m_input.MouseX(), m_input.MouseY());
+			}
+
 			// Sous-projet 1, bloc B3 — picking d'entite : Ctrl+clic gauche dans la
 			// vue 3D (hors ImGui) selectionne l'entite dont la position (XZ) est la
 			// plus proche du point de sol cliqué (seuil ~3 m), via EditorSceneModel
 			// + EditorSelection. Geste Ctrl+clic distinct du clic d'edition
 			// (sculpt/placement) pour ne pas interferer avec les deux systemes.
+			// Roadmap-6 : Ctrl+Maj+clic BASCULE l'entité dans la multi-sélection ;
+			// Ctrl+clic dans le vide vide la sélection.
 			if (terrainPick && m_worldEditorShell && m_worldEditorShell->IsInitialized()
 				&& !m_worldEditorImGui->WantsCaptureMouse()
 				&& m_input.IsDown(engine::platform::Key::Control)
@@ -10854,14 +10887,24 @@ namespace engine
 					const float d2 = dx * dx + dz * dz;
 					if (d2 < bestDist2) { bestDist2 = d2; best = &e; }
 				}
+				const bool shiftHeld = m_input.IsDown(engine::platform::Key::Shift);
 				if (best != nullptr)
 				{
-					m_worldEditorShell->MutableSelection().Select(best->id);
-					LOG_INFO(EditorWorld, "[WorldEditor] Entite selectionnee (Ctrl+clic): {}", best->label);
+					if (shiftHeld)
+						m_worldEditorShell->MutableSelection().Toggle(best->id);
+					else
+						m_worldEditorShell->MutableSelection().Select(best->id);
+					LOG_INFO(EditorWorld, "[WorldEditor] Entite selectionnee (Ctrl+clic{}): {} ({} au total)",
+						shiftHeld ? "+Maj" : "", best->label,
+						m_worldEditorShell->GetSelection().Count());
+				}
+				else if (!shiftHeld)
+				{
+					m_worldEditorShell->MutableSelection().Clear();
 				}
 			}
 
-			if (!modernEditActive && !buildingEditMode && m_terrain.IsValid() && m_worldEditorSession && terrainPick && m_vkDeviceContext.IsValid())
+			if (!modernEditActive && !buildingEditMode && !sceneGizmoGrabbed && m_terrain.IsValid() && m_worldEditorSession && terrainPick && m_vkDeviceContext.IsValid())
 			{
 				const bool cap = m_worldEditorImGui->WantsCaptureMouse();
 				engine::editor::WorldEditorSession& ws = *m_worldEditorSession;
@@ -10882,8 +10925,57 @@ namespace engine
 					if (TryTerrainWorldY(hm, overlay.terrainOriginX, overlay.terrainOriginZ, overlay.terrainWorldSize, overlay.heightScale,
 							pickX, pickZ, wy))
 					{
-						ws.PlaceOrMoveLayoutInstanceAtTerrainHit(m_cfg, static_cast<double>(pickX), static_cast<double>(wy),
-							static_cast<double>(pickZ));
+						// Roadmap-6 (2026-07-19) — placement/déplacement UNDOABLE :
+						// le clic passe par des commandes sur la pile du shell
+						// (adressage par guid stable). Fallback direct historique
+						// si le shell n'est pas initialisé (pas de pile undo).
+						if (m_worldEditorShell && m_worldEditorShell->IsInitialized())
+						{
+							// Foncteurs capturant [this] : l'Engine survit aux
+							// commandes dans la pile undo (même pattern Lot 5).
+							engine::editor::scene::LayoutPlacementOps ops;
+							ops.add = [this](const engine::editor::WorldMapEditLayoutInstance& inst) -> bool
+							{
+								return m_worldEditorSession ? m_worldEditorSession->AddLayoutInstance(inst) : false;
+							};
+							ops.removeByGuid = [this](const std::string& guid) -> bool
+							{
+								return m_worldEditorSession ? m_worldEditorSession->RemoveLayoutInstanceByGuid(guid) : false;
+							};
+							ops.setPositionByGuid = [this](const std::string& guid, double x, double y, double z) -> bool
+							{
+								return m_worldEditorSession
+									? m_worldEditorSession->SetLayoutInstancePositionByGuid(guid, x, y, z) : false;
+							};
+							const int selIdx = ws.SelectedLayoutInstanceIndex();
+							if (selIdx >= 0 && selIdx < static_cast<int>(ws.Doc().layoutInstances.size()))
+							{
+								const engine::editor::WorldMapEditLayoutInstance& inst =
+									ws.Doc().layoutInstances[static_cast<size_t>(selIdx)];
+								m_worldEditorShell->MutableCommandStack().Push(
+									std::make_unique<engine::editor::scene::MoveLayoutInstanceCommand>(
+										inst.guid, inst.worldX, inst.worldY, inst.worldZ,
+										static_cast<double>(pickX), static_cast<double>(wy), static_cast<double>(pickZ),
+										ops));
+								ws.Status() = "Instance deplacee.";
+							}
+							else
+							{
+								engine::editor::WorldMapEditLayoutInstance inst{};
+								if (ws.BuildLayoutInstanceForPlacement(m_cfg, static_cast<double>(pickX),
+										static_cast<double>(wy), static_cast<double>(pickZ), inst))
+								{
+									m_worldEditorShell->MutableCommandStack().Push(
+										std::make_unique<engine::editor::scene::PlaceLayoutInstanceCommand>(
+											std::move(inst), ops));
+								}
+							}
+						}
+						else
+						{
+							ws.PlaceOrMoveLayoutInstanceAtTerrainHit(m_cfg, static_cast<double>(pickX), static_cast<double>(wy),
+								static_cast<double>(pickZ));
+						}
 					}
 				}
 				else if (m_worldEditorTerrainTools.IsValid() && !cap && m_input.IsMouseDown(engine::platform::MouseButton::Left)
@@ -14889,6 +14981,378 @@ namespace engine
 			if (wasDragging) { panel->MarkPreviewDirty(); return true; }
 		}
 		return m_gizmoDragAxis >= 0;
+#else
+		(void)mouseX; (void)mouseY; return false;
+#endif
+	}
+
+	void Engine::SceneGizmoHandleSizes(const engine::math::Vec3& pos, float& axisLen, float& ringR) const
+	{
+		const uint32_t readIdx = m_renderReadIndex.load(std::memory_order_acquire);
+		const engine::render::Camera& cam = m_renderStates[readIdx].camera;
+		const float dx = cam.position.x - pos.x;
+		const float dy = cam.position.y - pos.y;
+		const float dz = cam.position.z - pos.z;
+		const float dist = std::sqrt(dx*dx + dy*dy + dz*dz);
+		// ~constant à l'écran : longueur d'axe proportionnelle à la distance
+		// (mêmes coefficients que le gizmo bâtiment, cf. GizmoHandleSizes).
+		axisLen = std::clamp(dist * 0.09f, 0.5f, 10.0f);
+		ringR   = axisLen * 0.8f;
+	}
+
+	void Engine::DrawEditorSceneGizmo()
+	{
+#if defined(_WIN32)
+		if (!m_editorEnabled || !m_worldEditorShell || !m_worldEditorShell->IsInitialized()) return;
+		// Le gizmo bâtiment garde la main en mode édition bâtiment (deux gizmos
+		// superposés seraient illisibles et se disputeraient les clics).
+		if (engine::editor::world::panels::BuildingEditorPanel* bp =
+			m_worldEditorShell->GetBuildingEditorPanel(); bp && bp->EditModeActive()) return;
+		const engine::editor::scene::EditorSelection& sel = m_worldEditorShell->GetSelection();
+		if (!sel.HasSelection()) return;
+		const engine::editor::scene::EditorSceneModel& model = m_worldEditorShell->GetSceneModel();
+		const engine::editor::scene::SceneEntity* primary = model.Find(sel.Current());
+		if (primary == nullptr || !primary->hasTransform) return;
+
+		const uint32_t readIdx = m_renderReadIndex.load(std::memory_order_acquire);
+		const engine::math::Mat4& vp = m_renderStates[readIdx].viewProjMatrix;
+		const ImGuiIO& io = ImGui::GetIO();
+		const float W = io.DisplaySize.x, H = io.DisplaySize.y;
+		if (W <= 0.0f || H <= 0.0f) return;
+
+		// Projection monde -> écran (pixels) via la viewProj courante (même
+		// convention que le gizmo bâtiment : viewProj col-major, pas de Y-flip).
+		auto project = [&](const engine::math::Vec3& w, ImVec2& out) -> bool {
+			const float* M = vp.m;
+			const float cx = M[0]*w.x + M[4]*w.y + M[8]*w.z  + M[12];
+			const float cy = M[1]*w.x + M[5]*w.y + M[9]*w.z  + M[13];
+			const float cw = M[3]*w.x + M[7]*w.y + M[11]*w.z + M[15];
+			if (cw <= 1e-4f) return false; // derrière la caméra
+			out.x = (cx / cw * 0.5f + 0.5f) * W;
+			out.y = (cy / cw * 0.5f + 0.5f) * H;
+			return true;
+		};
+
+		ImDrawList* dl = ImGui::GetBackgroundDrawList();
+
+		// Marqueurs de multi-sélection : un anneau magenta par entité (double
+		// épaisseur sur la primaire) pour VOIR ce qui sera affecté par le geste.
+		const ImU32 colSel = IM_COL32(230, 80, 230, 220);
+		for (const engine::editor::scene::EntityId& id : sel.Items())
+		{
+			const engine::editor::scene::SceneEntity* e = model.Find(id);
+			if (e == nullptr || !e->hasTransform) continue;
+			ImVec2 p;
+			if (project(e->transform.position, p))
+				dl->AddCircle(p, (id == sel.Current()) ? 11.0f : 7.0f, colSel, 24,
+					(id == sel.Current()) ? 3.0f : 1.5f);
+		}
+
+		const engine::math::Vec3 o = primary->transform.position;
+		ImVec2 so;
+		if (!project(o, so)) return;
+
+		float axisLen, ringR; SceneGizmoHandleSizes(o, axisLen, ringR);
+		const ImU32 colX = IM_COL32(235, 70, 70, 255);  // X rouge
+		const ImU32 colY = IM_COL32(70, 210, 70, 255);  // Y vert
+		const ImU32 colZ = IM_COL32(80, 130, 255, 255); // Z bleu
+		const ImU32 hot  = IM_COL32(255, 240, 130, 255);// survol/actif : jaune vif
+		const ImU32 cols[3] = { colX, colY, colZ };
+		const engine::math::Vec3 dirs[3] = { {1,0,0}, {0,1,0}, {0,0,1} };
+		const int mode = static_cast<int>(m_worldEditorShell->GetSceneGizmoMode());
+		const bool dragging = (m_sceneGizmoDragAxis >= 0);
+
+		if (mode == 0) // Translation : 3 axes monde
+		{
+			auto distToSeg = [](const ImVec2& p, const ImVec2& a, const ImVec2& b) -> float {
+				const float vx=b.x-a.x, vy=b.y-a.y, wx=p.x-a.x, wy=p.y-a.y;
+				const float len2=vx*vx+vy*vy; float t=(len2>1e-6f)?(wx*vx+wy*vy)/len2:0.0f;
+				t=std::clamp(t,0.0f,1.0f); const float cx=a.x+t*vx, cy=a.y+t*vy;
+				return std::sqrt((p.x-cx)*(p.x-cx)+(p.y-cy)*(p.y-cy));
+			};
+			int hovAxis = dragging ? m_sceneGizmoDragAxis : -1;
+			for (int a = 0; a < 3; ++a)
+			{
+				const engine::math::Vec3 tip{ o.x + dirs[a].x*axisLen, o.y + dirs[a].y*axisLen, o.z + dirs[a].z*axisLen };
+				ImVec2 se;
+				if (!project(tip, se)) continue;
+				if (!dragging)
+				{
+					const float sl = std::sqrt((se.x-so.x)*(se.x-so.x) + (se.y-so.y)*(se.y-so.y));
+					if (sl > 12.0f && distToSeg(io.MousePos, so, se) < 9.0f) hovAxis = a;
+				}
+				const bool axHot = (hovAxis == a);
+				dl->AddLine(so, se, axHot ? hot : cols[a], axHot ? 5.0f : 3.0f);
+				dl->AddCircleFilled(se, axHot ? 7.0f : 5.0f, axHot ? hot : cols[a]);
+			}
+		}
+		else if (mode == 1) // Rotation yaw : un anneau autour de Y
+		{
+			ImVec2 rp;
+			const engine::math::Vec3 rw{ o.x + ringR, o.y, o.z };
+			if (project(rw, rp))
+			{
+				const float rad = std::sqrt((rp.x-so.x)*(rp.x-so.x) + (rp.y-so.y)*(rp.y-so.y));
+				if (rad > 3.0f && rad < 4000.0f)
+				{
+					bool ringHot = dragging;
+					if (!dragging)
+					{
+						const float dm = std::sqrt((io.MousePos.x-so.x)*(io.MousePos.x-so.x)
+							+ (io.MousePos.y-so.y)*(io.MousePos.y-so.y));
+						ringHot = std::abs(dm - rad) < 9.0f;
+					}
+					dl->AddCircle(so, rad, ringHot ? hot : colY, 48, ringHot ? 4.0f : 2.5f);
+				}
+			}
+		}
+		else // Échelle uniforme : poignée carrée au centre (drag vertical)
+		{
+			bool sqHot = dragging;
+			if (!dragging)
+			{
+				sqHot = std::abs(io.MousePos.x - so.x) < 14.0f && std::abs(io.MousePos.y - so.y) < 14.0f;
+			}
+			dl->AddRectFilled(ImVec2(so.x - 9.0f, so.y - 9.0f), ImVec2(so.x + 9.0f, so.y + 9.0f),
+				sqHot ? hot : IM_COL32(210, 210, 210, 255), 2.0f);
+		}
+		dl->AddCircleFilled(so, 4.0f, IM_COL32(255, 255, 255, 255)); // centre
+
+		// Lecteur de valeurs : transform de l'entité primaire + taille de la
+		// sélection (le drag n'affiche pas ses valeurs autrement).
+		{
+			char l1[112], l2[112];
+			std::snprintf(l1, sizeof(l1), "Pos  X %.2f  Y %.2f  Z %.2f  (m)",
+				primary->transform.position.x, primary->transform.position.y, primary->transform.position.z);
+			std::snprintf(l2, sizeof(l2), "Yaw  %.0f deg   Echelle  %.2f   (%d selectionnee(s))",
+				primary->transform.eulerDeg.y, primary->transform.uniformScale,
+				static_cast<int>(sel.Count()));
+			const ImVec2 p1{ so.x + 14.0f, so.y + 10.0f };
+			const ImVec2 p2{ so.x + 14.0f, so.y + 26.0f };
+			dl->AddRectFilled(ImVec2(p1.x - 4.0f, p1.y - 2.0f), ImVec2(p1.x + 290.0f, p2.y + 16.0f),
+				IM_COL32(0, 0, 0, 150), 3.0f);
+			const ImU32 white = IM_COL32(235, 235, 235, 255);
+			const ImU32 hotTxt = IM_COL32(255, 230, 90, 255);
+			dl->AddText(p1, (dragging && m_sceneGizmoDragMode == 0) ? hotTxt : white, l1);
+			dl->AddText(p2, (dragging && m_sceneGizmoDragMode != 0) ? hotTxt : white, l2);
+		}
+#endif
+	}
+
+	bool Engine::UpdateEditorSceneGizmoDrag(int mouseX, int mouseY)
+	{
+#if defined(_WIN32)
+		if (!m_editorEnabled || !m_worldEditorShell || !m_worldEditorShell->IsInitialized()) return false;
+		if (engine::editor::world::panels::BuildingEditorPanel* bp =
+			m_worldEditorShell->GetBuildingEditorPanel(); bp && bp->EditModeActive())
+		{
+			m_sceneGizmoDragAxis = -1;
+			return false;
+		}
+		const engine::editor::scene::EditorSelection& sel = m_worldEditorShell->GetSelection();
+		const engine::editor::scene::EditorSceneModel& model = m_worldEditorShell->GetSceneModel();
+		const engine::editor::scene::SceneEntity* primary =
+			sel.HasSelection() ? model.Find(sel.Current()) : nullptr;
+		if (primary == nullptr || !primary->hasTransform)
+		{
+			m_sceneGizmoDragAxis = -1;
+			return false;
+		}
+		const engine::editor::world::WorldEditorShell::TransformWriter& writer =
+			m_worldEditorShell->GetTransformWriter();
+		if (!writer) return false;
+
+		const uint32_t readIdx = m_renderReadIndex.load(std::memory_order_acquire);
+		const engine::math::Mat4& vp = m_renderStates[readIdx].viewProjMatrix;
+		const ImGuiIO& io = ImGui::GetIO();
+		const float W = io.DisplaySize.x, H = io.DisplaySize.y;
+		if (W <= 0.0f || H <= 0.0f) return false;
+
+		auto project = [&](const engine::math::Vec3& w, float& sx, float& sy) -> bool {
+			const float* M = vp.m;
+			const float cx = M[0]*w.x + M[4]*w.y + M[8]*w.z  + M[12];
+			const float cy = M[1]*w.x + M[5]*w.y + M[9]*w.z  + M[13];
+			const float cw = M[3]*w.x + M[7]*w.y + M[11]*w.z + M[15];
+			if (cw <= 1e-4f) return false;
+			sx = (cx / cw * 0.5f + 0.5f) * W;
+			sy = (cy / cw * 0.5f + 0.5f) * H;
+			return true;
+		};
+
+		const engine::math::Vec3 o = primary->transform.position;
+		float ox, oy;
+		if (!project(o, ox, oy)) { m_sceneGizmoDragAxis = -1; return false; }
+		float axisLen, ringR; SceneGizmoHandleSizes(o, axisLen, ringR);
+		const engine::math::Vec3 dirs[3] = { {1,0,0}, {0,1,0}, {0,0,1} };
+		const int mode = static_cast<int>(m_worldEditorShell->GetSceneGizmoMode());
+		const float mx = static_cast<float>(mouseX), my = static_cast<float>(mouseY);
+
+		const bool pressed  = m_input.WasMousePressed(engine::platform::MouseButton::Left);
+		const bool downNow  = m_input.IsMouseDown(engine::platform::MouseButton::Left);
+		const bool released = m_input.WasMouseReleased(engine::platform::MouseButton::Left);
+
+		// --- Saisie d'un handle au clic (selon le mode courant) --------------
+		if (m_sceneGizmoDragAxis < 0 && pressed)
+		{
+			int grabbedAxis = -1;
+			if (mode == 0) // translation : un des 3 axes
+			{
+				auto distToSeg = [](float px, float py, float ax, float ay, float bx, float by) -> float {
+					const float vx = bx-ax, vy = by-ay, wx = px-ax, wy = py-ay;
+					const float len2 = vx*vx + vy*vy;
+					float t = (len2 > 1e-6f) ? (wx*vx + wy*vy) / len2 : 0.0f;
+					t = std::clamp(t, 0.0f, 1.0f);
+					const float cx = ax + t*vx, cy = ay + t*vy;
+					return std::sqrt((px-cx)*(px-cx) + (py-cy)*(py-cy));
+				};
+				float bestDist = 9.0f; // tolérance écran (pixels)
+				for (int a = 0; a < 3; ++a)
+				{
+					const engine::math::Vec3 tip{ o.x + dirs[a].x*axisLen, o.y + dirs[a].y*axisLen, o.z + dirs[a].z*axisLen };
+					float tx, ty;
+					if (!project(tip, tx, ty)) continue;
+					const float segLen = std::sqrt((tx-ox)*(tx-ox) + (ty-oy)*(ty-oy));
+					if (segLen <= 12.0f) continue; // axe quasi vu de bout
+					const float d = distToSeg(mx, my, ox, oy, tx, ty);
+					if (d < bestDist) { bestDist = d; grabbedAxis = a; }
+				}
+			}
+			else if (mode == 1) // rotation yaw : l'anneau
+			{
+				float rx, ry;
+				const engine::math::Vec3 rw{ o.x + ringR, o.y, o.z };
+				if (project(rw, rx, ry))
+				{
+					const float rad = std::sqrt((rx-ox)*(rx-ox) + (ry-oy)*(ry-oy));
+					const float dm = std::sqrt((mx-ox)*(mx-ox) + (my-oy)*(my-oy));
+					if (rad > 12.0f && std::abs(dm - rad) < 9.0f) grabbedAxis = 0;
+				}
+			}
+			else // échelle : la poignée centrale
+			{
+				if (std::abs(mx - ox) < 14.0f && std::abs(my - oy) < 14.0f) grabbedAxis = 0;
+			}
+
+			if (grabbedAxis >= 0)
+			{
+				// Capture des transforms de départ de TOUTES les entités
+				// éditables de la sélection (ancien état des commandes d'undo).
+				m_sceneGizmoDragStart.clear();
+				for (const engine::editor::scene::EntityId& id : sel.Items())
+				{
+					const engine::editor::scene::SceneEntity* e = model.Find(id);
+					if (e != nullptr && e->hasTransform)
+						m_sceneGizmoDragStart.emplace_back(id, e->transform);
+				}
+				if (m_sceneGizmoDragStart.empty()) return false;
+				m_sceneGizmoDragAxis = grabbedAxis;
+				m_sceneGizmoDragMode = mode;
+				m_sceneGizmoDragLastX = mx;
+				m_sceneGizmoDragLastY = my;
+				m_sceneGizmoDragLastAngle = std::atan2(my - oy, mx - ox);
+				return true; // capture : pas de picking/outil sur ce clic
+			}
+		}
+
+		// --- Application pendant le drag (écriture directe, undo au release) --
+		if (m_sceneGizmoDragAxis >= 0 && downNow)
+		{
+			if (m_sceneGizmoDragMode == 0) // translation le long de l'axe monde
+			{
+				const int a = m_sceneGizmoDragAxis;
+				const engine::math::Vec3 tip{ o.x + dirs[a].x*axisLen, o.y + dirs[a].y*axisLen, o.z + dirs[a].z*axisLen };
+				float tx, ty;
+				if (project(tip, tx, ty))
+				{
+					float axSx = tx - ox, axSy = ty - oy;
+					const float segLen = std::sqrt(axSx*axSx + axSy*axSy);
+					if (segLen > 1e-3f)
+					{
+						axSx /= segLen; axSy /= segLen;
+						const float worldPerPix = axisLen / segLen;
+						const float dScreen = (mx - m_sceneGizmoDragLastX)*axSx + (my - m_sceneGizmoDragLastY)*axSy;
+						const float d = dScreen * worldPerPix; // mètres monde le long de l'axe a
+						for (const auto& [id, startT] : m_sceneGizmoDragStart)
+						{
+							const engine::editor::scene::SceneEntity* e = model.Find(id);
+							if (e == nullptr) continue;
+							engine::editor::scene::EntityTransform t = e->transform;
+							t.position.x += dirs[a].x * d;
+							t.position.y += dirs[a].y * d;
+							t.position.z += dirs[a].z * d;
+							writer(id, t);
+						}
+					}
+				}
+			}
+			else if (m_sceneGizmoDragMode == 1) // rotation yaw autour du pivot de chaque entité
+			{
+				const float angNow = std::atan2(my - oy, mx - ox);
+				float dAng = angNow - m_sceneGizmoDragLastAngle;
+				while (dAng >  3.14159265f) dAng -= 6.28318530f;
+				while (dAng < -3.14159265f) dAng += 6.28318530f;
+				m_sceneGizmoDragLastAngle = angNow;
+				const float dDeg = dAng * (180.0f / 3.14159265f);
+				for (const auto& [id, startT] : m_sceneGizmoDragStart)
+				{
+					const engine::editor::scene::SceneEntity* e = model.Find(id);
+					if (e == nullptr) continue;
+					engine::editor::scene::EntityTransform t = e->transform;
+					t.eulerDeg.y += dDeg;
+					writer(id, t);
+				}
+			}
+			else // échelle uniforme (drag vertical : haut = agrandir)
+			{
+				const float factor = 1.0f + (m_sceneGizmoDragLastY - my) * 0.01f;
+				for (const auto& [id, startT] : m_sceneGizmoDragStart)
+				{
+					const engine::editor::scene::SceneEntity* e = model.Find(id);
+					if (e == nullptr) continue;
+					engine::editor::scene::EntityTransform t = e->transform;
+					t.uniformScale = std::clamp(t.uniformScale * factor, 0.01f, 1000.0f);
+					writer(id, t);
+				}
+			}
+			m_sceneGizmoDragLastX = mx;
+			m_sceneGizmoDragLastY = my;
+			return true;
+		}
+
+		// --- Fin du drag : pousser UNE étape d'annulation pour tout le geste --
+		if (released && m_sceneGizmoDragAxis >= 0)
+		{
+			auto sameTransform = [](const engine::editor::scene::EntityTransform& a,
+				const engine::editor::scene::EntityTransform& b) -> bool
+			{
+				return a.position.x == b.position.x && a.position.y == b.position.y
+					&& a.position.z == b.position.z
+					&& a.eulerDeg.x == b.eulerDeg.x && a.eulerDeg.y == b.eulerDeg.y
+					&& a.eulerDeg.z == b.eulerDeg.z
+					&& a.uniformScale == b.uniformScale;
+			};
+			const char* label = (m_sceneGizmoDragMode == 0) ? "Gizmo : déplacer"
+				: (m_sceneGizmoDragMode == 1) ? "Gizmo : tourner" : "Gizmo : échelle";
+			// Toujours envelopper dans une CompositeCommand (mergeKey 0) : deux
+			// drags successifs de la même entité ne doivent PAS fusionner en une
+			// seule étape d'annulation (contrairement au slider de l'Inspector).
+			auto composite = std::make_unique<engine::editor::world::CompositeCommand>(label);
+			for (const auto& [id, startT] : m_sceneGizmoDragStart)
+			{
+				const engine::editor::scene::SceneEntity* e = model.Find(id);
+				if (e == nullptr || sameTransform(startT, e->transform)) continue;
+				composite->AddChild(std::make_unique<engine::editor::world::SetEntityTransformCommand>(
+					id, startT, e->transform, writer));
+			}
+			if (!composite->Empty())
+			{
+				m_worldEditorShell->MutableCommandStack().Push(std::move(composite));
+			}
+			m_sceneGizmoDragAxis = -1;
+			m_sceneGizmoDragStart.clear();
+			return true;
+		}
+		return m_sceneGizmoDragAxis >= 0;
 #else
 		(void)mouseX; (void)mouseY; return false;
 #endif

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -119,6 +119,7 @@
 #if defined(_WIN32)
 #include "src/client/render/terrain/TerrainEditingTools.h"
 #include "src/world_editor/ui/TexturePreviewCache.h"
+#include "src/world_editor/scene/EditorSceneModel.h" // Roadmap-6 : gizmo scène (EntityId/EntityTransform)
 #endif
 #include "src/world_editor/render/EditorViewportRenderTarget.h"
 // Sous-projet C MVP (Task 12) — viewport offscreen pour l'apercu race
@@ -1102,6 +1103,41 @@ namespace engine
 		float m_gizmoDragAxisSy = 0.0f;   ///< direction écran de l'axe (unité) Y
 		float m_gizmoDragWorldPerPix = 0.0f; ///< mètres monde par pixel le long de l'axe (translation)
 		int   m_gizmoDragRefreshTick = 0;    ///< compteur de frames pour rafraîchir le mesh pendant le drag (throttle)
+
+		/// Roadmap-6 (2026-07-19) — Dessine le gizmo de transformation des
+		/// ENTITÉS DE SCÈNE sélectionnées (EditorSelection du shell) en overlay
+		/// ImGui : selon le mode du shell (E/T/C), axes de translation X/Y/Z,
+		/// anneau de rotation yaw, ou poignée d'échelle uniforme — sur l'entité
+		/// PRIMAIRE, plus un marqueur sur chaque entité de la multi-sélection.
+		/// No-op hors éditeur, sans sélection à transform, ou en mode édition
+		/// bâtiment (le gizmo bâtiment garde la main). Main thread, frame ImGui.
+		void DrawEditorSceneGizmo();
+
+		/// Roadmap-6 — Gère le cliquer-glisser du gizmo de scène : saisit un
+		/// handle au clic (axe / anneau yaw / poignée d'échelle selon le mode),
+		/// applique la transformation à TOUTES les entités éditables de la
+		/// sélection pendant le drag (écriture directe via TransformWriter),
+		/// puis pousse au relâchement UNE étape d'annulation
+		/// (SetEntityTransformCommand par entité, CompositeCommand si
+		/// plusieurs). \param mouseX,mouseY position souris (pixels fenêtre).
+		/// \return true si le gizmo capture la souris cette frame (le clic ne
+		/// doit alors PAS être interprété par le picking/outils terrain).
+		bool UpdateEditorSceneGizmoDrag(int mouseX, int mouseY);
+
+		/// Roadmap-6 — Taille MONDE des handles du gizmo de scène (même règle
+		/// « ~constante à l'écran » que GizmoHandleSizes, mais centrée sur une
+		/// position arbitraire). \param pos centre monde du gizmo (mètres).
+		void SceneGizmoHandleSizes(const engine::math::Vec3& pos, float& axisLen, float& ringR) const;
+
+		// Gizmo de scène — état du glissement en cours (Roadmap-6).
+		int   m_sceneGizmoDragAxis = -1;    ///< translation : axe saisi 0=X/1=Y/2=Z ; rotation/échelle : 0 ; -1 = aucun
+		int   m_sceneGizmoDragMode = 0;     ///< mode au moment de la saisie : 0=translation, 1=rotation yaw, 2=échelle
+		float m_sceneGizmoDragLastX = 0.0f; ///< dernière position souris X (pixels)
+		float m_sceneGizmoDragLastY = 0.0f; ///< dernière position souris Y (pixels)
+		float m_sceneGizmoDragLastAngle = 0.0f; ///< dernier angle souris/centre (rad, mode rotation)
+		/// Transforms des entités éditables de la sélection AU DÉBUT du drag
+		/// (ancien état des SetEntityTransformCommand poussées au relâchement).
+		std::vector<std::pair<engine::editor::scene::EntityId, engine::editor::scene::EntityTransform>> m_sceneGizmoDragStart;
 
 		/// Charge le coffre (Chest_Wood) en mesh SKINNE (squelette + clips Open/Close)
 		/// pour l'animer a l'interaction. A appeler au boot apres LoadInteractableProps.

--- a/src/client/app/Engine.h
+++ b/src/client/app/Engine.h
@@ -119,8 +119,10 @@
 #if defined(_WIN32)
 #include "src/client/render/terrain/TerrainEditingTools.h"
 #include "src/world_editor/ui/TexturePreviewCache.h"
-#include "src/world_editor/scene/EditorSceneModel.h" // Roadmap-6 : gizmo scène (EntityId/EntityTransform)
 #endif
+// Roadmap-6 : gizmo scène (EntityId/EntityTransform). Pur CPU, HORS du bloc
+// _WIN32 — Engine.h est aussi compilé sous Linux (via engine_core).
+#include "src/world_editor/scene/EditorSceneModel.h"
 #include "src/world_editor/render/EditorViewportRenderTarget.h"
 // Sous-projet C MVP (Task 12) — viewport offscreen pour l'apercu race
 // dans l'ecran ImGui de creation de personnage.

--- a/src/world_editor/core/CompositeCommand.h
+++ b/src/world_editor/core/CompositeCommand.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "src/world_editor/core/CommandStack.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace engine::editor::world
+{
+	/// Roadmap-6 (2026-07-19) — Commande composite : regroupe N commandes
+	/// enfants en UNE seule étape d'historique undo/redo. Utilisée par les
+	/// opérations multi-sélection (Dupliquer/Supprimer N entités, drag de
+	/// gizmo sur N entités) pour qu'un seul Ctrl+Z annule tout le geste.
+	///
+	/// `Execute` exécute les enfants dans l'ordre d'AJOUT ; `Undo` les annule
+	/// dans l'ordre INVERSE (le dernier exécuté est le premier annulé), comme
+	/// une transaction. Le `mergeKey` reste 0 (défaut ICommand) : deux gestes
+	/// composites successifs ne fusionnent JAMAIS entre eux — chaque geste est
+	/// une étape d'annulation distincte.
+	///
+	/// L'appelant est responsable de l'ORDRE des enfants quand il importe
+	/// (ex. suppressions par index décroissant pour que la capture du 1er
+	/// Execute ne soit pas invalidée par les retraits précédents).
+	///
+	/// Contrainte thread : main thread (comme tout `ICommand`).
+	class CompositeCommand final : public ICommand
+	{
+	public:
+		/// \param label Libellé affiché dans l'historique (copié ; ex.
+		///        "Supprimer 3 entités"). Vie aussi longue que la commande.
+		explicit CompositeCommand(std::string label)
+			: m_label(std::move(label)) {}
+
+		/// Ajoute une commande enfant (exécutée en ordre d'ajout au Execute,
+		/// en ordre inverse au Undo). À appeler AVANT le Push sur la pile.
+		void AddChild(std::unique_ptr<ICommand> child)
+		{
+			if (child) m_children.push_back(std::move(child));
+		}
+
+		/// true si aucune commande enfant (ne rien pousser dans ce cas).
+		bool Empty() const { return m_children.empty(); }
+
+		/// Nombre de commandes enfants (tests, libellés).
+		size_t ChildCount() const { return m_children.size(); }
+
+		const char* GetLabel() const override { return m_label.c_str(); }
+
+		/// Empreinte mémoire = structure + libellé + somme des enfants (pour
+		/// l'éviction par budget mémoire du CommandStack).
+		size_t GetMemoryFootprint() const override
+		{
+			size_t total = sizeof(CompositeCommand) + m_label.capacity();
+			for (const auto& c : m_children) total += c->GetMemoryFootprint();
+			return total;
+		}
+
+		/// Exécute tous les enfants dans l'ordre d'ajout.
+		void Execute() override
+		{
+			for (auto& c : m_children) c->Execute();
+		}
+
+		/// Annule tous les enfants dans l'ordre inverse d'ajout.
+		void Undo() override
+		{
+			for (auto it = m_children.rbegin(); it != m_children.rend(); ++it)
+				(*it)->Undo();
+		}
+
+	private:
+		std::string m_label;
+		std::vector<std::unique_ptr<ICommand>> m_children;
+	};
+}

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -19,11 +19,14 @@
 #include "src/shared/core/Config.h"
 #include "src/shared/core/Log.h"
 
+#include <algorithm> // std::sort — suppression multi par index décroissant (Roadmap-6)
 #include <cctype>   // std::tolower — ids kebab-case des toggles de panneaux
 #include <cstring>  // std::strcmp — filtrage du panneau « Scene » dans le menu View
 #include <functional>
 #include <utility>
+#include <vector>
 
+#include "src/world_editor/core/CompositeCommand.h"        // Roadmap-6 : gestes multi-sélection
 #include "src/world_editor/modes/EditorModeRegistry.h"
 #include "src/world_editor/scene/DeleteEntityCommand.h"    // lot 5
 #include "src/world_editor/scene/DuplicateEntityCommand.h" // lot 5
@@ -422,6 +425,21 @@ namespace engine::editor::world
 			[this] { return CanEditSelectedEntity(); }, nullptr,
 			[this] { DeleteSelectedEntity(); });
 
+		// Roadmap-6 (2026-07-19) — Modes du gizmo de transformation viewport
+		// (toggles exclusifs, cf. raccourcis E/T/C dans HandleShortcut).
+		add("tool.gizmo-translate", "Gizmo : déplacer", ActionCategory::Outils, "E",
+			nullptr,
+			[this] { return m_sceneGizmoMode == SceneGizmoMode::Translate; },
+			[this] { SetSceneGizmoMode(SceneGizmoMode::Translate); });
+		add("tool.gizmo-rotate", "Gizmo : tourner", ActionCategory::Outils, "T",
+			nullptr,
+			[this] { return m_sceneGizmoMode == SceneGizmoMode::Rotate; },
+			[this] { SetSceneGizmoMode(SceneGizmoMode::Rotate); });
+		add("tool.gizmo-scale", "Gizmo : échelle", ActionCategory::Outils, "C",
+			nullptr,
+			[this] { return m_sceneGizmoMode == SceneGizmoMode::Scale; },
+			[this] { SetSceneGizmoMode(SceneGizmoMode::Scale); });
+
 		// Toggle de visibilité par panneau (menu « Fenêtre »). Le panneau
 		// « Scene » est exclu (doublon de la vue 3D principale, cf. menu Vue
 		// historique). Id kebab-case dérivé du nom : "Asset Browser" →
@@ -458,51 +476,132 @@ namespace engine::editor::world
 		}
 	}
 
-	/// Lot 5 (2026-07-18) — true si la sélection courante est duplicable/
-	/// supprimable : foncteurs Engine installés ET kind ∈ {LayoutInstance,
-	/// MeshInsert, DungeonPortal}. Terrain (entité implicite unique), Water
-	/// (pas de transform simple) et None sont exclus.
+	namespace
+	{
+		/// Lot 5 / Roadmap-6 — true si le kind est éditable structurellement
+		/// (duplicable/supprimable) : Terrain (entité implicite unique), Water
+		/// (pas de transform simple) et None sont exclus.
+		bool IsStructurallyEditableKind(engine::editor::scene::EntityKind kind)
+		{
+			using K = engine::editor::scene::EntityKind;
+			return kind == K::LayoutInstance || kind == K::MeshInsert || kind == K::DungeonPortal;
+		}
+
+		/// Roadmap-6 — Extrait de la sélection la liste des entités éditables,
+		/// dans l'ordre de sélection (sans doublon, garanti par EditorSelection).
+		std::vector<engine::editor::scene::EntityId> EditableSelection(
+			const engine::editor::scene::EditorSelection& sel)
+		{
+			std::vector<engine::editor::scene::EntityId> out;
+			for (const engine::editor::scene::EntityId& id : sel.Items())
+			{
+				if (IsStructurallyEditableKind(id.kind)) out.push_back(id);
+			}
+			return out;
+		}
+	}
+
+	/// Lot 5 (2026-07-18, multi Roadmap-6) — true si AU MOINS une entité de la
+	/// sélection est duplicable/supprimable (foncteurs Engine installés).
 	bool WorldEditorShell::CanEditSelectedEntity() const
 	{
 		if (!m_entityEditOps.IsInstalled()) return false;
-		const engine::editor::scene::EntityKind kind = m_selection.Current().kind;
-		using K = engine::editor::scene::EntityKind;
-		return kind == K::LayoutInstance || kind == K::MeshInsert || kind == K::DungeonPortal;
+		for (const engine::editor::scene::EntityId& id : m_selection.Items())
+		{
+			if (IsStructurallyEditableKind(id.kind)) return true;
+		}
+		return false;
 	}
 
-	/// Lot 5 — Pousse une DuplicateEntityCommand sur la pile undo (Execute
-	/// immédiat : la copie apparaît, décalée, avec un nouveau guid). La
-	/// sélection reste sur l'original : la copie est ajoutée en FIN de liste,
-	/// aucun index existant n'est invalidé.
+	/// Lot 5 (multi Roadmap-6) — Duplique toutes les entités éditables de la
+	/// sélection. Une commande par entité, regroupées en CompositeCommand si
+	/// plusieurs (une seule étape d'annulation). Les copies s'ajoutent en FIN
+	/// de liste : aucun index existant n'est invalidé, la sélection reste sur
+	/// les originaux.
 	void WorldEditorShell::DuplicateSelectedEntity()
 	{
-		if (!CanEditSelectedEntity())
+		const std::vector<engine::editor::scene::EntityId> ids =
+			m_entityEditOps.IsInstalled()
+				? EditableSelection(m_selection)
+				: std::vector<engine::editor::scene::EntityId>{};
+		if (ids.empty())
 		{
 			LOG_INFO(EditorWorld, "Dupliquer : aucune entité duplicable sélectionnée");
 			return;
 		}
-		m_commandStack.Push(std::make_unique<DuplicateEntityCommand>(
-			m_selection.Current(), m_entityEditOps));
-		LOG_INFO(EditorWorld, "Dupliquer la sélection (kind={}, index={})",
-			static_cast<int>(m_selection.Current().kind), m_selection.Current().index);
+		if (ids.size() == 1u)
+		{
+			m_commandStack.Push(std::make_unique<DuplicateEntityCommand>(ids.front(), m_entityEditOps));
+		}
+		else
+		{
+			auto composite = std::make_unique<CompositeCommand>(
+				"Dupliquer " + std::to_string(ids.size()) + " entités");
+			for (const engine::editor::scene::EntityId& id : ids)
+			{
+				composite->AddChild(std::make_unique<DuplicateEntityCommand>(id, m_entityEditOps));
+			}
+			m_commandStack.Push(std::move(composite));
+		}
+		LOG_INFO(EditorWorld, "Dupliquer la sélection ({} entité(s))", ids.size());
 	}
 
-	/// Lot 5 — Pousse une DeleteEntityCommand sur la pile undo (Execute
-	/// immédiat : l'entité disparaît) puis VIDE la sélection — après un
-	/// erase, les index des entités suivantes glissent d'un rang et la
-	/// sélection courante pointerait une autre entité.
+	/// Lot 5 (multi Roadmap-6) — Supprime toutes les entités éditables de la
+	/// sélection, par index DÉCROISSANT au sein de chaque kind : la capture du
+	/// 1er Execute d'une DeleteEntityCommand se fait par index de scène, et
+	/// retirer d'abord les index hauts garantit que les index bas restent
+	/// valides pour les commandes suivantes du composite. VIDE ensuite la
+	/// sélection (les index des entités restantes ont glissé).
 	void WorldEditorShell::DeleteSelectedEntity()
 	{
-		if (!CanEditSelectedEntity())
+		std::vector<engine::editor::scene::EntityId> ids =
+			m_entityEditOps.IsInstalled()
+				? EditableSelection(m_selection)
+				: std::vector<engine::editor::scene::EntityId>{};
+		if (ids.empty())
 		{
 			LOG_INFO(EditorWorld, "Supprimer : aucune entité supprimable sélectionnée");
 			return;
 		}
-		const engine::editor::scene::EntityId id = m_selection.Current();
-		m_commandStack.Push(std::make_unique<DeleteEntityCommand>(id, m_entityEditOps));
+		std::sort(ids.begin(), ids.end(),
+			[](const engine::editor::scene::EntityId& a, const engine::editor::scene::EntityId& b)
+			{
+				if (a.kind != b.kind) return static_cast<int>(a.kind) < static_cast<int>(b.kind);
+				return a.index > b.index; // index décroissant au sein du kind
+			});
+		if (ids.size() == 1u)
+		{
+			m_commandStack.Push(std::make_unique<DeleteEntityCommand>(ids.front(), m_entityEditOps));
+		}
+		else
+		{
+			auto composite = std::make_unique<CompositeCommand>(
+				"Supprimer " + std::to_string(ids.size()) + " entités");
+			for (const engine::editor::scene::EntityId& id : ids)
+			{
+				composite->AddChild(std::make_unique<DeleteEntityCommand>(id, m_entityEditOps));
+			}
+			m_commandStack.Push(std::move(composite));
+		}
+		const size_t n = ids.size();
 		m_selection.Clear();
-		LOG_INFO(EditorWorld, "Supprimer la sélection (kind={}, index={})",
-			static_cast<int>(id.kind), id.index);
+		LOG_INFO(EditorWorld, "Supprimer la sélection ({} entité(s))", n);
+	}
+
+	/// Roadmap-6 — Change le mode du gizmo viewport (E/T/C, actions
+	/// `tool.gizmo-*`). Idempotent, logge la transition.
+	void WorldEditorShell::SetSceneGizmoMode(SceneGizmoMode mode)
+	{
+		if (m_sceneGizmoMode == mode) return;
+		m_sceneGizmoMode = mode;
+		const char* name = "Translate";
+		switch (mode)
+		{
+			case SceneGizmoMode::Translate: name = "Translate"; break;
+			case SceneGizmoMode::Rotate:    name = "Rotate"; break;
+			case SceneGizmoMode::Scale:     name = "Scale"; break;
+		}
+		LOG_INFO(EditorWorld, "Gizmo viewport -> {}", name);
 	}
 
 	/// M100.6 — Active un outil et logge la transition. Garde l'API simple :
@@ -814,6 +913,24 @@ namespace engine::editor::world
 		if (!ctrl && !shift && virtualKey == 0x2E)
 		{
 			DeleteSelectedEntity();
+			return true;
+		}
+		// Roadmap-6 (2026-07-19) — E / T / C (sans modifiers) : mode du gizmo
+		// viewport (dÉplacer / Tourner / éChelle). W est réservé à la caméra
+		// (WASD/ZQSD) et R à l'outil rivière (M100.13), d'où ce trio.
+		if (!ctrl && !shift && virtualKey == 'E')
+		{
+			SetSceneGizmoMode(SceneGizmoMode::Translate);
+			return true;
+		}
+		if (!ctrl && !shift && virtualKey == 'T')
+		{
+			SetSceneGizmoMode(SceneGizmoMode::Rotate);
+			return true;
+		}
+		if (!ctrl && !shift && virtualKey == 'C')
+		{
+			SetSceneGizmoMode(SceneGizmoMode::Scale);
 			return true;
 		}
 		// M100.6 — Raccourci 'B' (sans modifiers) active la sculpture terrain.

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -291,6 +291,28 @@ namespace engine::editor::world
 		/// Installe le foncteur d'écriture de transform (appelé par l'Engine).
 		void SetTransformWriter(TransformWriter w) { m_transformWriter = std::move(w); }
 
+		/// Roadmap-6 (2026-07-19) — Accès lecture au foncteur d'écriture de
+		/// transform. Consommé par le gizmo viewport (Engine) pour construire
+		/// des `SetEntityTransformCommand` au relâchement d'un drag. Peut être
+		/// vide si l'Engine ne l'a pas encore installé (tester avant usage).
+		const TransformWriter& GetTransformWriter() const { return m_transformWriter; }
+
+		/// Roadmap-6 — Mode du gizmo de transformation du viewport (entités de
+		/// scène sélectionnées). Piloté par les raccourcis E / T / C et par les
+		/// actions `tool.gizmo-*` ; lu par l'Engine pour dessiner et manipuler.
+		enum class SceneGizmoMode : uint8_t
+		{
+			Translate = 0, ///< E — déplacer le long des axes monde X/Y/Z.
+			Rotate    = 1, ///< T — tourner autour de l'axe vertical (yaw).
+			Scale     = 2, ///< C — échelle uniforme.
+		};
+
+		/// Roadmap-6 — Mode courant du gizmo viewport (Translate par défaut).
+		SceneGizmoMode GetSceneGizmoMode() const { return m_sceneGizmoMode; }
+
+		/// Roadmap-6 — Change le mode du gizmo viewport. Effet de bord : log.
+		void SetSceneGizmoMode(SceneGizmoMode mode);
+
 		/// Lot 5 (2026-07-18) — Installe les foncteurs d'édition structurelle
 		/// (capture / remove / restore / duplicate) des entités de scène.
 		/// Appelé par l'Engine (qui capture les documents mutables) au même
@@ -301,23 +323,27 @@ namespace engine::editor::world
 			m_entityEditOps = std::move(ops);
 		}
 
-		/// Lot 5 — true si la sélection courante est duplicable/supprimable :
-		/// foncteurs installés ET kind ∈ {LayoutInstance, MeshInsert,
-		/// DungeonPortal} (Terrain/Water/None exclus). Pilote `enabled` des
-		/// actions `edit.duplicate` / `edit.delete`.
+		/// Lot 5 (multi Roadmap-6) — true si AU MOINS une entité de la sélection
+		/// est duplicable/supprimable : foncteurs installés ET kind ∈
+		/// {LayoutInstance, MeshInsert, DungeonPortal} (Terrain/Water/None
+		/// exclus). Pilote `enabled` des actions `edit.duplicate`/`edit.delete`.
 		bool CanEditSelectedEntity() const;
 
-		/// Lot 5 — Duplique l'entité sélectionnée via une
-		/// `DuplicateEntityCommand` poussée sur la pile undo (nouveau guid +
-		/// léger décalage de position ; la sélection reste sur l'original,
-		/// dont l'index n'est pas invalidé par un ajout en fin de liste).
+		/// Lot 5 (multi Roadmap-6) — Duplique la sélection : une
+		/// `DuplicateEntityCommand` par entité éditable (nouveau guid + léger
+		/// décalage de position), regroupées en `CompositeCommand` si la
+		/// sélection en contient plusieurs (UNE étape d'annulation par geste).
+		/// La sélection reste sur les originaux (copies ajoutées en fin de
+		/// liste, aucun index invalidé).
 		/// No-op (log) si `CanEditSelectedEntity()` est false.
 		void DuplicateSelectedEntity();
 
-		/// Lot 5 — Supprime l'entité sélectionnée via une
-		/// `DeleteEntityCommand` poussée sur la pile undo, puis VIDE la
-		/// sélection (les index d'entités suivant la supprimée glissent d'un
-		/// rang — garder la sélection pointerait une autre entité).
+		/// Lot 5 (multi Roadmap-6) — Supprime la sélection : une
+		/// `DeleteEntityCommand` par entité éditable, ordonnées par index
+		/// DÉCROISSANT par kind (la capture du 1er Execute travaille par index
+		/// de scène — retirer d'abord les index hauts préserve les bas),
+		/// regroupées en `CompositeCommand` si plusieurs. VIDE ensuite la
+		/// sélection (les index des entités restantes ont glissé).
 		/// No-op (log) si `CanEditSelectedEntity()` est false.
 		void DeleteSelectedEntity();
 
@@ -516,6 +542,7 @@ namespace engine::editor::world
 		engine::editor::world::quests::QuestEditIo m_questEditIo;    // SP4 — E/S authoring quêtes
 		panels::QuestEditorPanel* m_questEditorPtr = nullptr;        // non possédé (dans m_panels)
 		ActiveTool m_activeTool = ActiveTool::None;
+		SceneGizmoMode m_sceneGizmoMode = SceneGizmoMode::Translate; // Roadmap-6
 		actions::EditorActionRegistry m_actions; // réorganisation UI 2026-07-17
 		/// Sériel du CommandStack au dernier `NoteSaved` (dirty-tracking).
 		uint64_t m_savedSerial = 0;

--- a/src/world_editor/scene/EditorSelection.cpp
+++ b/src/world_editor/scene/EditorSelection.cpp
@@ -1,18 +1,42 @@
 #include "src/world_editor/scene/EditorSelection.h"
 
+#include <algorithm>
+
 namespace engine::editor::scene
 {
 	void EditorSelection::Select(EntityId id)
 	{
-		if (id == m_current) return; // déjà sélectionné : pas de notification
-		m_current = id;
-		if (m_onChanged) m_onChanged(m_current);
+		if (id.kind == EntityKind::None) { Clear(); return; }
+		if (m_items.size() == 1u && m_items.front() == id) return; // déjà exactement {id}
+		m_items.clear();
+		m_items.push_back(id);
+		Notify();
+	}
+
+	void EditorSelection::Toggle(EntityId id)
+	{
+		if (id.kind == EntityKind::None) return;
+		const auto it = std::find(m_items.begin(), m_items.end(), id);
+		if (it != m_items.end())
+		{
+			m_items.erase(it);
+		}
+		else
+		{
+			m_items.push_back(id); // devient la primaire (back)
+		}
+		Notify();
 	}
 
 	void EditorSelection::Clear()
 	{
-		if (m_current.kind == EntityKind::None) return; // déjà vide
-		m_current = EntityId{};
-		if (m_onChanged) m_onChanged(m_current);
+		if (m_items.empty()) return; // déjà vide
+		m_items.clear();
+		Notify();
+	}
+
+	bool EditorSelection::Contains(EntityId id) const
+	{
+		return std::find(m_items.begin(), m_items.end(), id) != m_items.end();
 	}
 }

--- a/src/world_editor/scene/EditorSelection.h
+++ b/src/world_editor/scene/EditorSelection.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <functional>
 #include <utility>
+#include <vector>
 
 namespace engine::editor::scene
 {
@@ -37,6 +38,12 @@ namespace engine::editor::scene
 	/// changement **effectif** de sélection (pas de notification si la cible est
 	/// déjà sélectionnée).
 	///
+	/// Roadmap-6 (2026-07-19) : MULTI-sélection ordonnée. La sélection est une
+	/// liste d'`EntityId` sans doublon ; l'entité **primaire** (celle du gizmo
+	/// et de l'Inspector) est la DERNIÈRE sélectionnée — `Current()` la
+	/// retourne, ce qui préserve la compatibilité de tous les consommateurs
+	/// mono-sélection existants (Outliner, Inspector, Dupliquer/Supprimer).
+	///
 	/// Contrainte thread : main thread (comme le reste de l'éditeur ; ImGui
 	/// n'est pas thread-safe). Pur CPU, aucune dépendance Vulkan/ImGui.
 	class EditorSelection
@@ -44,26 +51,48 @@ namespace engine::editor::scene
 	public:
 		using OnChangedCallback = std::function<void(EntityId)>;
 
-		/// Sélectionne `id`. No-op (aucune notification) si `id` est déjà la
-		/// sélection courante.
+		/// Sélectionne `id` seul (remplace TOUTE la sélection). No-op (aucune
+		/// notification) si la sélection est déjà exactement `{id}`. Un `id` de
+		/// kind None équivaut à `Clear()`.
 		/// Effet de bord : invoque le callback OnChanged si la sélection change.
 		void Select(EntityId id);
+
+		/// Roadmap-6 — Bascule `id` dans la sélection (Ctrl+Maj+clic) : l'ajoute
+		/// s'il est absent (il devient l'entité primaire), le retire s'il est
+		/// présent (la primaire redevient le dernier restant). No-op pour un
+		/// kind None.
+		/// Effet de bord : invoque le callback OnChanged si la sélection change.
+		void Toggle(EntityId id);
 
 		/// Vide la sélection (kind = None). No-op si déjà vide.
 		/// Effet de bord : invoque le callback OnChanged si la sélection change.
 		void Clear();
 
-		/// Sélection courante (kind = None si aucune).
-		EntityId Current() const { return m_current; }
+		/// Entité primaire = dernière sélectionnée (kind = None si aucune).
+		EntityId Current() const { return m_items.empty() ? EntityId{} : m_items.back(); }
 
-		/// true si une entité est sélectionnée (kind != None).
-		bool HasSelection() const { return m_current.kind != EntityKind::None; }
+		/// true si au moins une entité est sélectionnée.
+		bool HasSelection() const { return !m_items.empty(); }
+
+		/// Roadmap-6 — true si `id` fait partie de la sélection.
+		bool Contains(EntityId id) const;
+
+		/// Roadmap-6 — Nombre d'entités sélectionnées.
+		size_t Count() const { return m_items.size(); }
+
+		/// Roadmap-6 — Liste ordonnée (ordre de sélection, primaire en dernier).
+		/// Valide jusqu'à la prochaine mutation de la sélection.
+		const std::vector<EntityId>& Items() const { return m_items; }
 
 		/// Installe l'observateur de changement (un seul ; remplace le précédent).
+		/// Le callback reçoit l'entité PRIMAIRE courante (None si sélection vide).
 		void SetOnChanged(OnChangedCallback cb) { m_onChanged = std::move(cb); }
 
 	private:
-		EntityId m_current{};
+		/// Invoque l'observateur avec l'entité primaire courante.
+		void Notify() { if (m_onChanged) m_onChanged(Current()); }
+
+		std::vector<EntityId> m_items; ///< sans doublon, primaire = back()
 		OnChangedCallback m_onChanged;
 	};
 }

--- a/src/world_editor/scene/LayoutPlacementCommands.h
+++ b/src/world_editor/scene/LayoutPlacementCommands.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/ui/WorldMapEditDocument.h"
+
+#include <functional>
+#include <string>
+#include <utility>
+
+namespace engine::editor::scene
+{
+	/// Roadmap-6 (2026-07-19) — Foncteurs d'édition du document layout pour le
+	/// PLACEMENT/DÉPLACEMENT undoable d'instances (props/arbres/rochers).
+	/// Installés par l'Engine au point d'usage (capture `[this]` : l'Engine
+	/// survit aux commandes dans la pile undo). Toutes les opérations sont
+	/// adressées par GUID (chaîne stable du document layout), JAMAIS par index
+	/// (instable après édition structurelle) — même règle que `EntityEditOps`.
+	struct LayoutPlacementOps
+	{
+		/// Ajoute l'instance (guid déjà posé) en fin de document.
+		/// \return false si le document n'est pas disponible.
+		std::function<bool(const engine::editor::WorldMapEditLayoutInstance&)> add;
+
+		/// Retire du document l'instance de guid donné.
+		/// \return false si l'instance n'est plus présente.
+		std::function<bool(const std::string&)> removeByGuid;
+
+		/// Écrit la position monde (mètres) de l'instance de guid donné.
+		/// \return false si l'instance n'est plus présente.
+		std::function<bool(const std::string&, double, double, double)> setPositionByGuid;
+
+		/// true si les trois foncteurs sont installés.
+		bool IsInstalled() const { return add && removeByGuid && setPositionByGuid; }
+	};
+
+	/// Roadmap-6 — Commande undoable de PLACEMENT d'une nouvelle instance de
+	/// layout (clic « poser » du mode placement). `Execute` ajoute l'instance
+	/// (le guid, généré AVANT la construction, est conservé au Redo) ; `Undo`
+	/// la retire par guid.
+	///
+	/// Contrainte thread : main thread (comme tout `ICommand`).
+	class PlaceLayoutInstanceCommand final : public engine::editor::world::ICommand
+	{
+	public:
+		/// \param instance Instance COMPLÈTE à poser (guid déjà généré).
+		/// \param ops Foncteurs d'édition (doivent survivre à la commande dans
+		///        la pile undo — capture Engine `[this]`).
+		PlaceLayoutInstanceCommand(engine::editor::WorldMapEditLayoutInstance instance,
+			LayoutPlacementOps ops)
+			: m_instance(std::move(instance)), m_ops(std::move(ops)) {}
+
+		const char* GetLabel() const override { return "Placer une instance"; }
+		size_t GetMemoryFootprint() const override
+		{
+			return sizeof(PlaceLayoutInstanceCommand)
+				+ m_instance.guid.capacity()
+				+ m_instance.gltfContentRelativePath.capacity()
+				+ m_instance.speciesId.capacity();
+		}
+
+		void Execute() override { if (m_ops.add) (void)m_ops.add(m_instance); }
+		void Undo() override { if (m_ops.removeByGuid) (void)m_ops.removeByGuid(m_instance.guid); }
+
+	private:
+		engine::editor::WorldMapEditLayoutInstance m_instance;
+		LayoutPlacementOps m_ops;
+	};
+
+	/// Roadmap-6 — Commande undoable de DÉPLACEMENT d'une instance de layout
+	/// existante (clic « déplacer ici » du mode placement avec une instance
+	/// sélectionnée). `Execute` écrit la nouvelle position, `Undo` restaure
+	/// l'ancienne — par guid stable. Pas de coalescing (chaque clic est une
+	/// étape d'annulation distincte, contrairement au drag de gizmo).
+	///
+	/// Contrainte thread : main thread (comme tout `ICommand`).
+	class MoveLayoutInstanceCommand final : public engine::editor::world::ICommand
+	{
+	public:
+		/// \param guid Instance ciblée (chaîne stable du document layout).
+		/// \param oldX,oldY,oldZ Position monde AVANT (restaurée au Undo), en mètres.
+		/// \param newX,newY,newZ Position monde APRÈS (appliquée au Execute), en mètres.
+		MoveLayoutInstanceCommand(std::string guid,
+			double oldX, double oldY, double oldZ,
+			double newX, double newY, double newZ,
+			LayoutPlacementOps ops)
+			: m_guid(std::move(guid))
+			, m_oldX(oldX), m_oldY(oldY), m_oldZ(oldZ)
+			, m_newX(newX), m_newY(newY), m_newZ(newZ)
+			, m_ops(std::move(ops)) {}
+
+		const char* GetLabel() const override { return "Déplacer une instance"; }
+		size_t GetMemoryFootprint() const override
+		{
+			return sizeof(MoveLayoutInstanceCommand) + m_guid.capacity();
+		}
+
+		void Execute() override
+		{
+			if (m_ops.setPositionByGuid) (void)m_ops.setPositionByGuid(m_guid, m_newX, m_newY, m_newZ);
+		}
+		void Undo() override
+		{
+			if (m_ops.setPositionByGuid) (void)m_ops.setPositionByGuid(m_guid, m_oldX, m_oldY, m_oldZ);
+		}
+
+	private:
+		std::string m_guid;
+		double m_oldX, m_oldY, m_oldZ;
+		double m_newX, m_newY, m_newZ;
+		LayoutPlacementOps m_ops;
+	};
+}

--- a/src/world_editor/tests/CompositeCommandTests.cpp
+++ b/src/world_editor/tests/CompositeCommandTests.cpp
@@ -1,0 +1,135 @@
+/// Roadmap-6 (2026-07-19) — Tests unitaires CPU de CompositeCommand :
+/// Execute dans l'ordre d'ajout, Undo dans l'ordre inverse, empreinte
+/// mémoire agrégée, intégration CommandStack (une seule étape d'historique).
+/// Pur CPU (aucune dépendance ImGui/Vulkan), tourne sous ctest Linux.
+
+#include "src/world_editor/core/CompositeCommand.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::editor::world::CommandStack;
+	using engine::editor::world::CompositeCommand;
+	using engine::editor::world::ICommand;
+
+	/// Commande sonde : journalise ses Execute/Undo dans un log partagé pour
+	/// vérifier l'ORDRE d'exécution du composite.
+	class ProbeCommand final : public ICommand
+	{
+	public:
+		ProbeCommand(std::vector<std::string>* log, std::string name)
+			: m_log(log), m_name(std::move(name)) {}
+		const char* GetLabel() const override { return m_name.c_str(); }
+		size_t GetMemoryFootprint() const override { return 100u; }
+		void Execute() override { m_log->push_back("exec:" + m_name); }
+		void Undo() override { m_log->push_back("undo:" + m_name); }
+	private:
+		std::vector<std::string>* m_log;
+		std::string m_name;
+	};
+
+	/// Execute en ordre d'ajout, Undo en ordre INVERSE (transaction).
+	void Test_ExecuteOrder_UndoReverse()
+	{
+		std::vector<std::string> log;
+		CompositeCommand c("geste");
+		c.AddChild(std::make_unique<ProbeCommand>(&log, "a"));
+		c.AddChild(std::make_unique<ProbeCommand>(&log, "b"));
+		c.AddChild(std::make_unique<ProbeCommand>(&log, "c"));
+		REQUIRE(!c.Empty());
+		REQUIRE(c.ChildCount() == 3u);
+
+		c.Execute();
+		REQUIRE(log.size() == 3u);
+		REQUIRE(log[0] == "exec:a" && log[1] == "exec:b" && log[2] == "exec:c");
+
+		log.clear();
+		c.Undo();
+		REQUIRE(log.size() == 3u);
+		REQUIRE(log[0] == "undo:c" && log[1] == "undo:b" && log[2] == "undo:a");
+	}
+
+	/// L'empreinte mémoire agrège celle des enfants (éviction par budget).
+	void Test_MemoryFootprintAggregates()
+	{
+		std::vector<std::string> log;
+		CompositeCommand c("geste");
+		REQUIRE(c.Empty());
+		const size_t base = c.GetMemoryFootprint();
+		c.AddChild(std::make_unique<ProbeCommand>(&log, "a"));
+		c.AddChild(std::make_unique<ProbeCommand>(&log, "b"));
+		REQUIRE(c.GetMemoryFootprint() >= base + 200u);
+	}
+
+	/// Poussé sur un CommandStack, le composite est UNE étape : un seul Undo
+	/// annule les 3 enfants, un seul Redo les rejoue.
+	void Test_CommandStackSingleStep()
+	{
+		std::vector<std::string> log;
+		auto c = std::make_unique<CompositeCommand>("geste");
+		c->AddChild(std::make_unique<ProbeCommand>(&log, "a"));
+		c->AddChild(std::make_unique<ProbeCommand>(&log, "b"));
+		c->AddChild(std::make_unique<ProbeCommand>(&log, "c"));
+
+		CommandStack stack;
+		stack.Push(std::move(c)); // Execute immédiat
+		REQUIRE(log.size() == 3u);
+		REQUIRE(stack.UndoSize() == 1u);
+
+		log.clear();
+		stack.Undo();
+		REQUIRE(log.size() == 3u);
+		REQUIRE(log[0] == "undo:c");
+		REQUIRE(stack.UndoSize() == 0u);
+		REQUIRE(stack.RedoSize() == 1u);
+
+		log.clear();
+		stack.Redo();
+		REQUIRE(log.size() == 3u);
+		REQUIRE(log[0] == "exec:a");
+	}
+
+	/// Deux composites successifs ne fusionnent JAMAIS (mergeKey 0) : chaque
+	/// geste reste une étape d'annulation distincte.
+	void Test_NoCoalescingBetweenGestures()
+	{
+		std::vector<std::string> log;
+		CommandStack stack;
+		for (int i = 0; i < 2; ++i)
+		{
+			auto c = std::make_unique<CompositeCommand>("geste");
+			c->AddChild(std::make_unique<ProbeCommand>(&log, "x"));
+			stack.Push(std::move(c));
+		}
+		REQUIRE(stack.UndoSize() == 2u);
+	}
+}
+
+int main()
+{
+	Test_ExecuteOrder_UndoReverse();
+	Test_MemoryFootprintAggregates();
+	Test_CommandStackSingleStep();
+	Test_NoCoalescingBetweenGestures();
+
+	if (g_failed == 0)
+	{
+		std::printf("[PASS] CompositeCommandTests\n");
+		return 0;
+	}
+	std::printf("[FAIL] CompositeCommandTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/src/world_editor/tests/EditorSelectionTests.cpp
+++ b/src/world_editor/tests/EditorSelectionTests.cpp
@@ -52,11 +52,63 @@ namespace
 		sel.Clear();
 		REQUIRE(calls == 3);
 	}
+
+	/// Roadmap-6 — Multi-sélection : Toggle ajoute/retire, Current = dernière
+	/// sélectionnée (primaire), Contains/Count/Items cohérents, Select remplace
+	/// toute la sélection.
+	void Test_MultiSelectionToggle()
+	{
+		EditorSelection sel;
+		int calls = 0;
+		EntityId lastPrimary{};
+		sel.SetOnChanged([&](EntityId id) { ++calls; lastPrimary = id; });
+
+		const EntityId a{EntityKind::LayoutInstance, 1};
+		const EntityId b{EntityKind::LayoutInstance, 2};
+		const EntityId c{EntityKind::MeshInsert, 0};
+
+		sel.Select(a);
+		REQUIRE(calls == 1);
+		sel.Toggle(b); // ajout : b devient primaire
+		REQUIRE(calls == 2);
+		REQUIRE(sel.Count() == 2u);
+		REQUIRE(sel.Current() == b);
+		REQUIRE(lastPrimary == b);
+		REQUIRE(sel.Contains(a) && sel.Contains(b) && !sel.Contains(c));
+
+		sel.Toggle(c); // ajout : c primaire, 3 au total
+		REQUIRE(sel.Count() == 3u);
+		REQUIRE(sel.Current() == c);
+		REQUIRE(sel.Items().size() == 3u);
+		REQUIRE(sel.Items().front() == a);
+
+		sel.Toggle(c); // retrait : la primaire redevient b
+		REQUIRE(sel.Count() == 2u);
+		REQUIRE(sel.Current() == b);
+		REQUIRE(!sel.Contains(c));
+
+		// Select remplace TOUTE la sélection par {c}.
+		sel.Select(c);
+		REQUIRE(sel.Count() == 1u);
+		REQUIRE(sel.Current() == c);
+		REQUIRE(!sel.Contains(a) && !sel.Contains(b));
+
+		// Toggle d'un kind None : no-op sans notification.
+		const int before = calls;
+		sel.Toggle(EntityId{});
+		REQUIRE(calls == before);
+
+		// Select d'un kind None ≡ Clear.
+		sel.Select(EntityId{});
+		REQUIRE(!sel.HasSelection());
+		REQUIRE(sel.Count() == 0u);
+	}
 }
 
 int main()
 {
 	Test_SelectionNotifiesOnChange();
+	Test_MultiSelectionToggle();
 
 	if (g_failed == 0)
 	{

--- a/src/world_editor/tests/LayoutPlacementCommandsTests.cpp
+++ b/src/world_editor/tests/LayoutPlacementCommandsTests.cpp
@@ -1,0 +1,145 @@
+/// Roadmap-6 (2026-07-19) — Tests unitaires CPU des commandes de placement/
+/// déplacement d'instances de layout (PlaceLayoutInstanceCommand /
+/// MoveLayoutInstanceCommand). Les foncteurs LayoutPlacementOps sont mockés
+/// sur un simple vecteur en RAM (adressage par guid, comme la session).
+/// Pur CPU (aucune dépendance ImGui/Vulkan), tourne sous ctest Linux.
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/scene/LayoutPlacementCommands.h"
+
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	using engine::editor::WorldMapEditLayoutInstance;
+	using engine::editor::scene::LayoutPlacementOps;
+	using engine::editor::scene::MoveLayoutInstanceCommand;
+	using engine::editor::scene::PlaceLayoutInstanceCommand;
+	using engine::editor::world::CommandStack;
+
+	/// Fabrique les foncteurs mock sur un vecteur d'instances (même sémantique
+	/// que WorldEditorSession : add en fin, remove/setPosition par guid).
+	LayoutPlacementOps MakeOps(std::vector<WorldMapEditLayoutInstance>* doc)
+	{
+		LayoutPlacementOps ops;
+		ops.add = [doc](const WorldMapEditLayoutInstance& inst) -> bool
+		{
+			doc->push_back(inst);
+			return true;
+		};
+		ops.removeByGuid = [doc](const std::string& guid) -> bool
+		{
+			for (size_t i = 0; i < doc->size(); ++i)
+			{
+				if ((*doc)[i].guid == guid)
+				{
+					doc->erase(doc->begin() + static_cast<std::ptrdiff_t>(i));
+					return true;
+				}
+			}
+			return false;
+		};
+		ops.setPositionByGuid = [doc](const std::string& guid, double x, double y, double z) -> bool
+		{
+			for (WorldMapEditLayoutInstance& inst : *doc)
+			{
+				if (inst.guid == guid)
+				{
+					inst.worldX = x; inst.worldY = y; inst.worldZ = z;
+					return true;
+				}
+			}
+			return false;
+		};
+		REQUIRE(ops.IsInstalled());
+		return ops;
+	}
+
+	/// Placement : Execute ajoute (guid conservé), Undo retire, Redo ré-ajoute
+	/// avec le MÊME guid.
+	void Test_PlaceUndoRedo()
+	{
+		std::vector<WorldMapEditLayoutInstance> doc;
+		WorldMapEditLayoutInstance inst{};
+		inst.guid = "inst-4242";
+		inst.worldX = 10.0; inst.worldY = 1.0; inst.worldZ = -3.0;
+		inst.speciesId = "chene";
+
+		CommandStack stack;
+		stack.Push(std::make_unique<PlaceLayoutInstanceCommand>(inst, MakeOps(&doc)));
+		REQUIRE(doc.size() == 1u);
+		REQUIRE(doc[0].guid == "inst-4242");
+		REQUIRE(doc[0].speciesId == "chene");
+
+		stack.Undo();
+		REQUIRE(doc.empty());
+
+		stack.Redo();
+		REQUIRE(doc.size() == 1u);
+		REQUIRE(doc[0].guid == "inst-4242"); // guid stable au Redo
+	}
+
+	/// Déplacement : Execute écrit la nouvelle position, Undo restaure
+	/// l'ancienne — par guid, insensible à l'ordre du vecteur.
+	void Test_MoveUndoRedo()
+	{
+		std::vector<WorldMapEditLayoutInstance> doc(2);
+		doc[0].guid = "a"; doc[0].worldX = 0.0; doc[0].worldY = 0.0; doc[0].worldZ = 0.0;
+		doc[1].guid = "b"; doc[1].worldX = 5.0; doc[1].worldY = 1.0; doc[1].worldZ = 5.0;
+
+		CommandStack stack;
+		stack.Push(std::make_unique<MoveLayoutInstanceCommand>(
+			"b", /*old*/ 5.0, 1.0, 5.0, /*new*/ 8.0, 2.0, -1.0, MakeOps(&doc)));
+		REQUIRE(doc[1].worldX == 8.0 && doc[1].worldY == 2.0 && doc[1].worldZ == -1.0);
+		REQUIRE(doc[0].worldX == 0.0); // l'autre instance n'est pas touchée
+
+		stack.Undo();
+		REQUIRE(doc[1].worldX == 5.0 && doc[1].worldY == 1.0 && doc[1].worldZ == 5.0);
+
+		stack.Redo();
+		REQUIRE(doc[1].worldX == 8.0);
+	}
+
+	/// Undo d'un placement dont l'instance a déjà disparu (suppression
+	/// concurrente) : no-op propre, pas de crash.
+	void Test_UndoAfterExternalRemoval()
+	{
+		std::vector<WorldMapEditLayoutInstance> doc;
+		WorldMapEditLayoutInstance inst{};
+		inst.guid = "inst-7";
+
+		CommandStack stack;
+		stack.Push(std::make_unique<PlaceLayoutInstanceCommand>(inst, MakeOps(&doc)));
+		REQUIRE(doc.size() == 1u);
+		doc.clear(); // suppression externe (hors commande)
+		stack.Undo(); // removeByGuid retourne false : pas de crash
+		REQUIRE(doc.empty());
+	}
+}
+
+int main()
+{
+	Test_PlaceUndoRedo();
+	Test_MoveUndoRedo();
+	Test_UndoAfterExternalRemoval();
+
+	if (g_failed == 0)
+	{
+		std::printf("[PASS] LayoutPlacementCommandsTests\n");
+		return 0;
+	}
+	std::printf("[FAIL] LayoutPlacementCommandsTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/src/world_editor/ui/WorldEditorSession.cpp
+++ b/src/world_editor/ui/WorldEditorSession.cpp
@@ -199,6 +199,21 @@ namespace engine::editor
 			SetStatus("Instance deplacee.");
 			return;
 		}
+		// Roadmap-6 : la construction est factorisée (réutilisée par le chemin
+		// undoable côté Engine) ; ce chemin direct reste pour compat/tests.
+		WorldMapEditLayoutInstance inst{};
+		if (!BuildLayoutInstanceForPlacement(cfg, worldX, worldY, worldZ, inst))
+		{
+			return;
+		}
+		(void)AddLayoutInstance(inst);
+	}
+
+	bool WorldEditorSession::BuildLayoutInstanceForPlacement(const engine::core::Config& cfg,
+		double worldX, double worldY, double worldZ,
+		WorldMapEditLayoutInstance& out)
+	{
+		EnsureTreeCatalogLoaded(cfg);
 		const int kind = std::clamp(m_instancePlacementKind, 0, 1);
 		WorldMapEditLayoutInstance inst{};
 		inst.guid = NewLayoutInstanceGuid();
@@ -214,7 +229,7 @@ namespace engine::editor
 			if (m_treeCatalog.Species().empty())
 			{
 				SetStatus("Aucune espece d'arbre valide (catalogue absent ou sans 2+ glTF par espece). Utilisez 'Rocher' ou corrigez le JSON.");
-				return;
+				return false;
 			}
 			const int si = std::clamp(m_treeSpeciesUiIndex, 0, static_cast<int>(m_treeCatalog.Species().size()) - 1);
 			const TreeSpeciesSpec& sp = m_treeCatalog.Species()[static_cast<size_t>(si)];
@@ -239,8 +254,43 @@ namespace engine::editor
 		inst.worldX = worldX;
 		inst.worldY = worldY;
 		inst.worldZ = worldZ;
-		m_doc.layoutInstances.push_back(std::move(inst));
-		SetStatus(kind == 1 ? "Rocher place." : "Arbre place.");
+		out = std::move(inst);
+		return true;
+	}
+
+	bool WorldEditorSession::AddLayoutInstance(const WorldMapEditLayoutInstance& inst)
+	{
+		m_doc.layoutInstances.push_back(inst);
+		SetStatus(inst.speciesId.empty() ? "Rocher place." : "Arbre place.");
+		return true;
+	}
+
+	bool WorldEditorSession::RemoveLayoutInstanceByGuid(const std::string& guid)
+	{
+		for (size_t i = 0; i < m_doc.layoutInstances.size(); ++i)
+		{
+			if (m_doc.layoutInstances[i].guid == guid)
+			{
+				RemoveLayoutInstance(i); // recale aussi m_selectedLayoutInstance
+				return true;
+			}
+		}
+		return false;
+	}
+
+	bool WorldEditorSession::SetLayoutInstancePositionByGuid(const std::string& guid, double worldX, double worldY, double worldZ)
+	{
+		for (WorldMapEditLayoutInstance& inst : m_doc.layoutInstances)
+		{
+			if (inst.guid == guid)
+			{
+				inst.worldX = worldX;
+				inst.worldY = worldY;
+				inst.worldZ = worldZ;
+				return true;
+			}
+		}
+		return false;
 	}
 
 	void WorldEditorSession::RemoveLayoutInstance(size_t index)

--- a/src/world_editor/ui/WorldEditorSession.h
+++ b/src/world_editor/ui/WorldEditorSession.h
@@ -88,8 +88,36 @@ namespace engine::editor
 		[[nodiscard]] bool ConsumeRouteApplyDraftRequest();
 
 		/// Place une nouvelle instance ou deplace celle selectionnee (coords monde, Y au sol).
+		/// Chemin DIRECT (non-undoable), conservé pour compat/tests — le clic
+		/// viewport passe désormais par les commandes Roadmap-6 ci-dessous.
 		void PlaceOrMoveLayoutInstanceAtTerrainHit(const engine::core::Config& cfg, double worldX, double worldY, double worldZ);
 		void RemoveLayoutInstance(size_t index);
+
+		/// Roadmap-6 (2026-07-19) — Construit (SANS l'ajouter au document)
+		/// l'instance qui serait posée au point de sol donné, selon le mode de
+		/// placement courant (rocher / arbre + espèce + échelle aléatoire).
+		/// Le guid est généré ici (stable, conservé par le Redo de la commande).
+		/// \param worldX,worldY,worldZ coordonnées monde (mètres, Y au sol).
+		/// \return false si aucune espèce d'arbre valide (statut renseigné).
+		/// Effet de bord : charge le catalogue d'arbres au 1er appel + SetStatus.
+		bool BuildLayoutInstanceForPlacement(const engine::core::Config& cfg,
+			double worldX, double worldY, double worldZ,
+			WorldMapEditLayoutInstance& out);
+
+		/// Roadmap-6 — Ajoute une instance déjà construite en fin de document
+		/// (guid conservé). Consommé par `PlaceLayoutInstanceCommand::Execute`.
+		/// Effet de bord : SetStatus (« Rocher place. » / « Arbre place. »).
+		bool AddLayoutInstance(const WorldMapEditLayoutInstance& inst);
+
+		/// Roadmap-6 — Retire l'instance de guid donné (recalage de la
+		/// sélection liste comme `RemoveLayoutInstance`). \return false si
+		/// le guid est introuvable. Consommé par les Undo/Redo des commandes.
+		bool RemoveLayoutInstanceByGuid(const std::string& guid);
+
+		/// Roadmap-6 — Écrit la position monde (mètres) de l'instance de guid
+		/// donné. \return false si le guid est introuvable. Consommé par
+		/// `MoveLayoutInstanceCommand` (Execute ET Undo).
+		bool SetLayoutInstancePositionByGuid(const std::string& guid, double worldX, double worldY, double worldZ);
 
 		/// Appele avant l'ecriture du JSON d'edition pour persister heightmap / splat sur disque (Vulkan).
 		void SetTerrainSaveHook(std::function<bool(const engine::core::Config&, const WorldMapEditDocument&)> hook);


### PR DESCRIPTION
## Objectif (roadmap 2026-07-19, chantier 6)

Trois manques combles dans l'editeur monde : pas de gizmo pour les entites de scene (seules les pieces de batiment en avaient un), selection mono-entite, et placement de props non-undoable (push_back direct).

## Multi-selection
- `EditorSelection` : liste ordonnee sans doublon, **primaire = derniere selectionnee** (`Current()` compatible avec tous les consommateurs existants — Outliner, Inspector).
- Viewport : **Ctrl+clic** selectionne, **Ctrl+Maj+clic** bascule dans la selection, Ctrl+clic dans le vide vide la selection.
- **Ctrl+D / Suppr operent sur toute la selection** via la nouvelle `CompositeCommand` (un geste = UNE etape d'annulation ; suppressions ordonnees par index decroissant par kind pour que la capture des commandes suivantes reste valide).

## Gizmo viewport (entites de scene)
- Modes commutables **E = deplacer** (axes X/Y/Z monde), **T = tourner** (anneau yaw), **C = echelle uniforme** — W reste la camera, R reste l'outil riviere. Actions `tool.gizmo-*` au registre (menus, palette Ctrl+P, fenetre Raccourcis).
- Le drag s'applique a **toutes** les entites selectionnees (via le `TransformWriter` existant) ; au relachement, une `SetEntityTransformCommand` par entite, enveloppees en `CompositeCommand` (deux drags successifs ne fusionnent jamais).
- Marqueurs magenta sur chaque entite selectionnee + lecteur de valeurs (pos/yaw/echelle + taille de selection). Rendu en BackgroundDrawList, meme projection que le gizmo batiment (pas de Y-flip). No-op en mode edition batiment (pas de double gizmo).

## Placement undoable
- Le clic de pose/deplacement d'instance (mode placement) pousse desormais `PlaceLayoutInstanceCommand` / `MoveLayoutInstanceCommand` sur la pile du shell — adressage par **guid stable** (jamais d'index), Redo conserve le guid.
- `WorldEditorSession::BuildLayoutInstanceForPlacement` factorise la construction (espece/echelle aleatoire) sans mutation ; chemin direct conserve en fallback sans shell.

## Tests (ctest, purs CPU)
- `composite_command_tests` : ordre Execute / Undo inverse, une seule etape d'historique, pas de coalescing entre gestes.
- `layout_placement_commands_tests` : place/undo/redo (guid stable), move/undo, undo apres suppression externe.
- `editor_selection_tests` etendu : Toggle/Contains/Count/primaire, Select-remplace, None.

## Validation en jeu (editeur)
1. Ctrl+clic un arbre → gizmo ; E : tirer un axe → il bouge ; Ctrl+Z → retour.
2. Ctrl+Maj+clic un 2e arbre → 2 anneaux magenta ; drag → les deux bougent ; Ctrl+Z → les deux reviennent.
3. T : anneau → rotation ; C : poignee → echelle ; Ctrl+Z apres chaque geste.
4. Ctrl+D / Suppr avec 2 entites selectionnees → 2 copies / 2 suppressions, UN seul Ctrl+Z.
5. Mode placement : poser un arbre → Ctrl+Z le retire ; deplacer une instance selectionnee → Ctrl+Z la remet.

**Deploiement** : ✅ client uniquement (editeur monde), pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)