### PR TITLE
feat(game): ceinture v2 evolutive - 4 a 12 slots via ceintures equipables + drag & drop

### DIFF
--- a/game/data/config/vendors.json
+++ b/game/data/config/vendors.json
@@ -6,7 +6,9 @@
       "kind": "general",
       "items": [
         { "item_id": 1, "buy_price": 100, "stock": 50 },
-        { "item_id": 2, "buy_price": 500, "stock": -1 }
+        { "item_id": 2, "buy_price": 500, "stock": -1 },
+        { "item_id": 5131, "buy_price": 800, "stock": -1 },
+        { "item_id": 5132, "buy_price": 2500, "stock": -1 }
       ]
     }
   ]

--- a/game/data/items/items.json
+++ b/game/data/items/items.json
@@ -293,6 +293,36 @@
       "icon": "items/bourse_volee.png",
       "type": "misc",
       "slot": "none"
+    },
+    {
+      "id": 5131,
+      "name": "Ceinture de cuir robuste",
+      "description": "Une ceinture de cuir epais a 6 poches. De quoi garder ses potions a portee de main.",
+      "icon": "items/ceinture_cuir.png",
+      "type": "armor",
+      "slot": "waist",
+      "belt_slots": 6,
+      "bonus": { "hp": 3 }
+    },
+    {
+      "id": 5132,
+      "name": "Ceinture de campagne",
+      "description": "Huit poches renforcees, cousues pour les longues expeditions.",
+      "icon": "items/ceinture_campagne.png",
+      "type": "armor",
+      "slot": "waist",
+      "belt_slots": 8,
+      "bonus": { "hp": 5, "stamina": 2 }
+    },
+    {
+      "id": 5133,
+      "name": "Grande ceinture du colporteur",
+      "description": "Douze poches, des boucles partout : le colporteur qui la portait ne manquait jamais de rien.",
+      "icon": "items/ceinture_colporteur.png",
+      "type": "armor",
+      "slot": "waist",
+      "belt_slots": 12,
+      "bonus": { "hp": 8, "stamina": 4 }
     }
   ]
 }

--- a/game/data/loot/loot_tables.txt
+++ b/game/data/loot/loot_tables.txt
@@ -26,3 +26,6 @@
 104 6003 1 owner 100 2 4
 104 5001 1 owner 12
 104 2002 1 owner 60 2 3
+# Ceinture v2 (2026-07-20) — la Grande ceinture du colporteur (12 slots)
+# ne s'achete pas : drop rare du mini-boss.
+104 5133 1 owner 8

--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -12208,52 +12208,206 @@ namespace engine
 							}
 						}
 
-						// Roadmap-3 (2026-07-19) — CEINTURE : 4 slots d'objets
-						// ACTIFS à droite de la barre d'action (jetons
-						// "item:<id>" : gâteaux, potions…). Activation par
-						// Maj+1..4 ou clic sur la case ; le serveur applique
-						// l'effet (CastRequest avec le jeton).
+						// Ceinture v2 (2026-07-20) — barre d'objets ACTIFS à taille
+						// DYNAMIQUE (4 par défaut, 12 max — capacité autoritaire
+						// = ceinture équipée en slot Waist, reçue via kind 100).
+						// Fenêtre ImGui invisible : chaque case est un vrai
+						// widget → drag & drop natif (sac → case, case → case),
+						// tooltips, clic droit pour vider. Activation : Maj+1..9
+						// ou clic complet (relâché sans drag) sur la case.
 						{
-							const float beltSlot = 44.0f;
-							const float beltGap = 6.0f;
-							const float beltX = barX + barWidth + 24.0f;
-							const float beltY = dh - beltSlot - 16.0f;
-							const auto& beltLayout = uiModel.playerStats.beltLayout;
-							const bool shiftHeld = m_input.IsDown(engine::platform::Key::Shift);
-							for (size_t bi = 0; bi < beltLayout.size(); ++bi)
+							const std::vector<std::string>& beltLayout = uiModel.playerStats.beltLayout;
+							const size_t beltCount = beltLayout.size();
+							if (beltCount > 0u)
 							{
-								const float bx0 = beltX + static_cast<float>(bi) * (beltSlot + beltGap);
-								const std::string& beltTok = beltLayout[bi];
-								uint32_t beltItemId = 0u;
-								const bool occupied = engine::anniversary::ParseItemToken(beltTok, beltItemId);
-								fg->AddRectFilled(ImVec2(bx0, beltY), ImVec2(bx0 + beltSlot, beltY + beltSlot),
-									occupied ? IM_COL32(30, 44, 34, 220) : IM_COL32(14, 16, 22, 160), 6.0f);
-								fg->AddRect(ImVec2(bx0, beltY), ImVec2(bx0 + beltSlot, beltY + beltSlot),
-									IM_COL32(120, 170, 130, occupied ? 220 : 120), 6.0f, 0, 2.0f);
-								char beltKeyLabel[8];
-								std::snprintf(beltKeyLabel, sizeof(beltKeyLabel), "M%d", static_cast<int>(bi) + 1);
-								fg->AddText(ImVec2(bx0 + 3.0f, beltY + 2.0f),
-									IM_COL32(200, 230, 205, 200), beltKeyLabel);
-								if (!occupied)
-									continue;
-								const engine::items::ItemDefinition* bdef = m_itemCatalog.Find(beltItemId);
-								const char* blabel = (bdef != nullptr && !bdef->name.empty())
-									? bdef->name.c_str() : "Objet";
-								fg->AddText(ImVec2(bx0 + 3.0f, beltY + beltSlot * 0.5f - 6.0f),
-									IM_COL32(235, 245, 235, 255), blabel);
-								const bool beltKeyPressed = keysAllowed && shiftHeld
-									&& m_input.WasPressed(static_cast<engine::platform::Key>('1' + static_cast<int>(bi)));
-								const bool beltClicked =
-									m_input.WasMousePressed(engine::platform::MouseButton::Left)
-									&& m_input.MouseX() >= static_cast<int>(bx0)
-									&& m_input.MouseX() <= static_cast<int>(bx0 + beltSlot)
-									&& m_input.MouseY() >= static_cast<int>(beltY)
-									&& m_input.MouseY() <= static_cast<int>(beltY + beltSlot);
-								if (beltKeyPressed || beltClicked)
+								const float beltSlotSz = 48.0f;
+								const float beltGap = 6.0f;
+								// 2 rangées à partir de 7 cases (une grande
+								// ceinture ne doit pas traverser l'écran).
+								const size_t perRow = (beltCount <= 6u) ? beltCount : ((beltCount + 1u) / 2u);
+								const size_t rowCount = (beltCount + perRow - 1u) / perRow;
+								const float beltW = static_cast<float>(perRow) * beltSlotSz
+									+ static_cast<float>(perRow - 1u) * beltGap;
+								const float beltH = static_cast<float>(rowCount) * beltSlotSz
+									+ static_cast<float>(rowCount - 1u) * beltGap;
+								const float beltX = barX + barWidth + 24.0f;
+								const float beltY = dh - beltH - 16.0f;
+								const bool shiftHeld = m_input.IsDown(engine::platform::Key::Shift);
+								const uint32_t beltClientId = m_gameplayUdp.ServerClientId();
+
+								ImGui::SetNextWindowPos(ImVec2(beltX - 6.0f, beltY - 20.0f));
+								ImGui::SetNextWindowSize(ImVec2(beltW + 12.0f, beltH + 26.0f));
+								ImGui::Begin("##belt_bar", nullptr,
+									ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoBackground
+									| ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoScrollbar
+									| ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoFocusOnAppearing
+									| ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoSavedSettings);
+								ImDrawList* bdl = ImGui::GetWindowDrawList();
+								char beltTitle[32];
+								std::snprintf(beltTitle, sizeof(beltTitle), "Ceinture  %d/%d",
+									static_cast<int>(beltCount),
+									static_cast<int>(engine::items::kBeltSlotsMax));
+								bdl->AddText(ImVec2(beltX, beltY - 18.0f),
+									IM_COL32(190, 215, 195, 200), beltTitle);
+
+								// Copie de travail : mutée par drop/échange/vidage,
+								// envoyée en une fois si changement.
+								std::vector<std::string> newBelt(beltLayout.begin(), beltLayout.end());
+								bool beltChanged = false;
+
+								for (size_t bi = 0; bi < beltCount; ++bi)
 								{
-									const uint32_t beltClientId = m_gameplayUdp.ServerClientId();
-									if (beltClientId != 0u)
+									const size_t row = bi / perRow;
+									const size_t colIdx = bi % perRow;
+									const float bx0 = beltX + static_cast<float>(colIdx) * (beltSlotSz + beltGap);
+									const float by0 = beltY + static_cast<float>(row) * (beltSlotSz + beltGap);
+									const std::string& beltTok = beltLayout[bi];
+									uint32_t beltItemId = 0u;
+									const bool occupied = engine::anniversary::ParseItemToken(beltTok, beltItemId);
+									const engine::items::ItemDefinition* bdef =
+										occupied ? m_itemCatalog.Find(beltItemId) : nullptr;
+
+									ImGui::SetCursorScreenPos(ImVec2(bx0, by0));
+									char beltBtnId[16];
+									std::snprintf(beltBtnId, sizeof(beltBtnId), "##belt%d", static_cast<int>(bi));
+									ImGui::InvisibleButton(beltBtnId, ImVec2(beltSlotSz, beltSlotSz));
+									const bool hovered = ImGui::IsItemHovered();
+
+									// Quantité restante en sac (somme des piles).
+									uint32_t beltQty = 0u;
+									if (occupied)
+									{
+										for (const engine::client::InventorySlotState& is : m_invUi.GetState().slots)
+											if (is.occupied && is.itemId == beltItemId)
+												beltQty += is.quantity;
+									}
+
+									// Visuel : fond, bordure (survol = doré), raccourci,
+									// initiale de l'objet en grand + quantité en bas-droite.
+									const ImU32 fillCol = occupied
+										? IM_COL32(32, 46, 36, 235) : IM_COL32(14, 16, 22, 170);
+									const ImU32 borderCol = hovered
+										? IM_COL32(235, 205, 120, 255)
+										: IM_COL32(120, 170, 130, occupied ? 220 : 110);
+									bdl->AddRectFilled(ImVec2(bx0, by0),
+										ImVec2(bx0 + beltSlotSz, by0 + beltSlotSz), fillCol, 6.0f);
+									bdl->AddRect(ImVec2(bx0, by0),
+										ImVec2(bx0 + beltSlotSz, by0 + beltSlotSz), borderCol, 6.0f, 0,
+										hovered ? 2.5f : 2.0f);
+									if (bi < 9u)
+									{
+										char beltKeyLabel[12];
+										std::snprintf(beltKeyLabel, sizeof(beltKeyLabel), "M+%d",
+											static_cast<int>(bi) + 1);
+										bdl->AddText(ImVec2(bx0 + 3.0f, by0 + 2.0f),
+											IM_COL32(200, 230, 205, 190), beltKeyLabel);
+									}
+									if (occupied)
+									{
+										// Initiale (2 lettres) au centre — lisible sans atlas d'icônes.
+										const char* bname = (bdef != nullptr && !bdef->name.empty())
+											? bdef->name.c_str() : "?";
+										char initials[3] = { bname[0], bname[1] != '\0' ? bname[1] : ' ', '\0' };
+										const ImVec2 initSz = ImGui::CalcTextSize(initials);
+										bdl->AddText(ImVec2(bx0 + (beltSlotSz - initSz.x) * 0.5f,
+											by0 + (beltSlotSz - initSz.y) * 0.5f),
+											IM_COL32(240, 250, 240, 255), initials);
+										char beltQtyTxt[12];
+										std::snprintf(beltQtyTxt, sizeof(beltQtyTxt), "%u", beltQty);
+										const ImVec2 qtySz = ImGui::CalcTextSize(beltQtyTxt);
+										bdl->AddText(ImVec2(bx0 + beltSlotSz - qtySz.x - 3.0f,
+											by0 + beltSlotSz - qtySz.y - 2.0f),
+											beltQty > 0u ? IM_COL32(255, 240, 190, 255)
+											             : IM_COL32(255, 120, 110, 255),
+											beltQtyTxt);
+									}
+
+									// Source de drag (réorganisation case → case).
+									if (occupied && ImGui::BeginDragDropSource(ImGuiDragDropFlags_None))
+									{
+										int fromIndex = static_cast<int>(bi);
+										ImGui::SetDragDropPayload("LN_BELT_MOVE", &fromIndex, sizeof(int));
+										ImGui::TextUnformatted((bdef != nullptr && !bdef->name.empty())
+											? bdef->name.c_str() : "Objet");
+										ImGui::EndDragDropSource();
+									}
+									// Cible de drop : échange interne OU objet du sac.
+									if (ImGui::BeginDragDropTarget())
+									{
+										if (const ImGuiPayload* mv = ImGui::AcceptDragDropPayload("LN_BELT_MOVE"))
+										{
+											if (mv->DataSize == static_cast<int>(sizeof(int)))
+											{
+												const int from = *static_cast<const int*>(mv->Data);
+												if (from >= 0 && from < static_cast<int>(newBelt.size())
+													&& from != static_cast<int>(bi))
+												{
+													std::swap(newBelt[static_cast<size_t>(from)], newBelt[bi]);
+													beltChanged = true;
+												}
+											}
+										}
+										if (const ImGuiPayload* it = ImGui::AcceptDragDropPayload("LN_EQUIP_ITEM"))
+										{
+											if (it->DataSize == static_cast<int>(sizeof(uint32_t)))
+											{
+												const uint32_t droppedId = *static_cast<const uint32_t*>(it->Data);
+												const std::string droppedTok =
+													engine::anniversary::MakeItemToken(droppedId);
+												bool already = false;
+												for (const std::string& s : newBelt)
+													if (s == droppedTok) { already = true; break; }
+												if (!already)
+												{
+													newBelt[bi] = droppedTok;
+													beltChanged = true;
+												}
+											}
+										}
+										ImGui::EndDragDropTarget();
+									}
+									// Clic droit : vider la case.
+									if (occupied && hovered && ImGui::IsMouseClicked(ImGuiMouseButton_Right))
+									{
+										newBelt[bi].clear();
+										beltChanged = true;
+									}
+									// Tooltip riche.
+									if (hovered && occupied)
+									{
+										ImGui::BeginTooltip();
+										ImGui::TextUnformatted((bdef != nullptr && !bdef->name.empty())
+											? bdef->name.c_str() : "Objet");
+										if (bdef != nullptr && !bdef->description.empty())
+											ImGui::TextDisabled("%s", bdef->description.c_str());
+										ImGui::Separator();
+										if (bi < 9u)
+											ImGui::TextDisabled("Maj+%d ou clic : utiliser", static_cast<int>(bi) + 1);
+										else
+											ImGui::TextDisabled("Clic : utiliser");
+										ImGui::TextDisabled("Clic droit : retirer  |  Glisser : deplacer");
+										ImGui::TextDisabled("En sac : %u", beltQty);
+										ImGui::EndTooltip();
+									}
+
+									// Activation : Maj+1..9, ou clic COMPLET (press +
+									// release dans la case, sans drag en cours — permet
+									// de glisser sans consommer l'objet).
+									const bool beltKeyPressed = keysAllowed && shiftHeld && bi < 9u
+										&& m_input.WasPressed(static_cast<engine::platform::Key>('1' + static_cast<int>(bi)));
+									const bool beltClickCompleted = ImGui::IsItemDeactivated()
+										&& hovered && ImGui::GetDragDropPayload() == nullptr;
+									if (occupied && (beltKeyPressed || beltClickCompleted)
+										&& beltClientId != 0u)
+									{
 										(void)m_gameplayUdp.SendCastRequest(beltClientId, 0ull, beltTok);
+									}
+								}
+								ImGui::End();
+
+								if (beltChanged && beltClientId != 0u)
+								{
+									(void)m_gameplayUdp.SendSetBeltLayout(beltClientId, newBelt);
 								}
 							}
 						}
@@ -13233,12 +13387,13 @@ namespace engine
 				else if (equipAction.kind ==
 					engine::render::CharacterWindowImGuiRenderer::PendingEquipAction::Kind::SlotCake)
 				{
-					std::array<std::string, 4> belt = m_uiModelBinding.GetModel().playerStats.beltLayout;
+					// Ceinture v2 — layout à taille dynamique (vector).
+					std::vector<std::string> belt = m_uiModelBinding.GetModel().playerStats.beltLayout;
 					const std::string beltToken = engine::anniversary::MakeItemToken(equipAction.itemId);
 					bool alreadySlotted = false;
 					for (const std::string& s : belt)
 						if (s == beltToken) { alreadySlotted = true; break; }
-					if (!alreadySlotted)
+					if (!alreadySlotted && !belt.empty())
 					{
 						size_t target = 0;
 						for (size_t i = 0; i < belt.size(); ++i)

--- a/src/client/net/GameplayUdpClient.cpp
+++ b/src/client/net/GameplayUdpClient.cpp
@@ -376,7 +376,7 @@ namespace engine::client
 		return ok;
 	}
 
-	bool GameplayUdpClient::SendSetBeltLayout(uint32_t clientId, const std::array<std::string, 4>& slots)
+	bool GameplayUdpClient::SendSetBeltLayout(uint32_t clientId, const std::vector<std::string>& slots)
 	{
 		engine::server::SetBeltLayoutMessage msg{};
 		msg.clientId = clientId;

--- a/src/client/net/GameplayUdpClient.h
+++ b/src/client/net/GameplayUdpClient.h
@@ -81,7 +81,9 @@ namespace engine::client
 		/// Roadmap-3 (2026-07-19) — Ceinture : pose le layout des 4 slots
 		/// d'objets actifs (jetons "item:<id>", kind 99). ACK autoritaire
 		/// par BeltLayoutUpdate (kind 100).
-		bool SendSetBeltLayout(uint32_t clientId, const std::array<std::string, 4>& slots);
+		/// Ceinture v2 (2026-07-20) — envoie le layout complet (taille = capacité
+		/// active affichée ; le shard rejette un count > capacité autoritaire).
+		bool SendSetBeltLayout(uint32_t clientId, const std::vector<std::string>& slots);
 
 		/// SP-B — envoie un choix de skill de classe (ChooseClassSkillRequest, kind 91).
 		/// Le shard valide (niveau, unicité, appartenance au kit) et renvoie un

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -298,6 +298,11 @@ namespace engine::render
 			// Colonne droite (slots 6..10 : arme, bouclier, amulette, 2 anneaux).
 			for (std::size_t i = 0; i < 5; ++i)
 				drawEquipCell(6 + i, rightX, bandY + static_cast<float>(i) * (cell + gap));
+			// Ceinture v2 (2026-07-20) — 11e cellule (slot Waist) en bas de la
+			// colonne gauche : la ceinture équipée porte la capacité de la
+			// barre d'objets actifs (4 par défaut, 12 max).
+			drawEquipCell(static_cast<std::size_t>(engine::items::EquipmentSlot::Waist),
+				bandX, bandY + 5.0f * (cell + gap));
 
 			// Aperçu 3D au centre (carré, non déformé), réduit en largeur pour laisser
 			// la place aux deux colonnes de cellules.
@@ -411,23 +416,27 @@ namespace engine::render
 						(m_itemCatalog != nullptr) ? m_itemCatalog->Find(s.itemId) : nullptr;
 					const bool equippable = (def != nullptr) && def->IsEquippable();
 
-					// Item ImGui superposé (visuels déjà dessinés via wdl) : survol, clic
-					// et SOURCE de glisser-déposer vers les cellules d'équipement.
-					ImGui::SetCursorScreenPos(mn);
-					char invId[24];
-					std::snprintf(invId, sizeof(invId), "##invcell%d", i);
-					ImGui::InvisibleButton(invId, ImVec2(cell, cell));
-					if (equippable && ImGui::BeginDragDropSource(ImGuiDragDropFlags_None))
-					{
-						ImGui::SetDragDropPayload("LN_EQUIP_ITEM", &s.itemId, sizeof(uint32_t));
-						ImGui::TextUnformatted(s.label.empty() ? "Objet" : s.label.c_str());
-						ImGui::EndDragDropSource();
-					}
 					// Roadmap-3 (2026-07-19) — tout CONSOMMABLE (gâteau, potion,
 					// nourriture) se place dans la CEINTURE d'un clic (geste
 					// volontaire du joueur ; le serveur valide la possession).
 					const bool isCake = (def != nullptr)
 						&& def->type == engine::items::ItemType::Consumable;
+
+					// Item ImGui superposé (visuels déjà dessinés via wdl) : survol, clic
+					// et SOURCE de glisser-déposer vers les cellules d'équipement.
+					// Ceinture v2 (2026-07-20) — les consommables sont AUSSI
+					// draggables (cible : cases de la barre ceinture, payload
+					// commun LN_EQUIP_ITEM = itemId u32).
+					ImGui::SetCursorScreenPos(mn);
+					char invId[24];
+					std::snprintf(invId, sizeof(invId), "##invcell%d", i);
+					ImGui::InvisibleButton(invId, ImVec2(cell, cell));
+					if ((equippable || isCake) && ImGui::BeginDragDropSource(ImGuiDragDropFlags_None))
+					{
+						ImGui::SetDragDropPayload("LN_EQUIP_ITEM", &s.itemId, sizeof(uint32_t));
+						ImGui::TextUnformatted(s.label.empty() ? "Objet" : s.label.c_str());
+						ImGui::EndDragDropSource();
+					}
 					if (ImGui::IsItemHovered() && !s.label.empty())
 					{
 						ImGui::BeginTooltip();
@@ -445,7 +454,7 @@ namespace engine::render
 							if (isCake)
 							{
 								ImGui::Separator();
-								ImGui::TextDisabled("Clic : placer dans la ceinture");
+								ImGui::TextDisabled("Clic ou glisser : placer dans la ceinture");
 							}
 						}
 						ImGui::EndTooltip();

--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -230,9 +230,11 @@ namespace engine::client
 		/// Grimoire — layout autoritaire des 10 slots (slot i → spellId, "" = vide),
 		/// reçu via ActionBarLayoutUpdate (enter-world / ACK serveur).
 		std::array<std::string, 10> actionBarLayout{};
-		/// Roadmap-3 (2026-07-19) — ceinture : 4 slots d'objets actifs
-		/// (jetons "item:<id>"), reçue via BeltLayoutUpdate (kind 100).
-		std::array<std::string, 4> beltLayout{};
+		/// Roadmap-3 (2026-07-19) / Ceinture v2 (2026-07-20) — ceinture : slots
+		/// d'objets actifs (jetons "item:<id>"), taille = capacité ACTIVE
+		/// autoritaire (4 par défaut, 12 max — ceinture équipée en Waist),
+		/// reçue via BeltLayoutUpdate (kind 100, count-prefixed).
+		std::vector<std::string> beltLayout{};
 		/// PR-C — progression de niveau (barre d'XP), reçue via PlayerXpUpdate
 		/// (enter-world + chaque gain d'XP). \c xpForNextLevel = 0 signale le cap
 		/// de niveau. \c hasXp reste faux tant qu'aucun PlayerXpUpdate n'est reçu.

--- a/src/shardd/gameplay/character/CharacterPersistence.cpp
+++ b/src/shardd/gameplay/character/CharacterPersistence.cpp
@@ -202,11 +202,19 @@ namespace engine::server
 				persisted.GetString("actionbar.slot." + std::to_string(slotIndex), "");
 		}
 
-		// Roadmap-3 (2026-07-19) — ceinture (absent = "" = vide, rétro-compat).
-		for (size_t slotIndex = 0; slotIndex < outState.beltLayout.size(); ++slotIndex)
+		// Roadmap-3 (2026-07-19) / Ceinture v2 (2026-07-20) — ceinture à
+		// taille dynamique : belt.count (borné 12) puis belt.slot.N.
+		// Rétro-compat : les fichiers antérieurs n'ont pas belt.count → on
+		// lit les 4 clés historiques (absent = "" = vide).
 		{
-			outState.beltLayout[slotIndex] =
-				persisted.GetString("belt.slot." + std::to_string(slotIndex), "");
+			const int64_t beltCount = std::clamp<int64_t>(
+				persisted.GetInt("belt.count", 4), 0, 12);
+			outState.beltLayout.assign(static_cast<size_t>(beltCount), std::string{});
+			for (size_t slotIndex = 0; slotIndex < outState.beltLayout.size(); ++slotIndex)
+			{
+				outState.beltLayout[slotIndex] =
+					persisted.GetString("belt.slot." + std::to_string(slotIndex), "");
+			}
 		}
 
 		// Anniversaires SP3 (2026-07-18) — expirations des gâteaux (clés
@@ -357,7 +365,10 @@ namespace engine::server
 			output << "actionbar.slot." << slotIndex << "=" << state.actionBarLayout[slotIndex] << "\n";
 		}
 
-		// Roadmap-3 (2026-07-19) — ceinture (4 slots, clés fixes).
+		// Roadmap-3 (2026-07-19) / Ceinture v2 — ceinture à taille dynamique :
+		// belt.count puis belt.slot.N (les vieux lecteurs ignorent belt.count
+		// et relisent les 4 premières clés — dégradation propre).
+		output << "belt.count=" << state.beltLayout.size() << "\n";
 		for (size_t slotIndex = 0; slotIndex < state.beltLayout.size(); ++slotIndex)
 		{
 			output << "belt.slot." << slotIndex << "=" << state.beltLayout[slotIndex] << "\n";

--- a/src/shardd/gameplay/character/CharacterPersistence.h
+++ b/src/shardd/gameplay/character/CharacterPersistence.h
@@ -52,7 +52,9 @@ namespace engine::server
 		std::array<std::string, 10> actionBarLayout{};
 		/// Roadmap-3 (2026-07-19) — ceinture : 4 slots d'objets actifs
 		/// (jetons "item:<id>", "" = vide). Clés belt.slot.N.
-		std::array<std::string, 4> beltLayout{};
+		/// Ceinture v2 (2026-07-20) — slots dynamiques (persistés belt.count +
+		/// belt.slot.N ; rétro-compat : fichiers sans belt.count = 4 slots).
+		std::vector<std::string> beltLayout{};
 		/// SP-B — compétences par-classe déjà choisies (un skill par tier/niveau débloqué).
 		std::vector<std::string> knownSkillIds;
 		/// Anniversaires SP3 (2026-07-18) — expirations UTC (epoch ms) des

--- a/src/shared/items/ItemCatalog.cpp
+++ b/src/shared/items/ItemCatalog.cpp
@@ -66,6 +66,10 @@ namespace engine::items
 			def.type        = ItemTypeFromString(ToLowerAscii(cfg.GetString(p + ".type", "misc")));
 			def.slot        = EquipmentSlotFromString(ToLowerAscii(cfg.GetString(p + ".slot", "none")));
 			def.visualMesh  = cfg.GetString(p + ".visualMesh", "");
+			// Ceinture v2 (2026-07-20) — capacité de barre ceinture (0 = pas
+			// une ceinture ; clamp final 4..12 fait côté serveur à l'usage).
+			def.beltSlots   = static_cast<std::uint8_t>(
+				std::clamp<std::int64_t>(cfg.GetInt(p + ".belt_slots", 0), 0, 255));
 			if (cfg.Has(p + ".bonus.hp") || cfg.Has(p + ".bonus.damage") ||
 				cfg.Has(p + ".bonus.resource") || cfg.Has(p + ".bonus.accuracy") ||
 				cfg.Has(p + ".bonus.range") || cfg.Has(p + ".bonus.critRate") ||
@@ -112,6 +116,7 @@ namespace engine::items
 		if (s == "amulet")   return EquipmentSlot::Amulet;
 		if (s == "ring1")    return EquipmentSlot::Ring1;
 		if (s == "ring2")    return EquipmentSlot::Ring2;
+		if (s == "waist")    return EquipmentSlot::Waist; // Ceinture v2
 		return EquipmentSlot::None;
 	}
 
@@ -139,6 +144,7 @@ namespace engine::items
 		case EquipmentSlot::Amulet:   return "amulet";
 		case EquipmentSlot::Ring1:    return "ring1";
 		case EquipmentSlot::Ring2:    return "ring2";
+		case EquipmentSlot::Waist:    return "waist"; // Ceinture v2
 		default:                      return "none";
 		}
 	}

--- a/src/shared/items/ItemDefinition.h
+++ b/src/shared/items/ItemDefinition.h
@@ -29,7 +29,9 @@ namespace engine::items
 		Amulet,    // 8  (non visuel)
 		Ring1,     // 9  (non visuel)
 		Ring2,     // 10 (non visuel)
-		Count      // 11 borne
+		Waist,     // 11 (non visuel) — Ceinture v2 (2026-07-20) : porte la
+		           //     capacité de la barre ceinture via beltSlots (4..12)
+		Count      // 12 borne
 	};
 
 	// Nombre de slots réellement équipables (hors None). Utile pour dimensionner
@@ -79,6 +81,12 @@ namespace engine::items
 		}
 	};
 
+	// Ceinture v2 (2026-07-20) — bornes de la barre ceinture (objets actifs).
+	// Le joueur démarre à 4 slots (sans ceinture équipée) ; une ceinture
+	// équipée (slot Waist) porte sa capacité via `beltSlots`, plafonnée à 12.
+	inline constexpr std::uint8_t kBeltSlotsDefault = 4;
+	inline constexpr std::uint8_t kBeltSlotsMax     = 12;
+
 	// Définition complète d'un objet du catalogue.
 	struct ItemDefinition
 	{
@@ -90,6 +98,9 @@ namespace engine::items
 		EquipmentSlot slot = EquipmentSlot::None; // None => non équipable
 		StatBonus     bonus;                      // additif quand équipé
 		std::string   visualMesh;                 // apparence modulaire (SP-D) ; vide en SP-A
+		// Ceinture v2 — capacité de barre ceinture apportée quand l'objet est
+		// équipé en slot Waist (0 = pas une ceinture ; clampée 4..12 côté serveur).
+		std::uint8_t  beltSlots = 0;
 
 		bool IsEquippable() const { return slot != EquipmentSlot::None; }
 	};

--- a/src/shared/network/ServerProtocol.cpp
+++ b/src/shared/network/ServerProtocol.cpp
@@ -818,77 +818,90 @@ namespace engine::server
 		return true;
 	}
 
-	// Roadmap-3 (2026-07-19) — Ceinture (kinds 99/100, miroir exact 88/89 :
-	// clientId u32 + 4 chaînes préfixées u16, jetons "item:<id>" bornés 64 o).
+	// Roadmap-3 (2026-07-19) / Ceinture v2 (2026-07-20) — kinds 99/100 :
+	// clientId u32 + count u16 (≤ 12) + count chaînes préfixées u16 (jetons
+	// "item:<id>" bornés 64 o). Modèle count-prefixed d'EquipmentUpdate ;
+	// count autoritaire = capacité active (ceinture équipée, défaut 4).
+
+	namespace
+	{
+		/// Ceinture v2 — encode le payload commun des kinds 99/100 (clientId +
+		/// count + slots). \param kind SetBeltLayout ou BeltLayoutUpdate.
+		std::vector<std::byte> EncodeBeltSlots(MessageKind kind, uint32_t clientId,
+			const std::vector<std::string>& slots)
+		{
+			size_t hint = 4 + 2;
+			for (const std::string& slot : slots)
+			{
+				hint += 2 + slot.size();
+			}
+			std::vector<std::byte> packet = BeginPacket(kind, hint);
+			WriteU32(packet, clientId);
+			WriteU16(packet, static_cast<uint16_t>(slots.size()));
+			for (const std::string& slot : slots)
+			{
+				WriteSizedString(packet, slot);
+			}
+			return packet;
+		}
+
+		/// Ceinture v2 — décode le payload commun des kinds 99/100. Rejette
+		/// count > 12 (borne dure du design) et toute chaîne > 64 octets.
+		bool DecodeBeltSlots(std::span<const std::byte> payload, uint32_t& outClientId,
+			std::vector<std::string>& outSlots)
+		{
+			if (payload.size() < 6)
+			{
+				return false;
+			}
+			outClientId = ReadU32(payload, 0);
+			const uint16_t count = ReadU16(payload, 4);
+			if (count > 12u)
+			{
+				return false;
+			}
+			outSlots.clear();
+			outSlots.resize(count);
+			size_t offset = 6;
+			for (std::string& slot : outSlots)
+			{
+				if (!ReadSizedString(payload, offset, slot) || slot.size() > 64u)
+				{
+					return false;
+				}
+			}
+			return offset == payload.size();
+		}
+	}
 
 	std::vector<std::byte> EncodeSetBeltLayout(const SetBeltLayoutMessage& message)
 	{
-		size_t hint = 4;
-		for (const std::string& slot : message.slots)
-		{
-			hint += 2 + slot.size();
-		}
-		std::vector<std::byte> packet = BeginPacket(MessageKind::SetBeltLayout, hint);
-		WriteU32(packet, message.clientId);
-		for (const std::string& slot : message.slots)
-		{
-			WriteSizedString(packet, slot);
-		}
-		return packet;
+		return EncodeBeltSlots(MessageKind::SetBeltLayout, message.clientId, message.slots);
 	}
 
 	bool DecodeSetBeltLayout(std::span<const std::byte> packet, SetBeltLayoutMessage& outMessage)
 	{
 		std::span<const std::byte> payload;
-		if (!DecodeHeader(packet, MessageKind::SetBeltLayout, payload) || payload.size() < 4)
+		if (!DecodeHeader(packet, MessageKind::SetBeltLayout, payload))
 		{
 			return false;
 		}
-		outMessage.clientId = ReadU32(payload, 0);
-		size_t offset = 4;
-		for (std::string& slot : outMessage.slots)
-		{
-			if (!ReadSizedString(payload, offset, slot) || slot.size() > 64u)
-			{
-				return false;
-			}
-		}
-		return offset == payload.size();
+		return DecodeBeltSlots(payload, outMessage.clientId, outMessage.slots);
 	}
 
 	std::vector<std::byte> EncodeBeltLayoutUpdate(const BeltLayoutUpdateMessage& message)
 	{
-		size_t hint = 4;
-		for (const std::string& slot : message.slots)
-		{
-			hint += 2 + slot.size();
-		}
-		std::vector<std::byte> packet = BeginPacket(MessageKind::BeltLayoutUpdate, hint);
-		WriteU32(packet, message.clientId);
-		for (const std::string& slot : message.slots)
-		{
-			WriteSizedString(packet, slot);
-		}
-		return packet;
+		return EncodeBeltSlots(MessageKind::BeltLayoutUpdate, message.clientId, message.slots);
 	}
 
 	bool DecodeBeltLayoutUpdate(std::span<const std::byte> packet, BeltLayoutUpdateMessage& outMessage)
 	{
 		std::span<const std::byte> payload;
-		if (!DecodeHeader(packet, MessageKind::BeltLayoutUpdate, payload) || payload.size() < 4)
+		if (!DecodeHeader(packet, MessageKind::BeltLayoutUpdate, payload))
 		{
 			return false;
 		}
-		outMessage.clientId = ReadU32(payload, 0);
-		size_t offset = 4;
-		for (std::string& slot : outMessage.slots)
-		{
-			if (!ReadSizedString(payload, offset, slot) || slot.size() > 64u)
-			{
-				return false;
-			}
-		}
-		return offset == payload.size();
+		return DecodeBeltSlots(payload, outMessage.clientId, outMessage.slots);
 	}
 
 	std::vector<std::byte> EncodeClassProgressionUpdate(const ClassProgressionUpdateMessage& message)

--- a/src/shared/network/ServerProtocol.h
+++ b/src/shared/network/ServerProtocol.h
@@ -481,21 +481,28 @@ namespace engine::server
 		std::array<std::string, 10> slots{};
 	};
 
-	/// Roadmap-3 (2026-07-19) — Ceinture : 4 slots d'objets actifs (slot i →
+	/// Roadmap-3 (2026-07-19) — Ceinture : slots d'objets actifs (slot i →
 	/// jeton "item:<id>", "" = vide). Validée côté shard : objet POSSÉDÉ et
 	/// activable (consommable ou gâteau).
+	/// Ceinture v2 (2026-07-20) — taille VARIABLE : count u16 + count chaînes
+	/// (modèle EquipmentUpdate). La capacité est AUTORITAIRE côté shard
+	/// (ceinture équipée en slot Waist : 4 par défaut, 12 max) ; un count
+	/// client > capacité est rejeté. Client et shard basculent ensemble
+	/// (lock-step, décodeur strict) — pas de bump kProtocolVersion (framing
+	/// inchangé, kinds 99/100 conservés).
 	struct SetBeltLayoutMessage
 	{
 		uint32_t clientId = 0;
-		std::array<std::string, 4> slots{};
+		std::vector<std::string> slots;
 	};
 
 	/// Roadmap-3 — layout ceinture autoritaire poussé par le shard
 	/// (enter-world / ACK de SetBeltLayout, même réconciliation que 89).
+	/// Ceinture v2 : le nombre de slots envoyés = capacité ACTIVE du joueur.
 	struct BeltLayoutUpdateMessage
 	{
 		uint32_t clientId = 0;
-		std::array<std::string, 4> slots{};
+		std::vector<std::string> slots;
 	};
 
 	/// SP-B — shard → client : état autoritaire de progression de classe (classId + skills connus).

--- a/src/shared/network/ServerProtocolTests.cpp
+++ b/src/shared/network/ServerProtocolTests.cpp
@@ -442,6 +442,50 @@ namespace
 		std::puts("[OK] TestActionBarLayoutUpdateRoundTrip");
 	}
 
+	/// Ceinture v2 (2026-07-20) — kinds 99/100 count-prefixed : round-trip à
+	/// taille variable (4 et 12 slots), rejet count > 12, rejet tronqué.
+	void TestBeltLayoutRoundTripVariableSize()
+	{
+		// 4 slots (défaut sans ceinture équipée).
+		engine::server::SetBeltLayoutMessage in{};
+		in.clientId = 42u;
+		in.slots = { "item:6002", "", "item:5101", "" };
+		const std::vector<std::byte> packet = engine::server::EncodeSetBeltLayout(in);
+		assert(!packet.empty());
+		engine::server::SetBeltLayoutMessage out{};
+		assert(engine::server::DecodeSetBeltLayout(packet, out));
+		assert(out.clientId == 42u);
+		assert(out.slots.size() == 4u);
+		assert(out.slots[0] == "item:6002");
+		assert(out.slots[1].empty());
+		assert(out.slots[2] == "item:5101");
+
+		// 12 slots (grande ceinture équipée) — kind 100.
+		engine::server::BeltLayoutUpdateMessage big{};
+		big.clientId = 7u;
+		big.slots.assign(12u, std::string{});
+		big.slots[11] = "item:6003";
+		const std::vector<std::byte> bigPacket = engine::server::EncodeBeltLayoutUpdate(big);
+		engine::server::BeltLayoutUpdateMessage bigOut{};
+		assert(engine::server::DecodeBeltLayoutUpdate(bigPacket, bigOut));
+		assert(bigOut.slots.size() == 12u);
+		assert(bigOut.slots[11] == "item:6003");
+
+		// count > 12 : encodé volontairement à 13 → rejeté au décodage.
+		engine::server::SetBeltLayoutMessage tooBig{};
+		tooBig.clientId = 1u;
+		tooBig.slots.assign(13u, std::string{});
+		const std::vector<std::byte> tooBigPacket = engine::server::EncodeSetBeltLayout(tooBig);
+		engine::server::SetBeltLayoutMessage rejected{};
+		assert(!engine::server::DecodeSetBeltLayout(tooBigPacket, rejected));
+
+		// Tronqué : rejeté proprement.
+		std::vector<std::byte> truncated = packet;
+		truncated.resize(truncated.size() - 2u);
+		assert(!engine::server::DecodeSetBeltLayout(truncated, out));
+		std::puts("[OK] TestBeltLayoutRoundTripVariableSize");
+	}
+
 	void TestClassProgressionUpdateRoundTrip()
 	{
 		engine::server::ClassProgressionUpdateMessage in{};
@@ -838,6 +882,7 @@ int main()
 	TestRespawnRequestRoundTrip();
 	TestCastRequestRoundTrip();
 	TestSetActionBarLayoutRoundTrip();
+	TestBeltLayoutRoundTripVariableSize();
 	TestActionBarLayoutUpdateRoundTrip();
 	TestClassProgressionUpdateRoundTrip();
 	TestChooseClassSkillRequestRoundTrip();

--- a/src/shared/server_bootstrap/ServerApp.cpp
+++ b/src/shared/server_bootstrap/ServerApp.cpp
@@ -3733,6 +3733,10 @@ namespace engine::server
 		(void)SendInventoryDelta(*client, client->inventory); // snapshot complet
 		(void)SendEquipmentUpdate(*client);
 		(void)SendPlayerStats(*client);
+		// Ceinture v2 — équiper une ceinture (slot Waist) change la capacité
+		// active : repousser le layout (le client redimensionne sa barre).
+		if (slot == static_cast<uint8_t>(engine::items::EquipmentSlot::Waist))
+			(void)SendBeltLayout(*client);
 	}
 
 	void ServerApp::HandleUnequipRequest(const Endpoint& endpoint, uint32_t clientId, uint8_t slot)
@@ -3776,6 +3780,10 @@ namespace engine::server
 		(void)SendInventoryDelta(*client, client->inventory); // snapshot complet
 		(void)SendEquipmentUpdate(*client);
 		(void)SendPlayerStats(*client);
+		// Ceinture v2 — déséquiper la ceinture ramène la capacité à 4 : le
+		// contenu au-delà reste stocké (inactif) et revient si on rééquipe.
+		if (slotIndex == static_cast<size_t>(engine::items::EquipmentSlot::Waist))
+			(void)SendBeltLayout(*client);
 	}
 
 	void ServerApp::HandleTalkRequest(const Endpoint& endpoint, uint32_t clientId, std::string_view targetId)
@@ -4919,10 +4927,21 @@ namespace engine::server
 			return;
 		}
 
+		// Ceinture v2 — le count client ne peut pas dépasser la capacité
+		// ACTIVE (ceinture équipée en Waist, autoritaire côté serveur).
+		const size_t capacity = BeltCapacity(*client);
+		if (message.slots.size() > capacity)
+		{
+			LOG_WARN(Net, "[ServerApp] SetBeltLayout reject: count {} > capacite {} (client_id={})",
+				message.slots.size(), capacity, client->clientId);
+			(void)SendBeltLayout(*client);
+			return;
+		}
+
 		// Validation autoritaire : chaque slot non vide = jeton "item:<id>"
 		// d'un objet POSSÉDÉ et ACTIVABLE (gâteau ou consommable connu),
 		// unicité par slot. Rejet = renvoi de l'état inchangé (kind 100).
-		std::array<std::string, 4> validated{};
+		std::vector<std::string> validated(message.slots.size());
 		for (size_t slotIndex = 0; slotIndex < message.slots.size(); ++slotIndex)
 		{
 			const std::string& token = message.slots[slotIndex];
@@ -4973,8 +4992,29 @@ namespace engine::server
 	{
 		BeltLayoutUpdateMessage msg{};
 		msg.clientId = client.clientId;
+		// Ceinture v2 — exactement la capacité ACTIVE : les slots au-delà
+		// (contenu d'une grande ceinture déséquipée) restent stockés côté
+		// serveur mais ne sont ni envoyés ni activables.
 		msg.slots = client.beltLayout;
+		msg.slots.resize(BeltCapacity(client));
 		return m_transport.Send(client.endpoint, EncodeBeltLayoutUpdate(msg));
+	}
+
+	uint8_t ServerApp::BeltCapacity(const ConnectedClient& client) const
+	{
+		using engine::items::EquipmentSlot;
+		const uint32_t waistItemId =
+			client.equipment[static_cast<size_t>(EquipmentSlot::Waist)];
+		if (waistItemId != 0u && m_itemCatalogLoaded)
+		{
+			const engine::items::ItemDefinition* def = m_itemCatalog.Find(waistItemId);
+			if (def != nullptr && def->beltSlots > 0u)
+			{
+				return std::clamp<uint8_t>(def->beltSlots,
+					engine::items::kBeltSlotsDefault, engine::items::kBeltSlotsMax);
+			}
+		}
+		return engine::items::kBeltSlotsDefault;
 	}
 
 	void ServerApp::HandleConsumableUse(ConnectedClient& client, uint32_t itemId)
@@ -4982,11 +5022,14 @@ namespace engine::server
 		const ConsumableEffectDef* def = FindConsumableEffect(itemId);
 		if (def == nullptr) return;
 		// Slotté en ceinture (les consommables ne s'activent QUE depuis la
-		// ceinture — geste volontaire, cf. règle gâteau).
+		// ceinture — geste volontaire, cf. règle gâteau). Ceinture v2 : seuls
+		// les slots ACTIFS (index < capacité) comptent.
 		const std::string token = engine::anniversary::MakeItemToken(itemId);
+		const size_t activeSlots =
+			std::min<size_t>(client.beltLayout.size(), BeltCapacity(client));
 		bool slotted = false;
-		for (const std::string& slot : client.beltLayout)
-			if (slot == token) { slotted = true; break; }
+		for (size_t i = 0; i < activeSlots; ++i)
+			if (client.beltLayout[i] == token) { slotted = true; break; }
 		if (!slotted)
 		{
 			SendChatSystemNotice(client, "Placez d'abord cet objet dans votre ceinture.");
@@ -5871,8 +5914,11 @@ namespace engine::server
 		bool slotted = false;
 		for (const std::string& slot : client.actionBarLayout)
 			if (slot == token) { slotted = true; break; }
-		for (const std::string& slot : client.beltLayout)
-			if (slot == token) { slotted = true; break; }
+		// Ceinture v2 — seuls les slots ACTIFS (index < capacité) comptent.
+		const size_t activeBeltSlots =
+			std::min<size_t>(client.beltLayout.size(), BeltCapacity(client));
+		for (size_t i = 0; i < activeBeltSlots; ++i)
+			if (client.beltLayout[i] == token) { slotted = true; break; }
 		if (!slotted)
 		{
 			SendChatSystemNotice(client, "Placez d'abord le gâteau dans votre ceinture (ou barre d'action).");
@@ -5965,12 +6011,15 @@ namespace engine::server
 				continue;
 			const CakeBuffDef* def = FindCakeBuff(client.activeCakeItemId);
 			const std::string activeToken = engine::anniversary::MakeCakeToken(client.activeCakeItemId);
-			// Roadmap-3 — slotté = barre d'action OU ceinture.
+			// Roadmap-3 — slotté = barre d'action OU ceinture (Ceinture v2 :
+			// seuls les slots ACTIFS, index < capacité, comptent).
 			bool slotted = false;
 			for (const std::string& slot : client.actionBarLayout)
 				if (slot == activeToken) { slotted = true; break; }
-			for (const std::string& slot : client.beltLayout)
-				if (slot == activeToken) { slotted = true; break; }
+			const size_t activeBeltSlots =
+				std::min<size_t>(client.beltLayout.size(), BeltCapacity(client));
+			for (size_t i = 0; i < activeBeltSlots; ++i)
+				if (client.beltLayout[i] == activeToken) { slotted = true; break; }
 			bool owned = false;
 			for (const ItemStack& s : client.inventory)
 				if (s.itemId == client.activeCakeItemId && s.quantity > 0u) { owned = true; break; }

--- a/src/shared/server_bootstrap/ServerApp.h
+++ b/src/shared/server_bootstrap/ServerApp.h
@@ -165,7 +165,12 @@ namespace engine::server
 		/// (jetons "item:<id>" : gâteaux, potions, nourriture ; "" = vide).
 		/// Autoritaire (validée par HandleSetBeltLayout : objet possédé et
 		/// activable) et persistée (belt.slot.N).
-		std::array<std::string, 4> beltLayout{};
+		/// Ceinture v2 (2026-07-20) — slots d'objets actifs, taille VARIABLE.
+		/// La capacité ACTIVE = BeltCapacity() (ceinture équipée en Waist,
+		/// défaut 4, max 12). Le vecteur peut être plus long que la capacité
+		/// (grande ceinture déséquipée : contenu conservé mais INACTIF) ;
+		/// seuls les index < capacité sont activables/envoyés au client.
+		std::vector<std::string> beltLayout{};
 		/// Anniversaires SP3 (2026-07-18) — gâteau ACTIF (0 = aucun). Posé par
 		/// un CastRequest "item:<id>" ; le buff est entretenu par TickCakeBuffs
 		/// tant que le gâteau reste slotté ET possédé ; NON persisté (à
@@ -620,7 +625,14 @@ namespace engine::server
 		void HandleSetBeltLayout(const Endpoint& endpoint, const SetBeltLayoutMessage& message);
 
 		/// Roadmap-3 — pousse le layout ceinture autoritaire (kind 100).
+		/// Ceinture v2 : envoie exactement BeltCapacity(client) slots.
 		bool SendBeltLayout(const ConnectedClient& client);
+
+		/// Ceinture v2 (2026-07-20) — capacité ACTIVE de la ceinture du joueur :
+		/// beltSlots de la ceinture équipée en slot Waist (résolue via
+		/// m_itemCatalog, autoritaire), clampée [4..12] ; 4 par défaut sans
+		/// ceinture équipée (kBeltSlotsDefault).
+		uint8_t BeltCapacity(const ConnectedClient& client) const;
 
 		/// Roadmap-3 — consomme un objet activable NON-gâteau de la ceinture
 		/// (ex. potion 2002) : vérifie slotté + possédé, applique l'effet


### PR DESCRIPTION
## Objectif (retour de test 2026-07-20)

Refonte de la ceinture (#996) validee sur 4 axes : **taille evolutive** (le joueur demarre a 4 slots ; acheter/trouver de meilleures ceintures monte jusqu'a **12**), visuel/position, remplissage par **glisser-deposer**, comportement d'activation.

## La ceinture devient un equipement

- Nouveau slot d'equipement **Waist** (11e cellule du paperdoll F1) + champ `belt_slots` au catalogue d'objets.
- **Capacite autoritaire serveur** : `BeltCapacity` = `belt_slots` de la ceinture equipee, clamp 4..12 ; 4 sans ceinture. Equiper/desequiper repousse le layout a la nouvelle taille. Le contenu au-dela de la capacite est conserve (inactif) et revient si on reequipe une grande ceinture.
- 3 ceintures de contenu : **Ceinture de cuir robuste** (6 slots, vendeur 800), **Ceinture de campagne** (8 slots, vendeur 2500), **Grande ceinture du colporteur** (12 slots, drop rare 8 % du Sanglier alpha).

## Wire (⚠️ lock-step)

Kinds 99/100 conserves mais payload **count-prefixed** (count u16 ≤ 12 + chaines, modele EquipmentUpdate) — pas de bump `kProtocolVersion` (framing inchange), mais **decodeur strict** : un client et un shard de generations differentes ne se comprennent pas sur ces 2 kinds → deployer ensemble. Round-trip teste (4 et 12 slots, rejet count 13, rejet tronque). Persistance `belt.count` + `belt.slot.N` retro-compatible.

## Client — nouvelle barre

- Fenetre ImGui : cases **48 px**, 2 rangees au-dela de 6 slots, titre « Ceinture N/12 », initiales de l'objet + **quantite en sac** (rouge si epuisee), tooltips riches, survol dore.
- **Drag & drop natif** : glisser un consommable du sac vers une case, reorganiser case ↔ case, **clic droit pour vider**.
- Activation : **Maj+1..9** ou clic complet (press+release sans drag — glisser ne consomme plus).

## Validation en jeu

1. Sans ceinture : 4 cases. Acheter la Ceinture de cuir robuste (vendeur) → l'equiper (F1, glisser sur la cellule Ceinture) → la barre passe a 6 cases.
2. Glisser une potion du sac vers une case precise ; reorganiser deux cases ; clic droit → la case se vide ; relog → tout persiste.
3. Maj+1 utilise la potion (quantite decremente) ; desequiper la ceinture → retour a 4 cases ; reequiper → les slots 5-6 reviennent avec leur contenu.
4. Tuer le Sanglier alpha jusqu'au drop de la Grande ceinture (12 slots, 2 rangees).

**Deploiement** : ⚠️ **client + shard en lock-step** (payload 99/100 change de format). Master non concerne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)