### PR TITLE
fix(ui): ceinture sans libelle + fenetre Personnage ancree en haut

### DIFF
--- a/src/client/app/Engine.cpp
+++ b/src/client/app/Engine.cpp
@@ -12272,12 +12272,8 @@ namespace engine
 									| ImGuiWindowFlags_NoScrollWithMouse | ImGuiWindowFlags_NoFocusOnAppearing
 									| ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoSavedSettings);
 								ImDrawList* bdl = ImGui::GetWindowDrawList();
-								char beltTitle[32];
-								std::snprintf(beltTitle, sizeof(beltTitle), "Ceinture  %d/%d",
-									static_cast<int>(beltCount),
-									static_cast<int>(engine::items::kBeltSlotsMax));
-								bdl->AddText(ImVec2(beltX, beltY - 18.0f),
-									IM_COL32(190, 215, 195, 200), beltTitle);
+								// Retour de test 2026-07-20 — pas de libellé « Ceinture x/y »
+								// au-dessus de la barre : les cases se suffisent.
 								// Trait séparateur vertical entre la barre
 								// d'action (icônes de pouvoir) et la ceinture.
 								bdl->AddLine(ImVec2(beltX - 26.0f, dh - beltSlotSz - 20.0f),

--- a/src/client/render/CharacterWindowImGuiRenderer.cpp
+++ b/src/client/render/CharacterWindowImGuiRenderer.cpp
@@ -192,16 +192,18 @@ namespace engine::render
 					worn[e.slot] = e.itemId;
 			}
 			float side = (5.0f * avail.x - 2.0f * gap) / 7.0f;
-			side = std::min(side, avail.y - statsH);   // borné par la hauteur disponible
+			// Borné par la hauteur disponible : bande (side) + rangée ceinture
+			// (cell + gap, cf. cellule Waist dessinée sous la colonne gauche) +
+			// stats. Avec cell = (side - 4·gap)/5, la contrainte
+			// side + gap + cell + statsH ≤ avail.y se résout en :
+			side = std::min(side, (5.0f * (avail.y - statsH - gap) + 4.0f * gap) / 6.0f);
 			side = std::max(side, 150.0f);
 			const float cell = std::max(30.0f, (side - 4.0f * gap) / 5.0f);
 			const float bandW = 2.0f * cell + 2.0f * gap + side;
 			const float offX = std::max(0.0f, (avail.x - bandW) * 0.5f);
-			// Centrage vertical du bloc (bande paperdoll + stats).
-			const float blockH = side + statsH;
-			const float padTop = std::max(0.0f, (avail.y - blockH) * 0.5f);
-			if (padTop > 0.0f)
-				ImGui::Dummy(ImVec2(1.0f, padTop));
+			// Retour joueur 2026-07-20 — bloc ANCRÉ EN HAUT (plus de centrage
+			// vertical) : le centrage laissait un grand vide au-dessus du
+			// paperdoll, impression que l'aperçu du personnage était descendu.
 
 			// Repères écran de la bande (dessin manuel via draw list).
 			const ImVec2 bandOrigin = ImGui::GetCursorScreenPos();
@@ -328,8 +330,11 @@ namespace engine::render
 					IM_COL32(120, 130, 160, 255), lbl);
 			}
 
-			// Curseur repositionné sous la bande paperdoll pour la suite (stats).
-			ImGui::SetCursorScreenPos(ImVec2(bandOrigin.x, bandY + side + 6.0f));
+			// Curseur repositionné pour la suite (stats) SOUS la rangée ceinture
+			// (cellule Waist à bandY + 5·(cell+gap), haute de cell) — avant, les
+			// stats s'écrivaient par-dessus la cellule Ceinture (retour 2026-07-20).
+			ImGui::SetCursorScreenPos(ImVec2(bandOrigin.x,
+				bandY + 5.0f * (cell + gap) + cell + 6.0f));
 
 			// Caractéristiques compactes (ex-fiche F1).
 			const engine::client::UIPlayerStats& ps = model.playerStats;


### PR DESCRIPTION
## Retours de test 2026-07-20

Deux corrections UI (capture : fenetre Personnage + barre ceinture) :

### 1. Barre ceinture (HUD) — plus de libelle « Ceinture x/y »
Le texte « Ceinture 4/12 » dessine au-dessus des cases est supprime
(`Engine.cpp`). Les cases (avec raccourcis M+1..M+9) se suffisent.
Le trait separateur vertical avec la barre d'action est conserve.

### 2. Onglet Equipement — vide au-dessus du personnage + stats qui recouvraient la cellule Ceinture
- Le bloc paperdoll (cellules d'equipement + apercu 3D + stats) etait
  **centre verticalement** dans la colonne gauche → grand vide au-dessus,
  impression que l'apercu du personnage etait « descendu ».
  Il est maintenant **ancre en haut**.
- Depuis la PR #1004 (ceinture v2), la 11e cellule (slot Waist) est dessinee
  sous la colonne gauche, mais les stats (« Niveau / Points de vie / ... »)
  s'ecrivaient **par-dessus**. Elles sont repositionnees sous la cellule
  Ceinture, et la borne de hauteur de l'apercu tient compte de cette rangee
  supplementaire (pas de debordement sur les petites fenetres).

**Deploiement** : ✅ client uniquement, pas de redeploiement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
