### PR TITLE
feat(editor): cablage des outils orphelins lot 1 - Spline, Zone de gameplay, Danger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1516,6 +1516,17 @@ if(MSVC)
 endif()
 add_test(NAME entity_edit_commands_tests COMMAND entity_edit_commands_tests)
 
+# Roadmap-8 (2026-07-19) — Tests CPU du round-trip Save/Load des documents
+# splines/zones/hazards (dette audit 7.2 comblee au cablage des outils).
+# Pur CPU + E/S temporaires, non gate WIN32.
+add_executable(gameplay_docs_round_trip_tests src/world_editor/tests/GameplayDocsRoundTripTests.cpp)
+target_include_directories(gameplay_docs_round_trip_tests PRIVATE ${CMAKE_SOURCE_DIR})
+target_link_libraries(gameplay_docs_round_trip_tests PRIVATE engine_core)
+if(MSVC)
+  target_compile_options(gameplay_docs_round_trip_tests PRIVATE /W4 /permissive- /Zc:preprocessor)
+endif()
+add_test(NAME gameplay_docs_round_trip_tests COMMAND gameplay_docs_round_trip_tests)
+
 # Roadmap-6 (2026-07-19) — Tests CPU pour CompositeCommand (undo groupe des
 # gestes multi-selection : ordre Execute/Undo, integration CommandStack).
 # Pur CPU, non gate WIN32 (execute aussi par le ctest de build-linux).

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -11,6 +11,7 @@
 #include "src/world_editor/ui/WorldMapIo.h" // lot B3 : SanitizeZoneId (namespacing zone)
 #include "src/world_editor/core/WorldEditorShell.h"
 #include "src/world_editor/core/CompositeCommand.h"            // Roadmap-6 : undo groupé du gizmo
+#include "src/world_editor/HazardCommand.h"                    // Roadmap-8 : pose de danger undoable
 #include "src/world_editor/inspector/SetEntityTransformCommand.h" // Roadmap-6 : undo du drag de gizmo
 #include "src/world_editor/scene/LayoutPlacementCommands.h"    // Roadmap-6 : placement undoable
 #include "src/world_editor/panels/ScenePanel.h"
@@ -10795,6 +10796,54 @@ namespace engine
 						&& m_input.WasMousePressed(engine::platform::MouseButton::Left))
 					{
 						m_worldEditorShell->MutableValleyChainTool().AddVertex(pickX, pickZ);
+					}
+				}
+				else if (tool == engine::editor::world::ActiveTool::Spline)
+				{
+					modernEditActive = true;
+					// Roadmap-8 — spline (routes/chemins) : chaque clic ajoute un
+					// noeud au trace en cours (largeur = defaut du panneau) ; le
+					// bouton « Ajouter la spline » du ToolPropertiesPanel pousse
+					// l'AddSplineCommand undoable.
+					if (freeClick && terrainPick
+						&& m_input.WasMousePressed(engine::platform::MouseButton::Left))
+					{
+						engine::editor::world::SplineTool& spline =
+							m_worldEditorShell->MutableSplineTool();
+						const float wy = m_terrainCollider.GroundHeightAt(pickX, pickZ);
+						spline.AddNode(engine::math::Vec3{ pickX, wy, pickZ },
+							spline.DefaultWidthMeters());
+					}
+				}
+				else if (tool == engine::editor::world::ActiveTool::GameplayZone)
+				{
+					modernEditActive = true;
+					// Roadmap-8 — zone de gameplay : chaque clic ajoute un sommet
+					// au polygone en cours ; « Ajouter la zone » (panneau) pousse
+					// l'AddGameplayZoneCommand undoable.
+					if (freeClick && terrainPick
+						&& m_input.WasMousePressed(engine::platform::MouseButton::Left))
+					{
+						const float wy = m_terrainCollider.GroundHeightAt(pickX, pickZ);
+						m_worldEditorShell->MutableZoneTool().AddPoint(
+							engine::math::Vec3{ pickX, wy, pickZ });
+					}
+				}
+				else if (tool == engine::editor::world::ActiveTool::Hazard)
+				{
+					modernEditActive = true;
+					// Roadmap-8 — danger : pose one-shot au point clique, undoable
+					// immediatement (AddHazardCommand aux parametres courants du
+					// panneau — type, forme, profondeur...).
+					if (freeClick && terrainPick
+						&& m_input.WasMousePressed(engine::platform::MouseButton::Left))
+					{
+						const float wy = m_terrainCollider.GroundHeightAt(pickX, pickZ);
+						m_worldEditorShell->MutableCommandStack().Push(
+							std::make_unique<engine::editor::world::AddHazardCommand>(
+								m_worldEditorShell->MutableHazardDocument(),
+								m_worldEditorShell->GetHazardTool().CreateAt(
+									engine::math::Vec3{ pickX, wy, pickZ })));
 					}
 				}
 			}

--- a/src/world_editor/GameplayZoneCommand.h
+++ b/src/world_editor/GameplayZoneCommand.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Roadmap-8 (2026-07-19) — Commande d'ajout d'une zone de gameplay
+// (undo/redo). Header-only, miroir d'AddSplineCommand (M100.29).
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/ZoneDocument.h"
+
+namespace engine::editor::world
+{
+	/// Ajoute une `GameplayZone` complète au document (Execute) ; Undo retire
+	/// la dernière (LIFO — sûr tant que les ajouts de zones passent tous par
+	/// cette commande, ce qui est le cas depuis le câblage Roadmap-8).
+	/// Contrainte thread : main thread (comme tout `ICommand`).
+	class AddGameplayZoneCommand final : public ICommand
+	{
+	public:
+		AddGameplayZoneCommand(ZoneDocument& doc, engine::world::zones::GameplayZone zone)
+			: m_doc(doc), m_zone(std::move(zone)) {}
+
+		const char* GetLabel() const override { return "Ajouter une zone de gameplay"; }
+		size_t GetMemoryFootprint() const override
+		{
+			return sizeof(*this) + m_zone.name.capacity()
+				+ m_zone.polygon.size() * sizeof(engine::math::Vec3);
+		}
+		void Execute() override { m_doc.Add(m_zone); }
+		void Undo() override { m_doc.RemoveLast(); }
+
+	private:
+		ZoneDocument& m_doc;
+		engine::world::zones::GameplayZone m_zone;
+	};
+}

--- a/src/world_editor/HazardCommand.h
+++ b/src/world_editor/HazardCommand.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// Roadmap-8 (2026-07-19) — Commande de pose d'un hazard (undo/redo).
+// Header-only, miroir d'AddSplineCommand (M100.29).
+
+#include "src/world_editor/core/CommandStack.h"
+#include "src/world_editor/HazardDocument.h"
+
+namespace engine::editor::world
+{
+	/// Pose un `HazardVolume` complet dans le document (Execute) ; Undo retire
+	/// le dernier (LIFO — sûr tant que les poses passent toutes par cette
+	/// commande, ce qui est le cas depuis le câblage Roadmap-8).
+	/// Contrainte thread : main thread (comme tout `ICommand`).
+	class AddHazardCommand final : public ICommand
+	{
+	public:
+		AddHazardCommand(HazardDocument& doc, engine::world::hazard::HazardVolume hazard)
+			: m_doc(doc), m_hazard(hazard) {}
+
+		const char* GetLabel() const override { return "Poser un danger"; }
+		size_t GetMemoryFootprint() const override { return sizeof(*this); }
+		void Execute() override { m_doc.Add(m_hazard); }
+		void Undo() override
+		{
+			auto& list = m_doc.Mutable();
+			if (!list.empty()) list.pop_back();
+		}
+
+	private:
+		HazardDocument& m_doc;
+		engine::world::hazard::HazardVolume m_hazard;
+	};
+}

--- a/src/world_editor/HazardDocument.h
+++ b/src/world_editor/HazardDocument.h
@@ -2,6 +2,7 @@
 
 // M100.16 — Document monde des hazards (état éditeur). Header-only.
 
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -28,6 +29,21 @@ namespace engine::editor::world
 			          static_cast<std::streamsize>(bytes.size()));
 			if (!out.good()) { err = "HazardDocument::SaveToDisk: write failed: " + path; return false; }
 			return true;
+		}
+
+		/// Roadmap-8 (dette audit 7.2) — Relit `hazards.bin` et REMPLACE le
+		/// contenu courant. Fichier absent = succès avec liste vide.
+		/// \return false si le fichier existe mais est corrompu.
+		bool LoadFromDisk(const std::string& path, std::string& err)
+		{
+			m_hazards.clear();
+			std::error_code ec;
+			if (!std::filesystem::exists(path, ec)) return true; // pas de hazards : OK
+			std::ifstream in(path, std::ios::binary);
+			if (!in.good()) { err = "HazardDocument::LoadFromDisk: open failed: " + path; return false; }
+			std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)),
+				std::istreambuf_iterator<char>());
+			return engine::world::hazard::LoadHazardsBin(bytes, m_hazards, err);
 		}
 
 	private:

--- a/src/world_editor/SplineDocument.h
+++ b/src/world_editor/SplineDocument.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -34,6 +35,24 @@ namespace engine::editor::world
 			if (!out.good()) { err = "SplineDocument::SaveToDisk: write failed: " + path; return false; }
 			return true;
 		}
+
+		/// Roadmap-8 (dette audit 7.2) — Relit `splines.bin` et REMPLACE le
+		/// contenu courant. Fichier absent = succès avec liste vide.
+		/// \return false si le fichier existe mais est corrompu.
+		bool LoadFromDisk(const std::string& path, std::string& err)
+		{
+			m_splines.clear();
+			std::error_code ec;
+			if (!std::filesystem::exists(path, ec)) return true; // pas de splines : OK
+			std::ifstream in(path, std::ios::binary);
+			if (!in.good()) { err = "SplineDocument::LoadFromDisk: open failed: " + path; return false; }
+			std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)),
+				std::istreambuf_iterator<char>());
+			return engine::world::spline::LoadSplinesBin(bytes, m_splines, err);
+		}
+
+		/// Roadmap-8 — Vide toutes les splines (changement de carte).
+		void Clear() { m_splines.clear(); }
 
 	private:
 		std::vector<engine::world::spline::Spline> m_splines;

--- a/src/world_editor/SplineTool.h
+++ b/src/world_editor/SplineTool.h
@@ -19,9 +19,16 @@ namespace engine::editor::world
 			m_current.nodes.push_back(n);
 		}
 		void Clear() { m_current.nodes.clear(); }
+
+		/// Roadmap-8 — largeur (mètres) appliquée aux prochains nœuds posés au
+		/// clic viewport ; éditée par le ToolPropertiesPanel.
+		float& DefaultWidthMeters() { return m_defaultWidthMeters; }
+		float DefaultWidthMeters() const { return m_defaultWidthMeters; }
+
 		void Render();
 
 	private:
 		engine::world::spline::Spline m_current;
+		float m_defaultWidthMeters = 6.0f; ///< Roadmap-8 — largeur des nœuds posés au clic.
 	};
 }

--- a/src/world_editor/ZoneDocument.h
+++ b/src/world_editor/ZoneDocument.h
@@ -1,0 +1,70 @@
+#pragma once
+
+// Roadmap-8 (2026-07-19) — Document des zones de gameplay de la carte
+// (polygones typés M100.28). Header-only, miroir de SplineDocument.
+// Créé au câblage de l'outil Zone (audit 2026-06-05, thème 1.1) : l'outil
+// existait mais n'avait AUCUN conteneur persisté côté éditeur.
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "src/client/world/zones/Zones.h"
+
+namespace engine::editor::world
+{
+	/// Conteneur éditeur des zones de gameplay d'une carte. Possède la liste,
+	/// la sérialise via le format partagé `zones.bin` (magic ZONS, versionné).
+	/// Contrainte thread : main thread (comme les autres documents éditeur).
+	class ZoneDocument
+	{
+	public:
+		/// Ajoute une zone en fin de liste. \return l'index attribué.
+		uint32_t Add(const engine::world::zones::GameplayZone& z)
+		{
+			const uint32_t id = static_cast<uint32_t>(m_zones.size());
+			m_zones.push_back(z);
+			return id;
+		}
+
+		/// Retire la dernière zone (Undo d'un Add — LIFO, cf. AddGameplayZoneCommand).
+		void RemoveLast() { if (!m_zones.empty()) m_zones.pop_back(); }
+
+		/// Vide toutes les zones (changement de carte).
+		void Clear() { m_zones.clear(); }
+
+		const std::vector<engine::world::zones::GameplayZone>& All() const { return m_zones; }
+		std::vector<engine::world::zones::GameplayZone>& Mutable() { return m_zones; }
+
+		/// Écrit `zones.bin` au chemin donné (format partagé SaveZonesBin).
+		/// Effet de bord : écriture disque (le dossier parent doit exister).
+		bool SaveToDisk(const std::string& path, std::string& err) const
+		{
+			const std::vector<uint8_t> bytes = engine::world::zones::SaveZonesBin(m_zones);
+			std::ofstream out(path, std::ios::binary | std::ios::trunc);
+			if (!out.good()) { err = "ZoneDocument::SaveToDisk: open failed: " + path; return false; }
+			out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+			if (!out.good()) { err = "ZoneDocument::SaveToDisk: write failed: " + path; return false; }
+			return true;
+		}
+
+		/// Roadmap-8 (dette audit 7.2) — Relit `zones.bin` et REMPLACE le
+		/// contenu courant. Fichier absent = succès avec liste vide (carte
+		/// sans zones). \return false si le fichier existe mais est corrompu.
+		bool LoadFromDisk(const std::string& path, std::string& err)
+		{
+			m_zones.clear();
+			std::error_code ec;
+			if (!std::filesystem::exists(path, ec)) return true; // pas de zones : OK
+			std::ifstream in(path, std::ios::binary);
+			if (!in.good()) { err = "ZoneDocument::LoadFromDisk: open failed: " + path; return false; }
+			std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(in)),
+				std::istreambuf_iterator<char>());
+			return engine::world::zones::LoadZonesBin(bytes, m_zones, err);
+		}
+
+	private:
+		std::vector<engine::world::zones::GameplayZone> m_zones;
+	};
+}

--- a/src/world_editor/core/ActiveTool.h
+++ b/src/world_editor/core/ActiveTool.h
@@ -31,9 +31,12 @@ namespace engine::editor::world
 		Overhang            = 13,  // M100.41 — raccourci Ctrl+Shift+O (Overhang)
 		Arch                = 14,  // M100.42 — raccourci Ctrl+Shift+A (Arche)
 		DungeonPortal       = 15,  // M100.43 — raccourci Ctrl+Shift+D (Donjon)
+		Spline              = 16,  // Roadmap-8 — routes/chemins (M100.29 câblé, sans raccourci)
+		GameplayZone        = 17,  // Roadmap-8 — zones de gameplay (M100.28 câblé, sans raccourci)
+		Hazard              = 18,  // Roadmap-8 — dangers/pièges (M100.16 câblé, sans raccourci)
 	};
 
 	/// Nombre d'outils « réels » (hors None). Sert aux tests d'exhaustivité
 	/// (palette d'outils : chaque outil apparaît exactement une fois).
-	inline constexpr int kActiveToolCount = 15;
+	inline constexpr int kActiveToolCount = 18;
 }

--- a/src/world_editor/core/WorldEditorShell.cpp
+++ b/src/world_editor/core/WorldEditorShell.cpp
@@ -631,6 +631,9 @@ namespace engine::editor::world
 			case ActiveTool::Overhang:            name = "Overhang"; break;
 			case ActiveTool::Arch:                name = "Arch"; break;
 			case ActiveTool::DungeonPortal:       name = "DungeonPortal"; break;
+			case ActiveTool::Spline:              name = "Spline"; break;        // Roadmap-8
+			case ActiveTool::GameplayZone:        name = "GameplayZone"; break;  // Roadmap-8
+			case ActiveTool::Hazard:              name = "Hazard"; break;        // Roadmap-8
 		}
 		(void)prev;
 		LOG_INFO(EditorWorld, "Active tool -> {}", name);
@@ -1085,6 +1088,11 @@ namespace engine::editor::world
 		zone_presets::ResetEditedZoneDocuments(
 			m_terrainDoc, m_waterDoc, m_meshInsertDoc, m_dungeonPortalDoc);
 		m_buildingDoc.Reset();
+		// Roadmap-8 — les 3 documents des outils câblés suivent le même cycle
+		// de vie que les autres : vidés à chaque changement de carte.
+		m_splineDoc.Clear();
+		m_zoneDoc.Clear();
+		m_hazardDoc.Clear();
 		// Correctif 4 — namespace disque de la nouvelle carte.
 		PropagateZoneIdToDocuments(zoneId);
 		LOG_INFO(EditorWorld,
@@ -1122,10 +1130,44 @@ namespace engine::editor::world
 			LOG_WARN(EditorWorld,
 				"[WorldEditorShell] Building LoadFromDisk failed: {}", err);
 		}
+		// Roadmap-8 (dette audit 7.2) — les documents splines/zones/hazards
+		// sont enfin RELUS (avant : écriture morte, contenu perdu au reload).
+		err.clear();
+		if (!m_splineDoc.LoadFromDisk(ZoneInstancesPath(cfg, "splines.bin"), err))
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] Spline LoadFromDisk failed: {}", err);
+		}
+		err.clear();
+		if (!m_zoneDoc.LoadFromDisk(ZoneInstancesPath(cfg, "zones.bin"), err))
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] Zone LoadFromDisk failed: {}", err);
+		}
+		err.clear();
+		if (!m_hazardDoc.LoadFromDisk(ZoneInstancesPath(cfg, "hazards.bin"), err))
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] Hazard LoadFromDisk failed: {}", err);
+		}
 		LOG_INFO(EditorWorld,
-			"[WorldEditorShell] Loaded zone documents: {} lake(s)/{} river(s), {} mesh insert(s), {} portal(s), {} building(s)",
+			"[WorldEditorShell] Loaded zone documents: {} lake(s)/{} river(s), {} mesh insert(s), {} portal(s), {} building(s), {} spline(s), {} zone(s), {} hazard(s)",
 			m_waterDoc.Get().lakes.size(), m_waterDoc.Get().rivers.size(),
-			m_meshInsertDoc.Size(), m_dungeonPortalDoc.Size(), m_buildingDoc.Size());
+			m_meshInsertDoc.Size(), m_dungeonPortalDoc.Size(), m_buildingDoc.Size(),
+			m_splineDoc.All().size(), m_zoneDoc.All().size(), m_hazardDoc.All().size());
+	}
+
+	/// Roadmap-8 — Chemin d'un fichier d'instances de la zone courante.
+	/// Effet de bord : crée le dossier parent au besoin (écriture disque).
+	std::string WorldEditorShell::ZoneInstancesPath(const engine::core::Config& cfg, const char* file) const
+	{
+		const std::string contentRoot = cfg.GetString("paths.content", "game/data");
+		const std::string& zoneId = m_terrainDoc.GetZoneId();
+		std::string dir = contentRoot + "/instances";
+		if (!zoneId.empty()) dir += "/zone_" + zoneId;
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		return dir + "/" + file;
 	}
 
 	size_t WorldEditorShell::SaveZoneDocuments(const engine::core::Config& cfg)
@@ -1159,8 +1201,30 @@ namespace engine::editor::world
 			LOG_WARN(EditorWorld,
 				"[WorldEditorShell] Building SaveToDisk failed: {}", err);
 		}
+		// Roadmap-8 — persistance des 3 documents des outils câblés.
+		err.clear();
+		if (m_splineDoc.SaveToDisk(ZoneInstancesPath(cfg, "splines.bin"), err)) { ++written; }
+		else
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] Spline SaveToDisk failed: {}", err);
+		}
+		err.clear();
+		if (m_zoneDoc.SaveToDisk(ZoneInstancesPath(cfg, "zones.bin"), err)) { ++written; }
+		else
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] Zone SaveToDisk failed: {}", err);
+		}
+		err.clear();
+		if (m_hazardDoc.SaveToDisk(ZoneInstancesPath(cfg, "hazards.bin"), err)) { ++written; }
+		else
+		{
+			LOG_WARN(EditorWorld,
+				"[WorldEditorShell] Hazard SaveToDisk failed: {}", err);
+		}
 		LOG_INFO(EditorWorld,
-			"[WorldEditorShell] Saved zone documents: {}/4 (eau, mesh inserts, portails, batiments)",
+			"[WorldEditorShell] Saved zone documents: {}/7 (eau, mesh inserts, portails, batiments, splines, zones, hazards)",
 			written);
 		return written;
 	}

--- a/src/world_editor/core/WorldEditorShell.h
+++ b/src/world_editor/core/WorldEditorShell.h
@@ -27,6 +27,12 @@
 #include "src/world_editor/water/WaterDocument.h"
 #include "src/world_editor/scene/EditorSceneModel.h" // sous-projet 1, bloc B (selection + scene)
 #include "src/world_editor/scene/EntityEditOps.h"    // lot 5 (2026-07-18) : dupliquer/supprimer
+#include "src/world_editor/SplineTool.h"     // Roadmap-8 : outils M100.16/28/29 câblés
+#include "src/world_editor/SplineDocument.h"
+#include "src/world_editor/ZoneTool.h"
+#include "src/world_editor/ZoneDocument.h"
+#include "src/world_editor/HazardTool.h"
+#include "src/world_editor/HazardDocument.h"
 
 #include <functional>
 #include <memory>
@@ -475,7 +481,31 @@ namespace engine::editor::world
 		volumes::dungeons::DungeonPortalTool&       MutableDungeonPortalTool()       { return m_dungeonPortalTool; }
 		const volumes::dungeons::DungeonPortalTool& GetDungeonPortalTool()     const { return m_dungeonPortalTool; }
 
+		/// Roadmap-8 (audit 2026-06-05, 1.1) — Outils M100.29 (spline), M100.28
+		/// (zones de gameplay) et M100.16 (dangers) enfin câblés : accès pour le
+		/// ToolPropertiesPanel (paramètres) et l'Engine (clics viewport).
+		SplineTool&       MutableSplineTool()       { return m_splineTool; }
+		const SplineTool& GetSplineTool()     const { return m_splineTool; }
+		ZoneTool&         MutableZoneTool()         { return m_zoneTool; }
+		const ZoneTool&   GetZoneTool()       const { return m_zoneTool; }
+		HazardTool&       MutableHazardTool()       { return m_hazardTool; }
+		const HazardTool& GetHazardTool()     const { return m_hazardTool; }
+
+		/// Roadmap-8 — Documents persistés des 3 outils câblés (sérialisés dans
+		/// `instances/zone_<id>/{splines,zones,hazards}.bin` par
+		/// `SaveZoneDocuments`, relus par `LoadZoneDocuments` — dette 7.2 comblée).
+		SplineDocument&       MutableSplineDocument()       { return m_splineDoc; }
+		const SplineDocument& GetSplineDocument()     const { return m_splineDoc; }
+		ZoneDocument&         MutableZoneDocument()         { return m_zoneDoc; }
+		const ZoneDocument&   GetZoneDocument()       const { return m_zoneDoc; }
+		HazardDocument&       MutableHazardDocument()       { return m_hazardDoc; }
+		const HazardDocument& GetHazardDocument()     const { return m_hazardDoc; }
+
 	private:
+		/// Roadmap-8 — Chemin du fichier d'instances `file` de la zone courante
+		/// (`<paths.content>/instances/zone_<id>/<file>`, chemin plat legacy si
+		/// aucune zone). Effet de bord : crée le dossier parent au besoin.
+		std::string ZoneInstancesPath(const engine::core::Config& cfg, const char* file) const;
 		/// Rend la barre de menu File/Edit/View/Tools/Window/Help (M100.1
 		/// stubs pour la plupart des items). Effet de bord : ImGui state.
 		void RenderMenuBar();
@@ -536,6 +566,12 @@ namespace engine::editor::world
 		volumes::arches::ArchTool   m_archTool;               // M100.42
 		volumes::dungeons::DungeonPortalDocument m_dungeonPortalDoc;  // M100.43
 		volumes::dungeons::DungeonPortalTool     m_dungeonPortalTool; // M100.43
+		SplineTool     m_splineTool;  // Roadmap-8 (M100.29 câblé)
+		SplineDocument m_splineDoc;   // Roadmap-8
+		ZoneTool       m_zoneTool;    // Roadmap-8 (M100.28 câblé)
+		ZoneDocument   m_zoneDoc;     // Roadmap-8
+		HazardTool     m_hazardTool;  // Roadmap-8 (M100.16 câblé)
+		HazardDocument m_hazardDoc;   // Roadmap-8
 		buildings::BuildingDocument m_buildingDoc;                    // Auberge éditable
 		panels::BuildingEditorPanel* m_buildingEditorPtr = nullptr;  // non possédé (dans m_panels)
 		engine::world::instances::BuildingTemplateLibrary m_buildingLibrary; // bibliothèque de types

--- a/src/world_editor/panels/ToolPropertiesPanel.cpp
+++ b/src/world_editor/panels/ToolPropertiesPanel.cpp
@@ -29,6 +29,8 @@
 #include "src/world_editor/terrain/ValleyChainTool.h"
 #include "src/world_editor/water/WaterDocument.h"
 #include "src/world_editor/core/WorldEditorShell.h"
+#include "src/world_editor/SplineCommand.h"       // Roadmap-8 : bouton « Ajouter la spline »
+#include "src/world_editor/GameplayZoneCommand.h" // Roadmap-8 : bouton « Ajouter la zone »
 
 #if defined(_WIN32)
 #	include "imgui.h"
@@ -36,7 +38,9 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdio>   // std::snprintf — buffer du champ Nom (Roadmap-8)
 #include <filesystem>
+#include <memory>
 
 namespace engine::editor::world::panels
 {
@@ -2170,6 +2174,106 @@ namespace engine::editor::world::panels
 				ImGui::TextUnformatted("Dungeon Portal (Phase 11)");
 				ImGui::Separator();
 				RenderDungeonPortalParams(*m_shell, m_shell->MutableDungeonPortalTool());
+			}
+			// Roadmap-8 (audit 2026-06-05, 1.1) — blocs de propriétés des outils
+			// M100.29 (spline), M100.28 (zones) et M100.16 (dangers) câblés.
+			else if (m_shell != nullptr &&
+				m_shell->GetActiveTool() == engine::editor::world::ActiveTool::Spline)
+			{
+				ImGui::TextUnformatted("Spline (route/chemin)");
+				ImGui::Separator();
+				engine::editor::world::SplineTool& tool = m_shell->MutableSplineTool();
+				ImGui::TextWrapped("Clic gauche dans la vue : ajoute un noeud au trace.");
+				ImGui::DragFloat("Largeur (m)", &tool.DefaultWidthMeters(), 0.25f, 0.5f, 60.0f, "%.2f");
+				ImGui::Text("Noeuds du trace : %d", static_cast<int>(tool.Current().nodes.size()));
+				ImGui::Text("Splines de la carte : %d", static_cast<int>(m_shell->GetSplineDocument().All().size()));
+				const bool canAddSpline = tool.Current().nodes.size() >= 2u;
+				if (!canAddSpline) ImGui::BeginDisabled();
+				if (ImGui::Button("Ajouter la spline"))
+				{
+					m_shell->MutableCommandStack().Push(
+						std::make_unique<engine::editor::world::AddSplineCommand>(
+							m_shell->MutableSplineDocument(), tool.Current()));
+					tool.Clear();
+				}
+				if (!canAddSpline) ImGui::EndDisabled();
+				ImGui::SameLine();
+				if (ImGui::Button("Effacer le trace")) tool.Clear();
+			}
+			else if (m_shell != nullptr &&
+				m_shell->GetActiveTool() == engine::editor::world::ActiveTool::GameplayZone)
+			{
+				ImGui::TextUnformatted("Zone de gameplay");
+				ImGui::Separator();
+				engine::editor::world::ZoneTool& tool = m_shell->MutableZoneTool();
+				engine::world::zones::GameplayZone& z = tool.Current();
+				ImGui::TextWrapped("Clic gauche dans la vue : ajoute un sommet au polygone.");
+				static const char* kZoneTypes[] = {
+					"Zone sure", "Zone JcJ", "Zone de raid", "Construction interdite",
+					"Declencheur de quete", "Meteo forcee" };
+				int typeIdx = static_cast<int>(z.type);
+				if (ImGui::Combo("Type", &typeIdx, kZoneTypes, 6))
+					z.type = static_cast<engine::world::zones::ZoneType>(typeIdx);
+				char nameBuf[64];
+				std::snprintf(nameBuf, sizeof(nameBuf), "%s", z.name.c_str());
+				if (ImGui::InputText("Nom", nameBuf, sizeof(nameBuf))) z.name = nameBuf;
+				if (z.type == engine::world::zones::ZoneType::QuestTrigger)
+				{
+					int questId = static_cast<int>(z.questId);
+					if (ImGui::DragInt("Quete (id)", &questId, 1, 0, 1000000))
+						z.questId = static_cast<uint32_t>(std::max(0, questId));
+				}
+				if (z.type == engine::world::zones::ZoneType::WeatherOverride)
+				{
+					int weather = static_cast<int>(z.weatherType);
+					if (ImGui::DragInt("Meteo (type)", &weather, 1, 0, 32))
+						z.weatherType = static_cast<uint32_t>(std::max(0, weather));
+					ImGui::DragFloat("Marge de transition (m)", &z.transitionMarginMeters, 0.5f, 0.0f, 100.0f);
+				}
+				ImGui::Text("Sommets du polygone : %d", static_cast<int>(z.polygon.size()));
+				ImGui::Text("Zones de la carte : %d", static_cast<int>(m_shell->GetZoneDocument().All().size()));
+				const bool canAddZone = z.polygon.size() >= 3u;
+				if (!canAddZone) ImGui::BeginDisabled();
+				if (ImGui::Button("Ajouter la zone"))
+				{
+					m_shell->MutableCommandStack().Push(
+						std::make_unique<engine::editor::world::AddGameplayZoneCommand>(
+							m_shell->MutableZoneDocument(), z));
+					tool.Clear();
+				}
+				if (!canAddZone) ImGui::EndDisabled();
+				ImGui::SameLine();
+				if (ImGui::Button("Effacer le polygone")) tool.Clear();
+			}
+			else if (m_shell != nullptr &&
+				m_shell->GetActiveTool() == engine::editor::world::ActiveTool::Hazard)
+			{
+				ImGui::TextUnformatted("Danger (piege)");
+				ImGui::Separator();
+				engine::editor::world::HazardTool& tool = m_shell->MutableHazardTool();
+				engine::world::hazard::HazardVolume& p = tool.Params();
+				ImGui::TextWrapped("Clic gauche dans la vue : pose un danger aux parametres courants (undoable).");
+				static const char* kHazardTypes[] = { "Sables mouvants", "Marecage", "Goudron", "Lave" };
+				int typeIdx = static_cast<int>(p.type);
+				if (ImGui::Combo("Type", &typeIdx, kHazardTypes, 4))
+					tool.SetType(static_cast<engine::world::hazard::HazardType>(typeIdx));
+				static const char* kShapes[] = { "Boite", "Cylindre" };
+				int shapeIdx = static_cast<int>(p.shape);
+				if (ImGui::Combo("Forme", &shapeIdx, kShapes, 2))
+					p.shape = static_cast<engine::world::hazard::HazardShape>(shapeIdx);
+				if (p.shape == engine::world::hazard::HazardShape::Cylinder)
+				{
+					ImGui::DragFloat("Rayon (m)", &p.cylRadius, 0.25f, 0.5f, 50.0f);
+					ImGui::DragFloat("Hauteur (m)", &p.cylHeight, 0.25f, 0.5f, 20.0f);
+				}
+				else
+				{
+					ImGui::DragFloat3("Demi-etendues (m)", &p.boxHalfExtents.x, 0.25f, 0.25f, 50.0f);
+				}
+				ImGui::DragFloat("Vitesse d'enfoncement (m/s)", &p.sinkRateMps, 0.01f, 0.0f, 2.0f);
+				ImGui::DragFloat("Profondeur max (m)", &p.maxDepthMeters, 0.05f, 0.0f, 5.0f);
+				ImGui::DragFloat("Multiplicateur de vitesse", &p.slowdownMul, 0.01f, 0.0f, 1.0f);
+				ImGui::Text("Dangers de la carte : %d", static_cast<int>(m_shell->GetHazardDocument().All().size()));
 			}
 			else
 			{

--- a/src/world_editor/tests/GameplayDocsRoundTripTests.cpp
+++ b/src/world_editor/tests/GameplayDocsRoundTripTests.cpp
@@ -1,0 +1,138 @@
+/// Roadmap-8 (2026-07-19) — Tests CPU du round-trip Save→Load des documents
+/// des outils câblés (SplineDocument, ZoneDocument, HazardDocument), qui
+/// comble la dette audit 7.2 (SaveToDisk sans LoadFromDisk = écriture morte).
+/// Fichiers temporaires ; pur CPU, tourne sous ctest Linux.
+
+#include "src/world_editor/SplineDocument.h"
+#include "src/world_editor/ZoneDocument.h"
+#include "src/world_editor/HazardDocument.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+namespace
+{
+	int g_failed = 0;
+
+	#define REQUIRE(cond) do { \
+		if (!(cond)) { \
+			std::fprintf(stderr, "[FAIL] %s:%d  %s\n", __FILE__, __LINE__, #cond); \
+			++g_failed; \
+		} \
+	} while (0)
+
+	/// Dossier temporaire de travail (créé au premier appel).
+	std::string TempDir()
+	{
+		const std::filesystem::path dir =
+			std::filesystem::temp_directory_path() / "lcdlln_gameplay_docs_tests";
+		std::error_code ec;
+		std::filesystem::create_directories(dir, ec);
+		return dir.string();
+	}
+
+	void Test_SplineRoundTrip()
+	{
+		using engine::editor::world::SplineDocument;
+		const std::string path = TempDir() + "/splines.bin";
+		SplineDocument doc;
+		engine::world::spline::Spline s;
+		engine::world::spline::SplineNode n1; n1.position = { 10.0f, 1.0f, -5.0f }; n1.widthMeters = 4.5f;
+		engine::world::spline::SplineNode n2; n2.position = { 20.0f, 2.0f, -8.0f }; n2.widthMeters = 6.0f;
+		s.nodes.push_back(n1);
+		s.nodes.push_back(n2);
+		doc.Add(s);
+		std::string err;
+		REQUIRE(doc.SaveToDisk(path, err));
+
+		SplineDocument loaded;
+		REQUIRE(loaded.LoadFromDisk(path, err));
+		REQUIRE(loaded.All().size() == 1u);
+		if (loaded.All().size() == 1u)
+		{
+			REQUIRE(loaded.All()[0].nodes.size() == 2u);
+			REQUIRE(loaded.All()[0].nodes[1].widthMeters == 6.0f);
+			REQUIRE(loaded.All()[0].nodes[0].position.x == 10.0f);
+		}
+	}
+
+	void Test_ZoneRoundTrip()
+	{
+		using engine::editor::world::ZoneDocument;
+		const std::string path = TempDir() + "/zones.bin";
+		ZoneDocument doc;
+		engine::world::zones::GameplayZone z;
+		z.type = engine::world::zones::ZoneType::PvPZone;
+		z.name = "arene";
+		z.polygon = { { 0.0f, 0.0f, 0.0f }, { 10.0f, 0.0f, 0.0f }, { 5.0f, 0.0f, 10.0f } };
+		doc.Add(z);
+		std::string err;
+		REQUIRE(doc.SaveToDisk(path, err));
+
+		ZoneDocument loaded;
+		REQUIRE(loaded.LoadFromDisk(path, err));
+		REQUIRE(loaded.All().size() == 1u);
+		if (loaded.All().size() == 1u)
+		{
+			REQUIRE(loaded.All()[0].type == engine::world::zones::ZoneType::PvPZone);
+			REQUIRE(loaded.All()[0].name == "arene");
+			REQUIRE(loaded.All()[0].polygon.size() == 3u);
+		}
+	}
+
+	void Test_HazardRoundTrip()
+	{
+		using engine::editor::world::HazardDocument;
+		const std::string path = TempDir() + "/hazards.bin";
+		HazardDocument doc;
+		engine::world::hazard::HazardVolume h =
+			engine::world::hazard::MakeDefaultHazard(engine::world::hazard::HazardType::Tar);
+		h.position = { 42.0f, 3.0f, -7.0f };
+		h.cylRadius = 8.0f;
+		doc.Add(h);
+		std::string err;
+		REQUIRE(doc.SaveToDisk(path, err));
+
+		HazardDocument loaded;
+		REQUIRE(loaded.LoadFromDisk(path, err));
+		REQUIRE(loaded.All().size() == 1u);
+		if (loaded.All().size() == 1u)
+		{
+			REQUIRE(loaded.All()[0].type == engine::world::hazard::HazardType::Tar);
+			REQUIRE(loaded.All()[0].position.x == 42.0f);
+			REQUIRE(loaded.All()[0].cylRadius == 8.0f);
+		}
+	}
+
+	/// Fichier absent = succès avec liste vide (carte sans instances).
+	void Test_MissingFileIsEmptySuccess()
+	{
+		std::string err;
+		engine::editor::world::SplineDocument sd;
+		REQUIRE(sd.LoadFromDisk(TempDir() + "/absent_splines.bin", err));
+		REQUIRE(sd.All().empty());
+		engine::editor::world::ZoneDocument zd;
+		REQUIRE(zd.LoadFromDisk(TempDir() + "/absent_zones.bin", err));
+		REQUIRE(zd.All().empty());
+		engine::editor::world::HazardDocument hd;
+		REQUIRE(hd.LoadFromDisk(TempDir() + "/absent_hazards.bin", err));
+		REQUIRE(hd.All().empty());
+	}
+}
+
+int main()
+{
+	Test_SplineRoundTrip();
+	Test_ZoneRoundTrip();
+	Test_HazardRoundTrip();
+	Test_MissingFileIsEmptySuccess();
+
+	if (g_failed == 0)
+	{
+		std::printf("[PASS] GameplayDocsRoundTripTests\n");
+		return 0;
+	}
+	std::printf("[FAIL] GameplayDocsRoundTripTests: %d failure(s)\n", g_failed);
+	return 1;
+}

--- a/src/world_editor/tests/ToolPaletteModelTests.cpp
+++ b/src/world_editor/tests/ToolPaletteModelTests.cpp
@@ -2,8 +2,9 @@
 /// (réorganisation UI 2026-07-17, PR 2).
 ///
 /// Pas d'ImGui ni de shell — la suite tourne sous ctest Linux. On vérifie :
-///   - Les 4 familles couvrent exactement les 15 outils de l'enum (chaque
-///     valeur 1..15 apparaît UNE fois, aucune n'est oubliée ni dupliquée).
+///   - Les familles couvrent exactement les kActiveToolCount outils de
+///     l'enum (chaque valeur apparaît UNE fois, aucune oubliée ni dupliquée).
+///     Roadmap-8 : 5 familles depuis l'ajout de « Gameplay » (zones, dangers).
 ///   - Aucun groupe vide, titres non vides et uniques.
 ///   - `ToolLabelFr` : libellé non vide et unique pour chaque outil, cas
 ///     `None` et valeur hors enum définis (pas de nullptr).
@@ -56,11 +57,12 @@ namespace
 		REQUIRE(total == static_cast<size_t>(kActiveToolCount));
 	}
 
-	/// Test : structure des groupes — 4 familles, non vides, titres uniques.
+	/// Test : structure des groupes — 5 familles (Roadmap-8 : + « Gameplay »),
+	/// non vides, titres uniques.
 	void Test_Groups_TitlesAndNonEmpty()
 	{
 		const std::vector<ToolPaletteGroup>& groups = GetToolPaletteGroups();
-		REQUIRE(groups.size() == 4u);
+		REQUIRE(groups.size() == 5u);
 		std::set<std::string> titles;
 		for (const ToolPaletteGroup& g : groups)
 		{

--- a/src/world_editor/ui/ToolGlyphs.cpp
+++ b/src/world_editor/ui/ToolGlyphs.cpp
@@ -180,6 +180,40 @@ namespace engine::editor::world
 			c.dl->AddCircleFilled(c.P(0.60f, 0.58f), c.w * 0.05f, IM_COL32(35, 37, 42, 255));
 			c.dl->AddLine(c.P(0.22f, 0.88f), c.P(0.78f, 0.88f), c.col, c.th);
 		}
+
+		// ---- Gameplay (Roadmap-8) -------------------------------------------
+
+		/// Spline : courbe en S + nœuds ronds (route à points de contrôle).
+		void GlyphSpline(const GlyphCtx& c)
+		{
+			c.dl->PathLineTo(c.P(0.15f, 0.85f));
+			c.dl->PathBezierCubicCurveTo(c.P(0.55f, 0.75f), c.P(0.35f, 0.25f), c.P(0.85f, 0.15f));
+			c.dl->PathStroke(c.col, 0, c.th * 1.3f);
+			c.dl->AddCircleFilled(c.P(0.15f, 0.85f), c.w * 0.07f, c.col);
+			c.dl->AddCircleFilled(c.P(0.50f, 0.50f), c.w * 0.07f, c.col);
+			c.dl->AddCircleFilled(c.P(0.85f, 0.15f), c.w * 0.07f, c.col);
+		}
+
+		/// Zone de gameplay : pentagone ouvert (polygone tracé) + drapeau.
+		void GlyphGameplayZone(const GlyphCtx& c)
+		{
+			c.dl->PathLineTo(c.P(0.20f, 0.80f));
+			c.dl->PathLineTo(c.P(0.15f, 0.40f));
+			c.dl->PathLineTo(c.P(0.50f, 0.18f));
+			c.dl->PathLineTo(c.P(0.85f, 0.42f));
+			c.dl->PathLineTo(c.P(0.75f, 0.80f));
+			c.dl->PathStroke(c.col, ImDrawFlags_Closed, c.th);
+			c.dl->AddLine(c.P(0.50f, 0.62f), c.P(0.50f, 0.36f), c.col, c.th);
+			c.dl->AddTriangleFilled(c.P(0.50f, 0.36f), c.P(0.66f, 0.42f), c.P(0.50f, 0.48f), c.col);
+		}
+
+		/// Danger : triangle d'avertissement + point d'exclamation.
+		void GlyphHazard(const GlyphCtx& c)
+		{
+			c.dl->AddTriangle(c.P(0.50f, 0.12f), c.P(0.10f, 0.85f), c.P(0.90f, 0.85f), c.col, c.th);
+			c.dl->AddLine(c.P(0.50f, 0.36f), c.P(0.50f, 0.62f), c.col, c.th * 1.2f);
+			c.dl->AddCircleFilled(c.P(0.50f, 0.74f), c.w * 0.05f, c.col);
+		}
 	}
 
 	void DrawToolGlyph(ImDrawList* drawList, ActiveTool tool,
@@ -217,6 +251,10 @@ namespace engine::editor::world
 			case ActiveTool::Overhang:           GlyphOverhang(c); break;
 			case ActiveTool::Arch:               GlyphArch(c); break;
 			case ActiveTool::DungeonPortal:      GlyphDungeonPortal(c); break;
+			// Roadmap-8 (audit 2026-06-05, 1.1) — outils M100.16/28/29 câblés.
+			case ActiveTool::Spline:             GlyphSpline(c); break;
+			case ActiveTool::GameplayZone:       GlyphGameplayZone(c); break;
+			case ActiveTool::Hazard:             GlyphHazard(c); break;
 			case ActiveTool::None:               break; // pas de glyphe
 		}
 	}

--- a/src/world_editor/ui/ToolPaletteModel.cpp
+++ b/src/world_editor/ui/ToolPaletteModel.cpp
@@ -33,6 +33,13 @@ namespace engine::editor::world
 				ActiveTool::Overhang,
 				ActiveTool::Arch,
 				ActiveTool::DungeonPortal,
+				ActiveTool::Spline, // Roadmap-8 — routes/chemins
+			} },
+			// Roadmap-8 (audit 2026-06-05, thème 1.1) — famille Gameplay :
+			// outils M100.16/M100.28 enfin câblés (zones typées + dangers).
+			{ "Gameplay", {
+				ActiveTool::GameplayZone,
+				ActiveTool::Hazard,
 			} },
 		};
 		return kGroups;
@@ -58,6 +65,9 @@ namespace engine::editor::world
 			case ActiveTool::Overhang:           return "Surplomb";
 			case ActiveTool::Arch:               return "Arche";
 			case ActiveTool::DungeonPortal:      return "Portail de donjon";
+			case ActiveTool::Spline:             return "Spline (route/chemin)";
+			case ActiveTool::GameplayZone:       return "Zone de gameplay";
+			case ActiveTool::Hazard:             return "Danger (piège)";
 		}
 		return "?";
 	}
@@ -82,6 +92,9 @@ namespace engine::editor::world
 			case ActiveTool::Overhang:           return "tool.overhang";
 			case ActiveTool::Arch:               return "tool.arch";
 			case ActiveTool::DungeonPortal:      return "tool.dungeon-portal";
+			case ActiveTool::Spline:             return "tool.spline";
+			case ActiveTool::GameplayZone:       return "tool.gameplay-zone";
+			case ActiveTool::Hazard:             return "tool.hazard";
 		}
 		return "";
 	}

--- a/src/world_editor/ui/ToolbarIconAtlas.cpp
+++ b/src/world_editor/ui/ToolbarIconAtlas.cpp
@@ -38,6 +38,13 @@ namespace engine::editor::world
 				return { 0xFF5A4A36u, "A", "Placer une arche naturelle (Phase 11)", true };
 			case ActiveTool::DungeonPortal:
 				return { 0xFF6A2E5Au, "D", "Placer un portail de donjon (Phase 11)", true };
+			// Roadmap-8 (audit 2026-06-05, 1.1) — outils M100.16/28/29 câblés.
+			case ActiveTool::Spline:
+				return { 0xFF9A8A5Au, "S", "Tracer une spline (route/chemin)",      true };
+			case ActiveTool::GameplayZone:
+				return { 0xFF3A7A5Au, "Z", "Tracer une zone de gameplay",           true };
+			case ActiveTool::Hazard:
+				return { 0xFFB05A2Au, "!", "Poser un danger (piège)",               true };
 		}
 		// Fallback générique pour outils futurs non encore mappés : carré
 		// neutre, désactivé, tooltip standard "Bientôt disponible".

--- a/src/world_editor/ui/WorldEditorImGui.cpp
+++ b/src/world_editor/ui/WorldEditorImGui.cpp
@@ -2905,6 +2905,10 @@ namespace engine::editor
 			{ "tool.overhang", "Surplomb", "Structures", "Ctrl+Shift+O", ActiveTool::Overhang },
 			{ "tool.arch", "Arche", "Structures", "Ctrl+Shift+A", ActiveTool::Arch },
 			{ "tool.dungeon-portal", "Portail de donjon", "Structures", "Ctrl+Shift+D", ActiveTool::DungeonPortal },
+			// Roadmap-8 (audit 2026-06-05, 1.1) — outils M100.16/28/29 câblés.
+			{ "tool.spline", "Spline (route/chemin)", "Structures", nullptr, ActiveTool::Spline },
+			{ "tool.gameplay-zone", "Zone de gameplay", "Gameplay", nullptr, ActiveTool::GameplayZone },
+			{ "tool.hazard", "Danger (piège)", "Gameplay", nullptr, ActiveTool::Hazard },
 		};
 		for (const ToolActionSpec& spec : kToolActions)
 		{
@@ -3117,8 +3121,9 @@ namespace engine::editor
 			{
 				// Sous-menus par famille — même source (registre, section)
 				// que la future palette d'outils et la palette Ctrl+P.
+				// Roadmap-8 : famille « Gameplay » (zones + dangers).
 				static constexpr const char* kFamilies[] =
-					{ "Terrain", "Eau", "Macro", "Structures" };
+					{ "Terrain", "Eau", "Macro", "Structures", "Gameplay" };
 				for (const char* family : kFamilies)
 				{
 					if (!ImGui::BeginMenu(family)) continue;


### PR DESCRIPTION
## Objectif (roadmap 2026-07-19, chantier 8 — volet cablage, lot 1)

L'audit 2026-06-05 (theme 1.1) liste **14 outils compiles et testes mais inatteignables** (ni dans l'enum ActiveTool, ni dans la palette). Ce lot cable les **3 outils sans doublon avec les systemes vivants** et d'effort homogene :

- **Spline** (M100.29) — routes/chemins par polyligne a largeur ; debloque Bridge + Wall en lot 2.
- **Zone de gameplay** (M100.28) — polygones types : sure / JcJ / raid / construction interdite / declencheur de quete / meteo forcee.
- **Danger** (M100.16) — sables mouvants, marecage, goudron, lave (forme boite/cylindre, enfoncement, ralentissement).

## Cablage complet (les 5 etages, pour chacun)

1. **Enum + palette** : `ActiveTool` 16/17/18, `kActiveToolCount`=18 (les tests palette parametres par la constante couvrent automatiquement), nouvelle famille **« Gameplay »** dans la palette et le menu Outils, icones ToolbarIconAtlas (le fallback rendait tout outil non mappe **desactive**) + glyphes vectoriels dedies.
2. **Clic viewport** (Engine) : Spline/Zone = ajout de noeud/sommet au trace (pattern polyline MountainRange, Y au sol) ; Danger = **pose one-shot undoable** (`AddHazardCommand`).
3. **Proprietes** (ToolPropertiesPanel) : largeur de spline ; type/nom/parametres de zone (id de quete, meteo) ; type/forme/profondeur de danger — avec boutons **Ajouter** qui poussent des commandes undoables (`AddSplineCommand` existante, nouvelle `AddGameplayZoneCommand`).
4. **Shell** : instanciation des 3 outils + 3 documents (nouveau `ZoneDocument`).
5. **Persistance** : `SaveZoneDocuments` ecrit `instances/zone_<id>/{splines,zones,hazards}.bin` et — **dette audit 7.2 comblee** — `LoadZoneDocuments` les RELIT (avant : ecriture morte, contenu perdu a chaque rechargement). Reset au changement de carte.

## Tests (ctest)

Nouveau `gameplay_docs_round_trip_tests` : round-trip Save→Load des 3 documents + fichier absent = liste vide. Les tests palette existants (exhaustivite, labels/ids uniques) couvrent les ajouts via `kActiveToolCount`.

## Limites V1 assumees (parite avec les polylines macro existantes)

Le trace en cours est suivi par les compteurs du panneau (pas d'overlay viewport dedie) ; les splines/zones/dangers poses ne sont pas encore rendus dans la vue editeur — overlay = suite naturelle du chantier.

## Decision produit a valider (suite du chantier 8)

L'exploration recommande de **retirer** 3 des 14 orphelins (Placement, Selection, Delete) : ils dupliquent les systemes vivants (placement layout undoable PR #999, multi-selection, DeleteEntityCommand Lot-5) sur un espace d'ids mort. Rien n'est supprime dans cette PR — dis-moi si tu valides le retrait. Restent en lots suivants : Bridge/Wall (des que Spline est merge), Foliage/Forest/Field (necessitent un pipeline de rendu vegetation), Layers (via Outliner), WindZone/Hamlet (niche).

**Deploiement** : ✅ client uniquement (editeur monde), pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)