### PR TITLE
fix(game): ceinture visible des l entree en monde - 4 cases par defaut

### DIFF
--- a/src/client/ui_common/UIModel.h
+++ b/src/client/ui_common/UIModel.h
@@ -234,7 +234,11 @@ namespace engine::client
 		/// d'objets actifs (jetons "item:<id>"), taille = capacité ACTIVE
 		/// autoritaire (4 par défaut, 12 max — ceinture équipée en Waist),
 		/// reçue via BeltLayoutUpdate (kind 100, count-prefixed).
-		std::vector<std::string> beltLayout{};
+		/// DÉFAUT : 4 cases vides (= kBeltSlotsDefault, « ceinture de base »
+		/// du joueur) — la barre est visible dès l'entrée en monde, AVANT le
+		/// 1er update autoritaire (retour de test 2026-07-20 : barre invisible
+		/// tant que le kind 100 n'était pas reçu/décodé).
+		std::vector<std::string> beltLayout = std::vector<std::string>(4);
 		/// PR-C — progression de niveau (barre d'XP), reçue via PlayerXpUpdate
 		/// (enter-world + chaque gain d'XP). \c xpForNextLevel = 0 signale le cap
 		/// de niveau. \c hasXp reste faux tant qu'aucun PlayerXpUpdate n'est reçu.


### PR DESCRIPTION
Retour de test 2026-07-20 (capture) : la barre ceinture n'apparaissait plus.

Cause : le modele UI demarre avec un vecteur beltLayout VIDE et la barre v2 n'affiche que `beltLayout.size()` cases → **rien** tant que le BeltLayoutUpdate (kind 100) n'est pas recu — et il ne l'est jamais si le shard n'a pas encore le build #1004 (lock-step).

Fix : le joueur commence avec **la ceinture de base : 4 cases vides par defaut** (`kBeltSlotsDefault`), visibles des l'entree en monde ; l'etat autoritaire du serveur les remplace des reception (6/8/12 selon la ceinture equipee).

⚠️ Rappel : pour que la synchronisation ceinture fonctionne (remplissage, activation), le **shard doit etre redeploye au build de la #1004** — sans cela les 4 cases s'affichent mais les actions serveur echouent.

**Deploiement** : ✅ client uniquement (ce fix) ; la #1004 reste ⚠️ lock-step client+shard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)