### PR TITLE
fix(editor): les 3 P0 de l audit 2026-06-05 + overlay preset repare

### DIFF
--- a/src/world_editor/terrain/erosion/ThermalSimulation.cpp
+++ b/src/world_editor/terrain/erosion/ThermalSimulation.cpp
@@ -120,11 +120,20 @@ namespace engine::editor::world::erosion
 					}
 
 					if (excessTotal <= 0.0f) continue;
-					// Anti-runaway : on ne peut pas relâcher plus que la
-					// hauteur disponible au-dessus du sea level (ou 0 par
-					// défaut). Borne soft : `min(1, h / excessTotal)` pour
-					// préserver la masse.
-					const float factor = std::min(1.0f, h / std::max(excessTotal, 1e-6f));
+					// Anti-runaway (P0 audit 2026-06-05, 4.1) : on ne relâche
+					// jamais plus que la hauteur DISPONIBLE au-dessus du
+					// plancher (sea level si stopUnderSeaLevel, 0 m sinon —
+					// c'était l'intention documentée, mais le code bornait sur
+					// `h` brut : facteur NÉGATIF pour h < 0 → transferts
+					// inversés non bornés (dérive de masse, altitudes qui
+					// divergent). Le clamp [0,1] garantit qu'une cellule ne
+					// descend jamais sous le plancher et que le facteur reste
+					// une fraction de l'excès calculé.
+					const float floorMeters = params.stopUnderSeaLevel ? seaLevelMeters : 0.0f;
+					const float available = h - floorMeters;
+					if (available <= 0.0f) continue;
+					const float factor = std::clamp(
+						available / std::max(excessTotal, 1e-6f), 0.0f, 1.0f);
 					for (int n = 0; n < 8; ++n)
 					{
 						const float e = perNeighborExcess[n];

--- a/src/world_editor/tests/ThermalWindErosionTests.cpp
+++ b/src/world_editor/tests/ThermalWindErosionTests.cpp
@@ -240,6 +240,60 @@ namespace
 		REQUIRE(r.totalTransferredMeters < 1e-3f);
 		(void)originalHeights;
 	}
+
+	/// P0 (audit 2026-06-05, 4.1) : terrain sous le plancher (hauteurs
+	/// négatives) → AUCUN transfert inversé. Avant le fix, le facteur
+	/// anti-runaway `h / excès` devenait NÉGATIF pour h < 0 : les deltas
+	/// s'inversaient (masse remontant la pente, amplitudes non bornées) et
+	/// les altitudes divergeaient. Après le fix, les cellules sans hauteur
+	/// disponible au-dessus du plancher n'émettent tout simplement pas.
+	void Test_Thermal_NegativeHeights_NoInvertedRunaway()
+	{
+		// Falaise raide dont TOUT le relief est sous 0 m (plancher hors sea).
+		ConsolidatedHeightGrid g;
+		g.width = 10; g.height = 10;
+		g.cellSizeMeters = 1.0f;
+		g.heights.resize(100);
+		for (int z = 0; z < 10; ++z)
+			for (int x = 0; x < 10; ++x)
+				g.heights[static_cast<size_t>(z) * 10 + x] =
+					-5.0f - static_cast<float>(x) * 20.0f; // pente raide, h < 0
+		ThermalSimulationParams params;
+		params.talusAngleDeg = 35.0f;
+		params.forcePerPass  = 0.5f;
+		params.numPasses     = 20;
+		params.stopUnderSeaLevel = false; // plancher = 0 m
+		const auto r = RunThermalSimulation(g, 0.0f, params);
+		REQUIRE(r.totalTransferredMeters == 0.0f); // rien de disponible au-dessus de 0
+		for (const float h : g.heights)
+		{
+			REQUIRE(std::isfinite(h));
+			REQUIRE(h >= -200.0f && h <= 10.0f); // aucune divergence
+		}
+	}
+
+	/// P0 (4.1) : une cellule juste au-dessus du plancher ne descend jamais
+	/// SOUS le plancher, quelle que soit la pente demandée.
+	void Test_Thermal_NeverBelowFloor()
+	{
+		ConsolidatedHeightGrid g;
+		g.width = 8; g.height = 8;
+		g.cellSizeMeters = 1.0f;
+		g.heights.resize(64, 0.0f);
+		// Un pic isolé de 3 m au centre : il doit relaxer mais jamais < 0.
+		g.heights[static_cast<size_t>(4) * 8 + 4] = 3.0f;
+		ThermalSimulationParams params;
+		params.talusAngleDeg = 35.0f;
+		params.forcePerPass  = 1.0f;
+		params.numPasses     = 40;
+		params.stopUnderSeaLevel = false; // plancher = 0 m
+		const auto r = RunThermalSimulation(g, 0.0f, params);
+		(void)r;
+		for (const float h : g.heights)
+		{
+			REQUIRE(h >= -1e-4f); // jamais sous le plancher (tolérance float)
+		}
+	}
 }
 
 int main()
@@ -253,6 +307,8 @@ int main()
 	Test_Wind_ZeroParticles_EmptyResult();
 	Test_Command_Apply_Undo_RestoresExact();
 	Test_Thermal_PreserveSteepSlopes();
+	Test_Thermal_NegativeHeights_NoInvertedRunaway();
+	Test_Thermal_NeverBelowFloor();
 
 	if (g_failed > 0)
 	{

--- a/src/world_editor/tests/ZonePresetsTests.cpp
+++ b/src/world_editor/tests/ZonePresetsTests.cpp
@@ -284,7 +284,10 @@ namespace
 	bool NearEq(double a, double b) { return std::fabs(a - b) < 1e-6; }
 
 	/// Parse scalaires (nombre, bool, string) + saute les clés
-	/// structurelles type/preset/affectedBy.
+	/// structurelles type/affectedBy. P1 (audit 2026-06-05, 6.4) : "preset"
+	/// N'est PLUS filtrée — `MaybeApplyToolPreset` (OperationDispatcher) la
+	/// lit via `GetString("preset")` ; la filtrer rendait l'overlay de
+	/// tool-preset silencieusement inopérant.
 	void Test_OpParams_ParsesScalars()
 	{
 		const std::string raw = R"({
@@ -294,9 +297,11 @@ namespace
 			"carvingEnabled": true, "windEnabled": false
 		})";
 		const auto p = zp::OperationParams::Parse(raw);
-		// type/preset/affectedBy ne sont PAS dans les params.
+		// type/affectedBy ne sont PAS dans les params ; "preset" y est (6.4).
 		REQUIRE(!p.Has("type"));
-		REQUIRE(!p.Has("preset"));
+		std::string presetId;
+		REQUIRE(p.GetString("preset", presetId));
+		REQUIRE(presetId == "realistic");
 		REQUIRE(!p.Has("affectedBy"));
 		double n = 0.0;
 		REQUIRE(p.GetNumber("numDroplets", n));

--- a/src/world_editor/volumes/MeshInsertIo.cpp
+++ b/src/world_editor/volumes/MeshInsertIo.cpp
@@ -1,5 +1,6 @@
 #include "src/world_editor/volumes/MeshInsertIo.h"
 
+#include <algorithm> // std::min — plafond du reserve (P0 audit 3.1)
 #include <cstring>
 
 namespace engine::editor::world::volumes
@@ -146,7 +147,15 @@ namespace engine::editor::world::volumes
 			return false;
 		}
 
-		outInstances.reserve(instanceCount);
+		// P0 (audit 2026-06-05, 3.1) — borne le reserve par ce que le fichier
+		// peut PHYSIQUEMENT contenir : une instance sérialisée fait au moins
+		// ~49 octets (guid + 3 chaînes + 2 vec3 + 2 f32 + flags) ; on prend 32
+		// en borne prudente. Sans ce plafond, un .bin corrompu annonçant
+		// count=0xFFFFFFFF provoquait un std::bad_alloc non catché (crash au
+		// chargement) AVANT toute vérification des octets. La boucle ci-dessous
+		// échoue proprement (« truncated ») si le count reste mensonger.
+		outInstances.reserve(std::min<size_t>(instanceCount,
+			(bytes.size() - cursor) / 32u));
 		for (uint32_t i = 0; i < instanceCount; ++i)
 		{
 			MeshInsertInstance inst;

--- a/src/world_editor/volumes/bridge/VMapBridge.cpp
+++ b/src/world_editor/volumes/bridge/VMapBridge.cpp
@@ -262,7 +262,11 @@ namespace engine::editor::world::volumes::bridge
 			outError = "VMapBridge: unsupported version";
 			return false;
 		}
-		outProxies.reserve(count);
+		// P0 (audit 2026-06-05, 3.1) — borne le reserve par la taille restante
+		// du fichier : un proxy sérialisé fait EXACTEMENT 33 octets (u64 guid +
+		// 6 f32 AABB + u8 kind). Un count corrompu (0xFFFFFFFF) provoquait un
+		// std::bad_alloc non catché avant toute lecture.
+		outProxies.reserve(std::min<size_t>(count, (bytes.size() - cursor) / 33u));
 		for (uint32_t i = 0; i < count; ++i)
 		{
 			VolumeAabbProxy p;

--- a/src/world_editor/volumes/dungeons/DungeonPortalIo.cpp
+++ b/src/world_editor/volumes/dungeons/DungeonPortalIo.cpp
@@ -1,5 +1,6 @@
 #include "src/world_editor/volumes/dungeons/DungeonPortalIo.h"
 
+#include <algorithm> // std::min — plafond du reserve (P0 audit 3.1)
 #include <cstring>
 
 namespace engine::editor::world::volumes::dungeons
@@ -144,7 +145,13 @@ namespace engine::editor::world::volumes::dungeons
 			return false;
 		}
 
-		outInstances.reserve(instanceCount);
+		// P0 (audit 2026-06-05, 3.1) — borne le reserve par la taille restante
+		// du fichier (une instance sérialisée ≥ ~41 octets, borne prudente 32) :
+		// un count corrompu (0xFFFFFFFF) provoquait un std::bad_alloc non
+		// catché avant toute lecture. La boucle échoue proprement si le count
+		// reste mensonger (« truncated »).
+		outInstances.reserve(std::min<size_t>(instanceCount,
+			(bytes.size() - cursor) / 32u));
 		for (uint32_t i = 0; i < instanceCount; ++i)
 		{
 			DungeonPortalInstance inst;

--- a/src/world_editor/zone_presets/OperationParams.cpp
+++ b/src/world_editor/zone_presets/OperationParams.cpp
@@ -131,8 +131,13 @@ namespace engine::editor::world::zone_presets
 			const char c = s[p];
 			// Clés structurelles déjà parsées côté ZonePresetOperation :
 			// on les saute (mais on consomme quand même leur valeur).
+			// P1 (audit 2026-06-05, 6.4) : "preset" N'EST PLUS filtrée — c'est
+			// `MaybeApplyToolPreset` (OperationDispatcher) qui la lit via
+			// `GetString("preset")` ; la filtrer ici rendait l'overlay de
+			// tool-preset silencieusement inopérant (les sims tournaient
+			// toujours avec les defaults + overrides scalaires seulement).
 			const bool structural =
-				(key == "type" || key == "preset" || key == "affectedBy");
+				(key == "type" || key == "affectedBy");
 
 			if (c == '"')
 			{

--- a/src/world_editor/zone_presets/WorldMapEditDocumentReset.h
+++ b/src/world_editor/zone_presets/WorldMapEditDocumentReset.h
@@ -24,9 +24,10 @@ namespace engine::editor::world::zone_presets
 	///
 	/// Note MVP : ce helper ne pousse PAS de `ResetZoneCommand` sur le
 	/// CommandStack (spec §D.3 le prévoit pour Ctrl+Z après preset).
-	/// L'annulation est laissée à un follow-up : pour cet incrément, le
-	/// reset est destructif (irréversible). L'utilisateur en est prévenu
-	/// par le dialog de confirmation côté UI (incrément 3).
+	/// Le reset reste destructif en RAM, MAIS depuis le P0 audit 6.1 le
+	/// point d'appel (`ZonePresetDialog::RunSelectedPreset`) écrit un filet
+	/// de sécurité disque AVANT `Execute` et restaure la carte si le preset
+	/// échoue ou est annulé — plus de perte irréversible.
 	void ResetEditedZoneDocuments(
 		engine::editor::world::TerrainDocument& terrain,
 		engine::editor::world::WaterDocument& water,

--- a/src/world_editor/zone_presets/ZonePresetDialog.cpp
+++ b/src/world_editor/zone_presets/ZonePresetDialog.cpp
@@ -16,6 +16,9 @@
 
 #include <chrono>
 #include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace engine::editor::world::zone_presets
 {
@@ -64,6 +67,31 @@ namespace engine::editor::world::zone_presets
 			preset.id, custom.reliefMultiplier, custom.waterDensityMultiplier,
 			custom.drynessMultiplier, custom.seed);
 
+		// P0 (audit 2026-06-05, 6.1) — TRANSACTION : l'exécution d'un preset
+		// commence par un reset DESTRUCTIF de la zone ; si une op échoue ou si
+		// l'utilisateur annule, la carte serait laissée dans un état partiel
+		// IRRÉVERSIBLE (le reset n'est pas une commande, pas de Ctrl+Z).
+		// Filet de sécurité : on persiste l'état courant sur DISQUE avant, et
+		// on RESTAURE depuis ce filet si l'exécution ne va pas au bout.
+		std::vector<engine::world::GlobalChunkCoord> preCoords;
+		if (cfg != nullptr)
+		{
+			shell.MutableTerrainDocument().ForEachLoadedChunk(
+				[&preCoords](engine::world::GlobalChunkCoord c,
+					const std::shared_ptr<engine::world::terrain::TerrainChunk>&)
+				{ preCoords.push_back(c); });
+			const size_t chunksSaved = shell.SaveTerrainChunks(*cfg);
+			const size_t docsSaved   = shell.SaveZoneDocuments(*cfg);
+			LOG_INFO(EditorWorld,
+				"[ZonePresetDialog] Filet de sécurité écrit avant preset ({} chunk(s), {} document(s))",
+				chunksSaved, docsSaved);
+		}
+		else
+		{
+			LOG_WARN(EditorWorld,
+				"[ZonePresetDialog] Config absente : preset exécuté SANS filet de sécurité (rollback impossible)");
+		}
+
 		using clock = std::chrono::steady_clock;
 		const auto t0 = clock::now();
 
@@ -79,6 +107,37 @@ namespace engine::editor::world::zone_presets
 		m_lastDurationMs  = std::chrono::duration<double, std::milli>(t1 - t0).count();
 		m_lastPresetId    = preset.id;
 		m_screen          = Screen::Result;
+
+		// P0 (6.1) — rollback : échec d'au moins une op OU annulation → la
+		// carte est restaurée depuis le filet disque. L'historique undo est
+		// vidé (les commandes du preset référencent l'état abandonné).
+		if (cfg != nullptr && (m_lastSummary.failed > 0u || m_lastSummary.wasCancelled))
+		{
+			engine::editor::world::TerrainDocument& terrain = shell.MutableTerrainDocument();
+			// Empreinte GPU à resynchroniser : union des chunks d'AVANT et de
+			// ceux créés par le preset (encore chargés à cet instant).
+			std::vector<engine::world::GlobalChunkCoord> touched = preCoords;
+			terrain.ForEachLoadedChunk(
+				[&touched](engine::world::GlobalChunkCoord c,
+					const std::shared_ptr<engine::world::terrain::TerrainChunk>&)
+				{
+					for (const engine::world::GlobalChunkCoord& k : touched)
+						if (k == c) return;
+					touched.push_back(c);
+				});
+			const std::string zoneId = terrain.GetZoneId();
+			shell.ResetForZoneChange(zoneId); // purge RAM + historique undo périmé
+			shell.LoadZoneDocuments(*cfg);    // eau / mesh inserts / portails depuis le filet
+			for (const engine::world::GlobalChunkCoord& c : touched)
+			{
+				(void)terrain.EnsureLoaded(*cfg, c.x, c.z); // relit le filet (ou plat 0 m)
+				terrain.OnCommit(c);                        // resync GPU + LODs du chunk
+			}
+			LOG_WARN(EditorWorld,
+				"[ZonePresetDialog] '{}' {} — carte RESTAURÉE depuis le filet disque ({} chunk(s) resynchronisés)",
+				preset.id, m_lastSummary.wasCancelled ? "annulé" : "en échec partiel",
+				touched.size());
+		}
 
 		LOG_INFO(EditorWorld,
 			"[ZonePresetDialog] '{}' terminé en {:.0f} ms (pushed={}, skipped={}, failed={})",
@@ -220,15 +279,19 @@ namespace engine::editor::world::zone_presets
 		ImGui::Separator();
 		if (m_lastSummary.unsupportedSkipped > 0u)
 		{
-			ImGui::TextWrapped("Note : certaines opérations (érosions, river_network, "
-				"coastline) n'ont pas encore de chemin d'exécution sans UI et sont "
-				"ignorées (M100.46 incrément 2e à venir).");
+			// P1 (audit 2026-06-05, 6.3) — texte corrigé : les érosions,
+			// river_network et coastline SONT câblées (12/14) ; les deux
+			// seules opérations non câblées sont sculpt_brush et splat_paint.
+			ImGui::TextWrapped("Note : les opérations sculpt_brush et splat_paint "
+				"n'ont pas encore de chemin d'exécution hors UI et sont ignorées "
+				"(les 12 autres types, érosions et rivières comprises, sont câblés).");
 			ImGui::Separator();
 		}
 		if (m_lastSummary.failed > 0u)
 		{
 			ImGui::TextWrapped("Certaines opérations ont échoué (catalogId introuvable, "
-				"paramètres invalides...). Voir les logs EditorWorld pour le détail.");
+				"paramètres invalides...). La carte a été RESTAURÉE depuis le filet "
+				"de sécurité écrit avant le preset. Voir les logs EditorWorld.");
 			ImGui::Separator();
 		}
 		if (ImGui::Button("Retour à la sélection", ImVec2(180.0f, 0.0f)))

--- a/src/world_editor/zone_presets/ZonePresetExecutor.h
+++ b/src/world_editor/zone_presets/ZonePresetExecutor.h
@@ -49,14 +49,19 @@ namespace engine::editor::world::zone_presets
 	///      d. arrêt si `progressCallback` retourne false OU si
 	///         `RequestCancel()` a été appelé entretemps.
 	///
-	/// Types câblés (incréments 2b + 2c + 2d) : `place_cave`, `place_overhang`,
-	/// `place_arch`, `place_dungeon`, `mountain_macro`, `valley_macro`,
-	/// `lake_polygon`, `river_manual` (8 sur 14). Les 4 restants
-	/// (`coastline`, `river_network`, `hydraulic_erosion`,
-	/// `thermal_wind_erosion`) sont ignorés silencieusement avec un log info
-	/// (besoin d'extraire la simulation des Tools UI — itération 2e+). Le
-	/// compteur `unsupportedSkipped` du résumé permet à l'UI d'informer
-	/// l'utilisateur.
+	/// Types câblés (P1 audit 2026-06-05, 6.3 — doc corrigée) : 12 sur 14 —
+	/// `place_cave`, `place_overhang`, `place_arch`, `place_dungeon`,
+	/// `mountain_macro`, `valley_macro`, `lake_polygon`, `river_manual`,
+	/// ET (incrément 2e livré) `coastline`, `river_network`,
+	/// `hydraulic_erosion`, `thermal_wind_erosion`. Les 2 seuls restants
+	/// (`sculpt_brush`, `splat_paint`) renvoient `Unsupported` (leur logique
+	/// vit encore dans les Tools UI). Le compteur `unsupportedSkipped` du
+	/// résumé permet à l'UI d'informer l'utilisateur.
+	///
+	/// P0 (audit 6.1) : le reset initial est destructif MAIS le point d'appel
+	/// (`ZonePresetDialog::RunSelectedPreset`) écrit un filet de sécurité
+	/// disque avant `Execute` et RESTAURE la carte si `failed > 0` ou
+	/// `wasCancelled` — voir la transaction côté dialog.
 	class ZonePresetExecutor
 	{
 	public:


### PR DESCRIPTION
## Objectif (roadmap 2026-07-19, chantier 8 — volet P0)

Corrige les **3 findings critiques** de l'audit editeur du 2026-06-05 ([docs/audit/2026-06-05-editeur-carte-audit.md](docs/audit/2026-06-05-editeur-carte-audit.md)), plus 2 quick-wins P1 adjacents.

## P0 — crash / perte de donnees / divergence

- **3.1 — crash au chargement d'un .bin corrompu** : les 3 lecteurs binaires (LCMI mesh inserts, LCDP portails, LCVC proxies collision) faisaient `reserve(count)` avec un count lu du fichier AVANT toute verification → `std::bad_alloc` non catche sur un count mensonger (0xFFFFFFFF). Le reserve est plafonne par ce que le fichier peut physiquement contenir ; la boucle echoue proprement (« truncated »).
- **6.1 — zone presets sans rollback** : l'application d'un preset commence par un reset destructif ; un echec en cours laissait une carte partielle IRRECUPERABLE. Desormais **transaction** : filet de securite disque ecrit avant (`SaveTerrainChunks` + `SaveZoneDocuments`), et si `failed > 0` ou annulation → restauration complete (purge RAM + historique perime, rechargement des documents, `EnsureLoaded`/`OnCommit` par chunk pour resynchroniser GPU et LODs).
- **4.1 — erosion thermique non conservative** : le facteur anti-runaway `h/exces` devenait **negatif** pour des hauteurs < 0 (transferts inverses non bornes → altitudes divergentes) et bornait sur `h` brut au lieu de la hauteur disponible au-dessus du plancher. Fix : `clamp((h − plancher)/exces, 0, 1)`, plancher = sea level si `stopUnderSeaLevel`, 0 m sinon — l'intention documentee du code.

## P1 bonus (adjacents, triviaux)

- **6.4 — overlay de tool-preset JAMAIS applique** : `OperationParams::Parse` filtrait la cle `"preset"` que `MaybeApplyToolPreset` relisait ensuite → retour anticipe systematique, les simulations tournaient toujours sur les defaults. La cle est desormais conservee ; `"preset":"realistic"` etc. agissent enfin.
- **6.3 — docs/UI mensongeres** : l'ecran de resultat et `ZonePresetExecutor.h` affirmaient que erosions/river_network/coastline etaient « ignorees » — faux (12/14 cablees) ; seuls `sculpt_brush`/`splat_paint` restent Unsupported. Textes corriges.

## Tests (ctest)

- `thermal_wind_erosion_tests` : +2 — terrain entierement negatif → zero transfert, aucune divergence ; pic au-dessus du plancher → ne descend jamais sous 0.
- `zone_presets_tests` : le test qui verrouillait le bug 6.4 (`!Has("preset")`) inverse — la cle est conservee et lisible.

## Validation en jeu (editeur)

1. Appliquer un preset de zone puis l'annuler / provoquer un echec (catalogId invalide) → la carte d'avant revient (terrain + eau + volumes), message « RESTAURÉE » au log.
2. Preset avec `"preset":"realistic"` sur hydraulic_erosion → les parametres du tool-preset s'appliquent (visible au log/resultat).

**Deploiement** : ✅ client uniquement (editeur monde), pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)