### PR TITLE
feat(server): synchro guilde master vers shard - partage du gateau a la guilde

### DIFF
--- a/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
+++ b/src/masterd/handlers/character/CharacterEnterWorldHandler.cpp
@@ -155,6 +155,26 @@ namespace engine::server
 			}
 		}
 
+		// Roadmap-7 (2026-07-19) — guilde du compte pour le push d'admission au
+		// shard (partage du buff gâteau à la guilde, dette #991). SELECT direct
+		// sur guild_members_v2 (un compte = au plus une guilde, clé composite) :
+		// évite de coupler ce handler au GuildHandler (construit APRÈS lui dans
+		// main_linux.cpp — piège d'ordre de déclaration). Tolérant : guilde
+		// indéterminée → 0 (sans guilde), le shard n'étend pas le partage.
+		uint64_t guildId = 0;
+		if (stmtCache)
+		{
+			auto* guildStmt = stmtCache->Acquire(mysql,
+				"SELECT guild_id FROM guild_members_v2 WHERE account_id = ? LIMIT 1");
+			if (guildStmt
+				&& guildStmt->Bind(0, *accountId)
+				&& guildStmt->Execute()
+				&& guildStmt->FetchRow())
+			{
+				guildId = guildStmt->GetUInt64(0);
+			}
+		}
+
 		// Tout est validé : on enregistre le mapping pour le chat.
 		const std::string normalized = SessionCharacterMap::Normalize(parsed->characterName);
 		m_charMap->Set(connId, *accountId, parsed->characterId, parsed->characterName, normalized, accountRole);
@@ -176,12 +196,15 @@ namespace engine::server
 				// TD.6 — on embarque aussi le genre (cf. migration 0067) pour permettre au
 				// client de sélectionner le bon mesh skinné (Male_Ranger vs Female_Ranger)
 				// pour les avatars distants.
+				// Roadmap-7 — on embarque aussi la guilde du compte (guild_members_v2,
+				// 0 = sans guilde) pour que le shard connaisse l'appartenance des
+				// joueurs connectés (partage du buff gâteau à la guilde).
 				auto admitPkt = engine::network::BuildAdmitCharacterPacket(*accountId, parsed->characterId,
-					parsed->characterName, dbGender);
+					parsed->characterName, dbGender, guildId);
 				if (!admitPkt.empty() && m_server->Send(*shardConnId, admitPkt))
 				{
-					LOG_INFO(Net, "[CharacterEnterWorldHandler] admit push sent (shard_id={}, shardConnId={}, account_id={}, character_id={})",
-						dbServerId, *shardConnId, *accountId, parsed->characterId);
+					LOG_INFO(Net, "[CharacterEnterWorldHandler] admit push sent (shard_id={}, shardConnId={}, account_id={}, character_id={}, guild_id={})",
+						dbServerId, *shardConnId, *accountId, parsed->characterId, guildId);
 				}
 				else
 				{

--- a/src/shardd/main_linux.cpp
+++ b/src/shardd/main_linux.cpp
@@ -210,13 +210,15 @@ int main(int argc, char** argv)
 	// ce câblage, le Hello UDP du client (clientNonce=character_id) serait rejeté car le
 	// ticket TCP avait été émis avant le choix de perso (character_id=0 → non admis).
 	toMaster.SetAdmitCharacterCallback([&admittedRegistry](uint64_t account_id, uint64_t character_id,
-		std::string_view character_name, std::string_view gender) {
+		std::string_view character_name, std::string_view gender, uint64_t guild_id) {
 		const std::uint64_t nowMs = static_cast<std::uint64_t>(
 			std::chrono::duration_cast<std::chrono::milliseconds>(
 				std::chrono::steady_clock::now().time_since_epoch()).count());
-		admittedRegistry.Admit(character_id, account_id, character_name, gender, nowMs);
-		LOG_INFO(Net, "[ShardMain] Admit pushed by master (account_id={}, character_id={}, name='{}', gender='{}', nowMs={})",
-			account_id, character_id, character_name, gender, nowMs);
+		// Roadmap-7 — la guilde du compte transite dans le push d'admission
+		// (0 = sans guilde) ; consommée au Hello pour ConnectedClient.guildId.
+		admittedRegistry.Admit(character_id, account_id, character_name, gender, guild_id, nowMs);
+		LOG_INFO(Net, "[ShardMain] Admit pushed by master (account_id={}, character_id={}, name='{}', gender='{}', guild_id={}, nowMs={})",
+			account_id, character_id, character_name, gender, guild_id, nowMs);
 	});
 	toMaster.Start();
 	// TA.3 : boucle gameplay UDP (ServerApp) sur un thread dedie, gated par admittedRegistry.

--- a/src/shardd/world/AdmittedCharacterRegistry.cpp
+++ b/src/shardd/world/AdmittedCharacterRegistry.cpp
@@ -3,7 +3,7 @@
 namespace engine::server
 {
 	void AdmittedCharacterRegistry::Admit(uint64_t characterId, uint64_t accountId,
-		std::string_view characterName, std::string_view gender, uint64_t nowMs)
+		std::string_view characterName, std::string_view gender, uint64_t guildId, uint64_t nowMs)
 	{
 		if (characterId == 0u)
 		{
@@ -22,6 +22,13 @@ namespace engine::server
 		if (!gender.empty())
 		{
 			entry.gender.assign(gender);
+		}
+		// Roadmap-7 — même règle de préservation : une admission sans guilde
+		// (ticket TCP, master legacy) ne doit pas écraser la guilde poussée par
+		// un EnterWorld antérieur.
+		if (guildId != 0u)
+		{
+			entry.guildId = guildId;
 		}
 	}
 
@@ -89,6 +96,21 @@ namespace engine::server
 			return {};
 		}
 		return it->second.gender;
+	}
+
+	uint64_t AdmittedCharacterRegistry::AdmittedGuildId(uint64_t characterId, uint64_t nowMs) const
+	{
+		if (characterId == 0u)
+		{
+			return 0u;
+		}
+		std::lock_guard<std::mutex> lock(m_mutex);
+		const auto it = m_admitted.find(characterId);
+		if (it == m_admitted.end() || (nowMs - it->second.admittedAtMs) > m_ttlMs)
+		{
+			return 0u;
+		}
+		return it->second.guildId;
 	}
 
 	size_t AdmittedCharacterRegistry::Count() const

--- a/src/shardd/world/AdmittedCharacterRegistry.h
+++ b/src/shardd/world/AdmittedCharacterRegistry.h
@@ -36,19 +36,30 @@ namespace engine::server
 		/// \param gender TD.6 — genre du personnage ("male"/"female", cf. migration 0067) ;
 		///        peut être vide si master legacy. Propagé au client via SnapshotEntity pour
 		///        sélectionner le mesh skinné des avatars distants.
+		/// \param guildId Roadmap-7 — guilde du compte (guild_members_v2 côté master) ;
+		///        0 = sans guilde ou master antérieur à l'extension. Consommé par
+		///        `ServerApp::HandleHello` pour remplir `ConnectedClient.guildId`
+		///        (partage du buff gâteau à la guilde, dette #991).
 		void Admit(uint64_t characterId, uint64_t accountId, std::string_view characterName,
-			std::string_view gender, uint64_t nowMs);
+			std::string_view gender, uint64_t guildId, uint64_t nowMs);
 
-		/// Surcharge legacy (sans nom ni genre) — équivalente à Admit(..., "", "", nowMs).
-		void Admit(uint64_t characterId, uint64_t accountId, uint64_t nowMs)
+		/// Surcharge legacy (sans guilde) — équivalente à Admit(..., gender, 0, nowMs).
+		void Admit(uint64_t characterId, uint64_t accountId, std::string_view characterName,
+			std::string_view gender, uint64_t nowMs)
 		{
-			Admit(characterId, accountId, std::string_view{}, std::string_view{}, nowMs);
+			Admit(characterId, accountId, characterName, gender, 0u, nowMs);
 		}
 
-		/// Surcharge legacy (sans genre) — équivalente à Admit(..., name, "", nowMs).
+		/// Surcharge legacy (sans nom ni genre) — équivalente à Admit(..., "", "", 0, nowMs).
+		void Admit(uint64_t characterId, uint64_t accountId, uint64_t nowMs)
+		{
+			Admit(characterId, accountId, std::string_view{}, std::string_view{}, 0u, nowMs);
+		}
+
+		/// Surcharge legacy (sans genre) — équivalente à Admit(..., name, "", 0, nowMs).
 		void Admit(uint64_t characterId, uint64_t accountId, std::string_view characterName, uint64_t nowMs)
 		{
-			Admit(characterId, accountId, characterName, std::string_view{}, nowMs);
+			Admit(characterId, accountId, characterName, std::string_view{}, 0u, nowMs);
 		}
 
 		/// Retire un personnage (ex. déconnexion). No-op si absent.
@@ -71,6 +82,11 @@ namespace engine::server
 		/// locale n'est pas configurée (et propagé au client via SnapshotEntity).
 		std::string AdmittedGender(uint64_t characterId, uint64_t nowMs) const;
 
+		/// Roadmap-7 — guilde du personnage admis et non expiré, 0 sinon (ou si le
+		/// master n'avait pas fourni de guilde). Utilisé par `ServerApp::HandleHello`
+		/// pour remplir `ConnectedClient.guildId`.
+		uint64_t AdmittedGuildId(uint64_t characterId, uint64_t nowMs) const;
+
 		/// Nombre d'entrées (admises ou non, sans purge). Utile aux tests / diagnostics.
 		size_t Count() const;
 
@@ -85,6 +101,7 @@ namespace engine::server
 			uint64_t admittedAtMs = 0;
 			std::string characterName; ///< TD.5 — peut être vide (admission sans nom).
 			std::string gender;        ///< TD.6 — peut être vide (admission sans genre).
+			uint64_t guildId = 0;      ///< Roadmap-7 — 0 = sans guilde / master legacy.
 		};
 
 		mutable std::mutex m_mutex;

--- a/src/shardd/world/AdmittedCharacterRegistryTests.cpp
+++ b/src/shardd/world/AdmittedCharacterRegistryTests.cpp
@@ -132,6 +132,35 @@ namespace
 		assert(reg.AdmittedGender(40u, 1000u) == "female");
 		std::puts("[OK] TestReAdmitWithoutGenderPreservesGender");
 	}
+
+	/// Roadmap-7 — Admit avec guilde retourne ce guildId ; surcharges legacy
+	/// (sans guilde) retournent 0 ; TTL et character_id inconnu → 0.
+	void TestAdmitWithGuild()
+	{
+		AdmittedCharacterRegistry reg;
+		reg.SetTtlMs(1000u);
+		reg.Admit(50u, 1u, std::string_view{"homme"}, std::string_view{"male"}, 7u, 100u);
+		assert(reg.AdmittedGuildId(50u, 100u) == 7u);
+		// Surcharge legacy (nom+genre sans guilde) => 0.
+		reg.Admit(51u, 1u, std::string_view{"anon"}, std::string_view{"male"}, 100u);
+		assert(reg.AdmittedGuildId(51u, 100u) == 0u);
+		// character_id inconnu ou expiré => 0.
+		assert(reg.AdmittedGuildId(999u, 100u) == 0u);
+		assert(reg.AdmittedGuildId(50u, 100u + 5000u) == 0u); // TTL dépassé
+		std::puts("[OK] TestAdmitWithGuild");
+	}
+
+	/// Roadmap-7 — un re-Admit sans guilde (ticket TCP, master legacy) après un
+	/// Admit avec guilde PRÉSERVE la guilde (même règle que nom/genre).
+	void TestReAdmitWithoutGuildPreservesGuild()
+	{
+		AdmittedCharacterRegistry reg;
+		reg.Admit(60u, 7u, std::string_view{"femme"}, std::string_view{"female"}, 3u, 0u);
+		assert(reg.AdmittedGuildId(60u, 0u) == 3u);
+		reg.Admit(60u, 7u, std::string_view{"femme"}, std::string_view{"female"}, 1000u); // sans guilde
+		assert(reg.AdmittedGuildId(60u, 1000u) == 3u);
+		std::puts("[OK] TestReAdmitWithoutGuildPreservesGuild");
+	}
 }
 
 int main()
@@ -145,6 +174,8 @@ int main()
 	TestReAdmitWithoutNamePreservesName();
 	TestAdmitWithGender();
 	TestReAdmitWithoutGenderPreservesGender();
+	TestAdmitWithGuild();
+	TestReAdmitWithoutGuildPreservesGuild();
 	std::puts("All AdmittedCharacterRegistry tests passed");
 	return 0;
 }

--- a/src/shared/network/ShardPayloads.cpp
+++ b/src/shared/network/ShardPayloads.cpp
@@ -160,11 +160,19 @@ namespace engine::network
 			if (!r.ReadString(out.gender))
 				return std::nullopt;
 		}
+		// Roadmap-7 — guild_id optionnel EN QUEUE (après gender, ne jamais insérer
+		// avant les champs optionnels existants) : un master ancien ne l'émet pas
+		// → 0 (sans guilde), repli propre côté shard (pas de partage guilde).
+		if (r.Remaining() > 0u)
+		{
+			if (!r.ReadU64(out.guild_id))
+				return std::nullopt;
+		}
 		return out;
 	}
 
 	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id,
-		std::string_view character_name, std::string_view gender)
+		std::string_view character_name, std::string_view gender, uint64_t guild_id)
 	{
 		PacketBuilder builder;
 		ByteWriter w = builder.PayloadWriter();
@@ -173,6 +181,9 @@ namespace engine::network
 		if (!w.WriteString(character_name))
 			return {};
 		if (!w.WriteString(gender))
+			return {};
+		// Roadmap-7 — guilde du compte, champ additif en queue (cf. Parse).
+		if (!w.WriteU64(guild_id))
 			return {};
 		const size_t payloadBytes = w.Offset();
 		// Push master→shard, pas de request_id ni session.

--- a/src/shared/network/ShardPayloads.h
+++ b/src/shared/network/ShardPayloads.h
@@ -100,6 +100,12 @@ namespace engine::network
 		uint64_t character_id = 0;
 		std::string character_name;
 		std::string gender;
+		/// Roadmap-7 (2026-07-19) — guilde du compte (table guild_members_v2 côté
+		/// master, un compte = au plus une guilde). 0 = sans guilde OU master
+		/// antérieur à cette extension (champ optionnel en queue, cf. Parse).
+		/// Permet au shard (y compris no-DB) de connaître l'appartenance de
+		/// guilde des joueurs connectés (ex. partage du buff gâteau, dette #991).
+		uint64_t guild_id = 0;
 	};
 
 	/// Parses MASTER_TO_SHARD_ADMIT_CHARACTER payload. Returns nullopt if truncated.
@@ -109,6 +115,8 @@ namespace engine::network
 	/// \param character_name nom du personnage (table SQL characters.name) ; sera tronqué
 	///        à 32 caractères côté master avant l'appel (cohérent avec la contrainte SQL).
 	/// \param gender genre du personnage ("male"/"female", cf. migration 0067).
+	/// \param guild_id Roadmap-7 — guilde du compte (0 = sans guilde). Champ ADDITIF en
+	///        queue de payload : un shard ancien l'ignore, un master ancien ne l'émet pas.
 	std::vector<uint8_t> BuildAdmitCharacterPacket(uint64_t account_id, uint64_t character_id,
-		std::string_view character_name, std::string_view gender);
+		std::string_view character_name, std::string_view gender, uint64_t guild_id = 0);
 }

--- a/src/shared/network/ShardPayloadsTests.cpp
+++ b/src/shared/network/ShardPayloadsTests.cpp
@@ -9,9 +9,12 @@
  */
 
 #include "src/shared/network/ShardPayloads.h"
+#include "src/shared/network/PacketView.h"
 
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
+#include <vector>
 
 using engine::network::ShardPlayerPresence;
 using engine::network::BuildShardHeartbeatPayload;
@@ -81,11 +84,62 @@ static void TestHeartbeatTruncatedRejected()
 	Assert(!parsed.has_value(), "payload tronqué rejeté (nullopt)");
 }
 
+// Roadmap-7 (2026-07-19) — round-trip complet du push d'admission avec guilde :
+// Build (paquet entier) → PacketView (extraction payload) → Parse.
+static void TestAdmitCharacterRoundTripWithGuild()
+{
+	auto pkt = engine::network::BuildAdmitCharacterPacket(42ull, 1337ull, "Aria", "female", 7ull);
+	Assert(!pkt.empty(), "admit: build OK");
+	engine::network::PacketView view;
+	Assert(engine::network::PacketView::Parse(pkt.data(), pkt.size(), view)
+		== engine::network::PacketParseResult::Ok, "admit: paquet parsable");
+	auto parsed = engine::network::ParseAdmitCharacterPayload(view.Payload(), view.PayloadSize());
+	Assert(parsed.has_value(), "admit: parse payload OK");
+	if (parsed)
+	{
+		Assert(parsed->account_id == 42ull, "admit: account_id round-trip");
+		Assert(parsed->character_id == 1337ull, "admit: character_id round-trip");
+		Assert(parsed->character_name == "Aria", "admit: name round-trip");
+		Assert(parsed->gender == "female", "admit: gender round-trip");
+		Assert(parsed->guild_id == 7ull, "admit: guild_id round-trip");
+	}
+}
+
+// Roadmap-7 — compat master ANCIEN (sans guild_id) : payload amputé de ses 8
+// derniers octets (le u64 guild_id de queue) → parse OK, guild_id = 0.
+static void TestAdmitCharacterLegacyWithoutGuild()
+{
+	auto pkt = engine::network::BuildAdmitCharacterPacket(42ull, 1337ull, "Aria", "male", 9ull);
+	engine::network::PacketView view;
+	Assert(engine::network::PacketView::Parse(pkt.data(), pkt.size(), view)
+		== engine::network::PacketParseResult::Ok, "admit legacy: paquet parsable");
+	std::vector<uint8_t> legacyPayload(view.Payload(), view.Payload() + view.PayloadSize() - 8u);
+	auto parsed = engine::network::ParseAdmitCharacterPayload(legacyPayload.data(), legacyPayload.size());
+	Assert(parsed.has_value(), "admit legacy: parse OK sans guild_id");
+	if (parsed)
+	{
+		Assert(parsed->character_name == "Aria", "admit legacy: name intact");
+		Assert(parsed->gender == "male", "admit legacy: gender intact");
+		Assert(parsed->guild_id == 0ull, "admit legacy: guild_id retombe a 0");
+	}
+	// Payload minimal 16 octets (master TA.3 d'origine : ni nom, ni genre, ni guilde).
+	std::vector<uint8_t> minimal(16u, 0u);
+	auto parsedMin = engine::network::ParseAdmitCharacterPayload(minimal.data(), minimal.size());
+	Assert(parsedMin.has_value(), "admit legacy: payload 16 octets parse OK");
+	if (parsedMin)
+	{
+		Assert(parsedMin->character_name.empty() && parsedMin->gender.empty()
+			&& parsedMin->guild_id == 0ull, "admit legacy 16o: champs optionnels par defaut");
+	}
+}
+
 int main()
 {
 	TestHeartbeatLegacyNoPlayers();
 	TestHeartbeatWithPlayers();
 	TestHeartbeatTruncatedRejected();
+	TestAdmitCharacterRoundTripWithGuild();
+	TestAdmitCharacterLegacyWithoutGuild();
 	std::cerr << (s_failCount == 0 ? "[OK] all shard_payloads tests passed\n" : "[FAIL] some tests failed\n");
 	return s_failCount == 0 ? 0 : 1;
 }

--- a/src/shared/network/ShardToMasterClient.cpp
+++ b/src/shared/network/ShardToMasterClient.cpp
@@ -238,9 +238,10 @@ LOG_DEBUG(Net, "[STMC] SendRegister name='{}' display='{}' endpoint='{}' cap={} 
 					parsed->account_id, parsed->character_id);
 				return;
 			}
-			LOG_INFO(Core, "[ShardToMasterClient] AdmitCharacter received (account_id={}, character_id={}, name='{}', gender='{}')",
-				parsed->account_id, parsed->character_id, parsed->character_name, parsed->gender);
-			m_admit_callback(parsed->account_id, parsed->character_id, parsed->character_name, parsed->gender);
+			LOG_INFO(Core, "[ShardToMasterClient] AdmitCharacter received (account_id={}, character_id={}, name='{}', gender='{}', guild_id={})",
+				parsed->account_id, parsed->character_id, parsed->character_name, parsed->gender, parsed->guild_id);
+			m_admit_callback(parsed->account_id, parsed->character_id, parsed->character_name, parsed->gender,
+				parsed->guild_id);
 		}
 	}
 

--- a/src/shared/network/ShardToMasterClient.h
+++ b/src/shared/network/ShardToMasterClient.h
@@ -74,9 +74,12 @@ namespace engine::network
 		/// pour alimenter les plaques de nom côté client ; peut être vide (master legacy).
 		/// TD.6 — `gender` ("male"/"female", cf. migration 0067) permet au client de choisir
 		/// le mesh skinné des avatars distants ; peut être vide (master sans migration 0067).
+		/// Roadmap-7 — `guild_id` : guilde du compte (guild_members_v2 côté master), 0 si
+		/// sans guilde ou master antérieur à l'extension. Consommé par le shard pour le
+		/// partage de buffs à la guilde (gâteau, dette #991).
 		/// `nullptr` (défaut) = drop silencieux.
 		using AdmitCharacterCallback = std::function<void(uint64_t account_id, uint64_t character_id,
-			std::string_view character_name, std::string_view gender)>;
+			std::string_view character_name, std::string_view gender, uint64_t guild_id)>;
 		void SetAdmitCharacterCallback(AdmitCharacterCallback cb) { m_admit_callback = std::move(cb); }
 
 		enum class State

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -1516,6 +1516,10 @@ namespace engine::server
 				// Présence unifiée : résout le compte propriétaire (clé de ShardPresenceService).
 				acceptedClient.accountId = m_admittedRegistry->AdmittedAccountId(
 					acceptedClient.persistenceCharacterKey, nowMs);
+				// Roadmap-7 — guilde du compte (poussée par le master dans le push
+				// d'admission ; 0 = sans guilde). Sert au partage du buff gâteau.
+				acceptedClient.guildId = m_admittedRegistry->AdmittedGuildId(
+					acceptedClient.persistenceCharacterKey, nowMs);
 				if (acceptedClient.characterName.empty())
 				{
 					std::string admittedName = m_admittedRegistry->AdmittedCharacterName(
@@ -6012,11 +6016,27 @@ namespace engine::server
 					}
 				}
 			}
-			// DETTE (documentée PR #991) — partage « guilde » : le shard ne
-			// connaît PAS l'appartenance de guilde (aucun GuildSystem câblé
-			// dans ServerApp ; les guildes vivent côté master/DB). V1 = groupe
-			// à portée uniquement ; étendre à la guilde exigera une synchro
-			// d'appartenance master→shard (chantier séparé).
+			// Roadmap-7 (2026-07-19) — partage « guilde » (solde la DETTE #991) :
+			// la guilde du compte est désormais synchronisée master→shard via le
+			// push d'admission (ConnectedClient.guildId, snapshot enter-world).
+			// Mêmes règles que le groupe : co-membres CONNECTÉS et À PORTÉE
+			// (kCakeBuffRadiusMeters), sans doublon avec les membres de groupe
+			// déjà retenus. guildId == 0 (sans guilde / master legacy) → no-op.
+			if (client.guildId != 0u)
+			{
+				for (ConnectedClient& other : m_clients)
+				{
+					if (other.clientId == client.clientId) continue;
+					if (other.guildId != client.guildId) continue;
+					const float dx = other.positionMetersX - client.positionMetersX;
+					const float dz = other.positionMetersZ - client.positionMetersZ;
+					if (dx * dx + dz * dz > kCakeBuffRadiusMeters * kCakeBuffRadiusMeters) continue;
+					bool already = false;
+					for (const ConnectedClient* r : recipients)
+						if (r->clientId == other.clientId) { already = true; break; }
+					if (!already) recipients.push_back(&other);
+				}
+			}
 
 			for (ConnectedClient* target : recipients)
 			{

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -207,6 +207,12 @@ namespace engine::server
 		/// Compte propriétaire (résolu au Hello via AdmittedCharacterRegistry). Clé de la
 		/// présence unifiée (ShardPresenceService) ; 0 si non résolu (registre absent).
 		uint64_t accountId = 0;
+		/// Roadmap-7 — guilde du compte (snapshot à l'enter-world, poussé par le master
+		/// dans kOpcodeMasterToShardAdmitCharacter et résolu au Hello via
+		/// AdmittedCharacterRegistry::AdmittedGuildId). 0 = sans guilde / master legacy.
+		/// Consommé par TickCakeBuffs pour partager le buff gâteau aux co-membres de
+		/// guilde connectés à portée (dette #991).
+		uint64_t guildId = 0;
 		/// Niveau du personnage (table characters.level, chargé au Hello via LoadSpawnFromDb).
 		/// Reporté au master dans le heartbeat enrichi (présence web-portal).
 		uint32_t level = 1;


### PR DESCRIPTION
## Objectif (roadmap 2026-07-19, chantier 7)

Le shard ne connaissait pas l'appartenance de guilde des joueurs (elle vit cote master/DB) — c'est la **dette #991** qui avait force a limiter le partage du buff gateau d'anniversaire au groupe. Cette PR synchronise la guilde master→shard et **solde la dette**.

## Architecture retenue

Extension **additive** du push d'admission existant `kOpcodeMasterToShardAdmitCharacter` (le canal TCP persistant shard↔master de TA.3) : `guild_id` (u64) ajoute **en queue de payload apres `gender`**, exactement le pattern des extensions name (TD.5) et gender (TD.6).

- Un shard ancien ignore l'octet de queue ; un master ancien ne l'emet pas → `guild_id=0`, repli propre (pas de partage guilde).
- **Aucun bump de version, aucun nouveau kind UDP client, aucune migration DB** (`guild_members_v2` existe depuis la 0055).

## Chaine complete

1. **Master** (`CharacterEnterWorldHandler`) : `SELECT guild_id FROM guild_members_v2 WHERE account_id=?` (prepared statement, tolerant — SELECT direct pour eviter le couplage au `GuildHandler`, construit apres ce handler dans `main_linux.cpp`), embarque dans le push d'admission.
2. **Shard** : `AdmittedCharacterRegistry` stocke `guildId` (preserve au re-Admit sans guilde, meme regle que nom/genre) ; `ConnectedClient.guildId` rempli au Hello UDP.
3. **`TickCakeBuffs`** : le buff gateau s'etend aux **co-membres de guilde connectes et a portee** (30 m, meme regle que le groupe), sans doublon avec les membres de groupe.

Limite V1 assumee : snapshot a l'enter-world (un join/leave de guilde en cours de session est pris en compte au prochain enter-world).

## Tests (ctest)

- `shard_payloads_tests` : round-trip Build→PacketView→Parse avec guilde ; payload legacy ampute du u64 de queue → `guild_id=0`, name/gender intacts ; payload minimal 16 octets.
- `admitted_character_registry_tests` : guildId + TTL + preservation au re-Admit legacy.

## Validation en jeu

Deux comptes de la meme guilde (`guild_members_v2`), connectes a moins de 30 m l'un de l'autre, PAS dans le meme groupe : l'un mange un gateau slotte → les deux recoivent l'aura (logs shard `Admit pushed by master (... guild_id=N)`).

**Deploiement** : ⚠️ redeploiement **master + shard** requis en lock-step (payload d'admission etendu + consommation shard). Compatible dans les deux sens pendant la transition (champ additif), mais la feature n'est active que quand les deux sont a jour. Client non concerne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)