### PR TITLE
fix(ui): exploits non realises masques dans l onglet Exploits

### DIFF
--- a/src/client/render/ExploitsImGuiRenderer.cpp
+++ b/src/client/render/ExploitsImGuiRenderer.cpp
@@ -79,20 +79,22 @@ namespace engine::render
 		if (!any)
 			ImGui::TextDisabled("Aucun exploit debloque pour le moment.");
 
-		ImGui::SeparatorText("A debloquer");
-		any = false;
-		for (const auto& e : st.entries)
+		// Retour de test 2026-07-20 — les exploits NON réalisés sont MASQUÉS
+		// (pas de spoiler de la liste complète) : seul leur NOMBRE est
+		// affiché. Le compteur d'en-tête « N / M débloqués » reste la jauge
+		// de progression globale.
+		const size_t lockedCount = st.entries.size() - unlocked;
+		if (lockedCount > 0u)
 		{
-			if (e.unlockedAtUnix != 0u) continue;
-			any = true;
-			ImGui::BeginDisabled();
-			ImGui::BulletText("%s", e.title.c_str());
-			ImGui::EndDisabled();
-			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-				ImGui::SetTooltip("%s", e.description.c_str());
+			ImGui::SeparatorText("A debloquer");
+			ImGui::TextDisabled("%zu exploit(s) secret(s) restant(s) a decouvrir...",
+				lockedCount);
 		}
-		if (!any)
+		else if (!st.entries.empty())
+		{
+			ImGui::SeparatorText("A debloquer");
 			ImGui::TextDisabled("Tout est debloque. Bravo !");
+		}
 #endif
 	}
 }


### PR DESCRIPTION
Retour de test 2026-07-20 (capture) : l'onglet Exploits de la fenetre Personnage listait TOUS les exploits non realises (39 lignes — paliers de fidelite, anniversaires, signalements...), ce qui spoile la liste complete.

Les exploits verrouilles sont desormais **masques** : la section « A debloquer » n'affiche plus que leur **nombre** (« N exploit(s) secret(s) restant(s) a decouvrir... »). Le compteur d'en-tete « N / M debloques » reste la jauge de progression, et les exploits deja obtenus gardent leur date + tooltip.

Validation en jeu : F1 → onglet Exploits → seuls les exploits obtenus sont listes ; la ligne « 39 exploit(s) secret(s)... » remplace la liste.

**Deploiement** : ✅ client uniquement, pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)